### PR TITLE
feat(room-settings): add underpass walk-under-furniture checkbox

### DIFF
--- a/src/api/navigator/IRoomData.ts
+++ b/src/api/navigator/IRoomData.ts
@@ -11,6 +11,7 @@ export interface IRoomData
     tags: string[];
     tradeState: number;
     allowWalkthrough: boolean;
+    allowUnderpass: boolean;
     lockState: number;
     password: string;
     allowPets: boolean;

--- a/src/components/navigator/views/room-settings/NavigatorRoomSettingsBasicTabView.tsx
+++ b/src/components/navigator/views/room-settings/NavigatorRoomSettingsBasicTabView.tsx
@@ -162,6 +162,11 @@ export const NavigatorRoomSettingsBasicTabView: FC<NavigatorRoomSettingsTabViewP
                 <input className="form-check-input" type="checkbox" checked={ roomData.allowWalkthrough } onChange={ event => handleChange('allow_walkthrough', event.target.checked) } />
                 <Text>{ LocalizeText('navigator.roomsettings.allow_walk_through') }</Text>
             </Flex>
+            <Flex alignItems="center" gap={ 1 }>
+                <Base className="col-3" />
+                <input className="form-check-input" type="checkbox" checked={ roomData.allowUnderpass } onChange={ event => handleChange('allow_underpass', event.target.checked) } />
+                <Text>{ LocalizeText('navigator.roomsettings.allow_underpass') }</Text>
+            </Flex>
             <Text variant="danger" underline bold pointer className="d-flex justify-content-center align-items-center gap-1" onClick={ deleteRoom }>
                 <FaTimes className="fa-icon" /> { LocalizeText('navigator.roomsettings.delete') } 
             </Text>

--- a/src/components/navigator/views/room-settings/NavigatorRoomSettingsView.tsx
+++ b/src/components/navigator/views/room-settings/NavigatorRoomSettingsView.tsx
@@ -39,6 +39,7 @@ export const NavigatorRoomSettingsView: FC<{}> = props =>
             tags: data.tags,
             tradeState: data.tradeMode,
             allowWalkthrough: data.allowWalkThrough,
+            allowUnderpass: data.allowUnderpass,
             lockState: data.doorMode,
             password: null,
             allowPets: data.allowPets,
@@ -97,6 +98,9 @@ export const NavigatorRoomSettingsView: FC<{}> = props =>
                     break;
                 case 'allow_walkthrough':
                     newValue.allowWalkthrough = Boolean(value);
+                    break;
+                case 'allow_underpass':
+                    newValue.allowUnderpass = Boolean(value);
                     break;
                 case 'allow_pets':
                     newValue.allowPets = Boolean(value);
@@ -171,7 +175,8 @@ export const NavigatorRoomSettingsView: FC<{}> = props =>
                     newValue.chatSettings.weight,
                     newValue.chatSettings.speed,
                     newValue.chatSettings.distance,
-                    newValue.chatSettings.protection
+                    newValue.chatSettings.protection,
+                    newValue.allowUnderpass
                 ));
 
             return newValue;


### PR DESCRIPTION
## Summary
- Add `allowUnderpass` checkbox in room settings UI (Info tab) below "Disabilita blocco caselle"
- Room owners can toggle walk-under-furniture per room

## Changes
- `IRoomData.ts`: add `allowUnderpass: boolean` field
- `NavigatorRoomSettingsView.tsx`: map field from server, handle changes, send via `SaveRoomSettingsComposer`
- `NavigatorRoomSettingsBasicTabView.tsx`: render checkbox with localization key `navigator.roomsettings.allow_underpass`

## Dependencies
- **Server-side PR**: duckietm/Arcturus-Morningstar-Extended#12
- **nitro-renderer** changes required (not included, must be patched in `node_modules`):
  - `RoomSettingsData.ts`: add `_allowUnderpass` field + getter/setter
  - `RoomSettingsDataParser.ts`: read `allowUnderpass` int from server packet
  - `SaveRoomSettingsComposer.ts`: add `allowUnderpass` boolean parameter

## Test plan
- [ ] Apply server-side PR and run DB migration
- [ ] Patch nitro-renderer files in node_modules
- [ ] Open room settings > Info tab — checkbox should appear
- [ ] Toggle on/off and verify persistence

Co-Authored-By: medievalshell <medievalshell@users.noreply.github.com>