### PR TITLE
Localize user profile strings and fix corrupted UserContainerView rendering

### DIFF
--- a/src/components/user-profile/UserContainerView.tsx
+++ b/src/components/user-profile/UserContainerView.tsx
@@ -41,8 +41,15 @@ export const UserContainerView: FC<{
                     <p className="text-sm italic leading-tight">{ userProfile.motto }</p>
                 </div>
                 <div className="flex flex-col gap-1">
-                    <p className="text-sm leading-none" dangerouslySetInnerHTML={{ __html: LocalizeText('extendedprofile.created', ['created'], [userProfile.registration]) }} />
-                    <p className="text-sm leading-none" dangerouslySetInnerHTML={{ __html: LocalizeText('extendedprofile.last.login', ['lastlogin'], [FriendlyTime.format(userProfile.secondsSinceLastVisit, '.ago', 2)]) }} />
+                    <p className="text-sm leading-none">
+                        <b>{ LocalizeText('extendedprofile.created.title') }</b> { userProfile.registration }
+                    </p>
+                    <p className="text-sm leading-none">
+                        <b>{ LocalizeText('extendedprofile.last.login.title') }</b> { FriendlyTime.format(userProfile.secondsSinceLastVisit, '.ago', 2) }
+                    </p>
+                    <p className="text-sm leading-none">
+                        <b>{ LocalizeText('extendedprofile.friends.count') }</b> { userProfile.friendsCount }
+                    </p>
                     <p className="text-sm leading-none">
                         <b>{ LocalizeText('extendedprofile.achievementscore') }</b> { userProfile.achievementPoints }
                     </p>

--- a/src/components/user-profile/UserContainerView.tsx
+++ b/src/components/user-profile/UserContainerView.tsx
@@ -41,12 +41,8 @@ export const UserContainerView: FC<{
                     <p className="text-sm italic leading-tight">{ userProfile.motto }</p>
                 </div>
                 <div className="flex flex-col gap-1">
-                    <p className="text-sm leading-none">
-                        <b>{ LocalizeText('extendedprofile.created.title') }</b> { userProfile.registration }
-                    </p>
-                    <p className="text-sm leading-none">
-                        <b>{ LocalizeText('extendedprofile.last.login.title') }</b> { FriendlyTime.format(userProfile.secondsSinceLastVisit, '.ago', 2) }
-                    </p>
+                    <p className="text-sm leading-none" dangerouslySetInnerHTML={{ __html: LocalizeText('extendedprofile.created', ['created'], [userProfile.registration]) }} />
+                    <p className="text-sm leading-none" dangerouslySetInnerHTML={{ __html: LocalizeText('extendedprofile.last.login', ['lastlogin'], [FriendlyTime.format(userProfile.secondsSinceLastVisit, '.ago', 2)]) }} />
                     <p className="text-sm leading-none">
                         <b>{ LocalizeText('extendedprofile.friends.count') }</b> { userProfile.friendsCount }
                     </p>

--- a/src/components/user-profile/UserProfileView.tsx
+++ b/src/components/user-profile/UserProfileView.tsx
@@ -145,16 +145,16 @@ export const UserProfileView: FC<{}> = props =>
                 </div>
                 <NitroCard.Tabs>
                     <NitroCard.TabItem isActive={ activeTab === 'badge' } count={ userBadges.length } onClick={ () => onTabClick('badge') }>
-                        Badge
+                        { LocalizeText('extendedprofile.tab.badge') }
                     </NitroCard.TabItem>
                     <NitroCard.TabItem isActive={ activeTab === 'amici' } count={ userProfile.friendsCount } onClick={ () => onTabClick('amici') }>
-                        Amici
+                        { LocalizeText('extendedprofile.tab.friends') }
                     </NitroCard.TabItem>
                     <NitroCard.TabItem isActive={ activeTab === 'stanze' } onClick={ () => onTabClick('stanze') }>
-                        Stanze
+                        { LocalizeText('extendedprofile.tab.rooms') }
                     </NitroCard.TabItem>
                     <NitroCard.TabItem isActive={ activeTab === 'gruppi' } count={ userProfile.groups?.length } onClick={ () => onTabClick('gruppi') }>
-                        Gruppi
+                        { LocalizeText('extendedprofile.tab.groups') }
                     </NitroCard.TabItem>
                 </NitroCard.Tabs>
                 <div className="flex-1 overflow-auto p-2">
@@ -166,7 +166,7 @@ export const UserProfileView: FC<{}> = props =>
                                 ))
                                 : (
                                     <Flex center fullWidth className="h-full">
-                                        <Text small variant="muted">Nessun badge da mostrare</Text>
+                                        <Text small variant="muted">{ LocalizeText('extendedprofile.badge.empty') }</Text>
                                     </Flex>
                                 )
                             }
@@ -178,7 +178,7 @@ export const UserProfileView: FC<{}> = props =>
                                 <FriendsContainerView friendsCount={ userProfile.friendsCount } relationships={ userRelationships } />
                             ) : (
                                 <Flex center className="h-full">
-                                    <Text small variant="muted">Caricamento...</Text>
+                                    <Text small variant="muted">{ LocalizeText('generic.loading') }</Text>
                                 </Flex>
                             ) }
                         </div>
@@ -187,12 +187,12 @@ export const UserProfileView: FC<{}> = props =>
                         <div className="flex flex-col gap-1 h-full">
                             { !userRooms && (
                                 <Flex center className="h-full">
-                                    <Text small variant="muted">Caricamento stanze...</Text>
+                                    <Text small variant="muted">{ LocalizeText('extendedprofile.rooms.loading') }</Text>
                                 </Flex>
                             ) }
                             { userRooms && userRooms.length === 0 && (
                                 <Flex center className="h-full">
-                                    <Text small variant="muted">Nessuna stanza trovata</Text>
+                                    <Text small variant="muted">{ LocalizeText('extendedprofile.rooms.empty') }</Text>
                                 </Flex>
                             ) }
                             { userRooms && userRooms.length > 0 && userRooms.map(room => (


### PR DESCRIPTION
## Summary
- Replace all hardcoded Italian strings with `LocalizeText()` calls in `UserProfileView`
- Add missing friends count display in `UserContainerView`
- Keep `dangerouslySetInnerHTML` for created/last login (compatible with existing external_texts HTML keys)

## Required external_texts keys

```json
"extendedprofile.tab.badge": "Badges",
"extendedprofile.tab.friends": "Friends",
"extendedprofile.tab.rooms": "Rooms",
"extendedprofile.tab.groups": "Groups",
"extendedprofile.badge.empty": "No badges to display",
"extendedprofile.rooms.loading": "Loading rooms...",
"extendedprofile.rooms.empty": "No rooms found",
"extendedprofile.created": "<b>Created:</b> %created%",
"extendedprofile.last.login": "<b>Last login:</b> %lastlogin%",
"extendedprofile.friends.count": "Friends:",
"generic.loading": "Loading..."
```