### PR TITLE
Fix crackableHits undefined TypeError in InfoStandWidgetFurniView

### DIFF
--- a/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetFurniView.tsx
+++ b/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetFurniView.tsx
@@ -220,8 +220,8 @@ export const InfoStandWidgetFurniView: FC<InfoStandWidgetFurniViewProps> = props
 
                 canUse = true;
                 isCrackable = true;
-                crackableHits = stuffData.hits;
-                crackableTarget = stuffData.target;
+                crackableHits = stuffData?.hits ?? 0;
+                crackableTarget = stuffData?.target ?? 0;
             }
 
             else if(avatarInfo.extraParam === RoomWidgetEnumItemExtradataParameter.JUKEBOX)
@@ -527,7 +527,7 @@ export const InfoStandWidgetFurniView: FC<InfoStandWidgetFurniViewProps> = props
                         { isCrackable &&
                             <>
                                 <hr className="m-0 bg-[#0003] border-0 opacity-[.5] h-px" />
-                                <Text small wrap variant="white">{ LocalizeText('infostand.crackable_furni.hits_remaining', [ 'hits', 'target' ], [ crackableHits.toString(), crackableTarget.toString() ]) }</Text>
+                                <Text small wrap variant="white">{ LocalizeText('infostand.crackable_furni.hits_remaining', [ 'hits', 'target' ], [ (crackableHits ?? 0).toString(), (crackableTarget ?? 0).toString() ]) }</Text>
                             </> }
                         { avatarInfo.groupId > 0 &&
                             <>


### PR DESCRIPTION
## Summary
- Add nullish coalescing checks for `crackableHits` and `crackableTarget` to prevent `TypeError: can't access property "toString", crackableHits is undefined`
- Guards both the assignment from `stuffData` and the `.toString()` call in the render

## Test plan
- [ ] Open infostand on a crackable furni — verify hits remaining text renders correctly
- [ ] Open infostand on a non-crackable furni — verify no TypeError in console