### PR TITLE
Fix/badge infos views

### DIFF
--- a/src/components/user-profile/BadgeInfoView.tsx
+++ b/src/components/user-profile/BadgeInfoView.tsx
@@ -1,4 +1,5 @@
-import { FC, useState } from 'react';
+import { FC, useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { LocalizeBadgeDescription, LocalizeBadgeName } from '../../api';
 import { Flex, LayoutBadgeImageView } from '../../common';
 
@@ -10,21 +11,49 @@ interface BadgeInfoViewProps
 export const BadgeInfoView: FC<BadgeInfoViewProps> = props =>
 {
     const { badgeCode } = props;
-    const [ isHovered, setIsHovered ] = useState(false);
+    const [ tooltipPos, setTooltipPos ] = useState<{ top: number; left: number } | null>(null);
+    const slotRef = useRef<HTMLDivElement>(null);
+
+    const onMouseEnter = useCallback(() =>
+    {
+        if(!slotRef.current) return;
+
+        const rect = slotRef.current.getBoundingClientRect();
+        const tooltipWidth = 180;
+        const tooltipHeight = 60;
+        const gap = 6;
+
+        let left = (rect.left + (rect.width / 2)) - (tooltipWidth / 2);
+
+        if(left < gap) left = gap;
+        if((left + tooltipWidth) > (window.innerWidth - gap)) left = window.innerWidth - tooltipWidth - gap;
+
+        const top = (rect.bottom + gap + tooltipHeight) > window.innerHeight
+            ? rect.top - gap - tooltipHeight
+            : rect.bottom + gap;
+
+        setTooltipPos({ top, left });
+    }, []);
+
+    const onMouseLeave = useCallback(() => setTooltipPos(null), []);
 
     return (
         <Flex center
+            innerRef={ slotRef }
             className="nitro-card-panel w-[45px] h-[45px] relative cursor-pointer"
-            onMouseEnter={ () => setIsHovered(true) }
-            onMouseLeave={ () => setIsHovered(false) }
+            onMouseEnter={ onMouseEnter }
+            onMouseLeave={ onMouseLeave }
         >
             <LayoutBadgeImageView badgeCode={ badgeCode } />
-            { isHovered && (
-                <div className="absolute top-full left-1/2 z-50 mt-1 w-[180px] -translate-x-1/2 border border-[#c4cabf] bg-[#f2f2eb] px-2 py-1 text-xs text-black shadow-none pointer-events-none rounded-[6px]">
-                    <div className="absolute -top-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 border-l border-t border-[#c4cabf] bg-[#f2f2eb]" />
+            { tooltipPos && createPortal(
+                <div
+                    className="fixed z-50 w-[180px] border border-[#c4cabf] bg-[#f2f2eb] px-2 py-1 text-xs text-black shadow-none pointer-events-none rounded-[6px]"
+                    style={ { top: tooltipPos.top, left: tooltipPos.left } }
+                >
                     <div className="font-bold mb-0.5">{ LocalizeBadgeName(badgeCode) }</div>
                     <div className="text-gray-600">{ LocalizeBadgeDescription(badgeCode) }</div>
-                </div>
+                </div>,
+                document.body
             ) }
         </Flex>
     );


### PR DESCRIPTION
## Summary

Badge name/description tooltips were being clipped by the NitroCard container in both the user profile and the infostand panels. Root cause: the tooltip was positioned `absolute` as a child of the wrapper, so any ancestor with `overflow: hidden` / `overflow: auto` clipped it.

Fix: render the tooltip in a React portal to `document.body` with `position: fixed`, computing coordinates from the badge's `getBoundingClientRect()`. Same pattern already used in `InfoStandBadgeSlotView`.

## Changes

- **`LayoutBadgeImageView`** (`showInfo={true}` — used by user/bot/rentable-bot infostands): replaced the CSS-only `group-hover:block ... absolute -left-[220px]` tooltip with a portal + fixed implementation. Defaults to the left of the badge, auto-flips right if there's no room, clamps X/Y inside the viewport. Ref is passed via `innerRef` (Base is an FC, not a forwardRef).
- **`BadgeInfoView`** (profile "Badges" tab): same approach. Swapped `<Flex>` for a plain `<div>` because `Flex` is not a forwardRef. Auto-flips above/below the badge, clamps X inside the viewport.

## Test plan

- [ ] Open a user profile (`Open profile` from a room/messenger), Badges tab → hover any badge → the box renders fully even when the badge is near the card's edges
- [ ] Click a user avatar in a room → infostand → hover the group badge and user badges → tooltip is visible outside the small infostand bounds
- [ ] Same check on bots and rentable bots
- [ ] Drag the profile window near the screen edges → tooltip stays inside the viewport (clamp works)
- [ ] Verify that setting `badge.descriptions.enabled` to `false` in config disables the tooltip
