### PR TITLE
fix(toolbar): anchor Me menu popup to face button instead of fixed of…

### DIFF
--- a/src/components/toolbar/ToolbarMeView.tsx
+++ b/src/components/toolbar/ToolbarMeView.tsx
@@ -32,7 +32,7 @@ export const ToolbarMeView: FC<PropsWithChildren<{
     }, [ setMeExpanded ]);
 
     return (
-        <Flex alignItems="center" className="absolute bottom-[60px] left-[33px] bg-[rgba(20,20,20,.95)] border border-[solid] border-[#101010] [box-shadow:inset_2px_2px_rgba(255,255,255,.1),inset_-2px_-2px_rgba(255,255,255,.1)] rounded-[$border-radius] p-2" gap={ 2 } innerRef={ elementRef }>
+        <Flex alignItems="center" className="bg-[rgba(20,20,20,.95)] border border-[solid] border-[#101010] [box-shadow:inset_2px_2px_rgba(255,255,255,.1),inset_-2px_-2px_rgba(255,255,255,.1)] rounded-[$border-radius] p-2" gap={ 2 } innerRef={ elementRef }>
             { (GetConfigurationValue('guides.enabled') && useGuideTool) &&
                 <div className="navigation-item relative nitro-icon icon-me-helper-tool cursor-pointer" onClick={ event => DispatchUiEvent(new GuideToolEvent(GuideToolEvent.TOGGLE_GUIDE_TOOL)) } /> }
             <div className="navigation-item relative nitro-icon icon-me-achievements cursor-pointer" onClick={ event => CreateLinkEvent('achievements/toggle') }>


### PR DESCRIPTION
…fset

Removed `absolute bottom-[60px] left-[33px]` from the inner Flex of ToolbarMeView. The outer wrapper in ToolbarView already anchors the popup above the face button (bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2), so the inner pixel-perfect override was detaching it and making it float mid-screen.
OLD BUGGY<img width="521" height="221" alt="immagine" src="https://github.com/user-attachments/assets/7f0d220b-5391-4553-be60-87796006e296" />
FIXED <img width="370" height="128" alt="immagine" src="https://github.com/user-attachments/assets/568fd467-3e05-4235-b47b-2e695b391bb0" />

