### PR TITLE
fix: V3.5.0 follow-ups (DraggableWindow useRef, catalog test contract)

### DIFF
--- a/src/common/draggable-window/DraggableWindow.tsx
+++ b/src/common/draggable-window/DraggableWindow.tsx
@@ -30,7 +30,7 @@ export const DraggableWindow: FC<DraggableWindowProps> = props =>
     const [isDragging, setIsDragging] = useState(false);
     const [isPositioned, setIsPositioned] = useState(false);
     const [dragHandler, setDragHandler] = useState<HTMLElement>(null);
-    const elementRef = useRef<HTMLDivElement>();
+    const elementRef = useRef<HTMLDivElement>(null);
     const bringToTop = useCallback(() => {
         let zIndex = 400;
         for (const existingWindow of CURRENT_WINDOWS)

--- a/src/hooks/catalog/useCatalog.filters.test.tsx
+++ b/src/hooks/catalog/useCatalog.filters.test.tsx
@@ -142,6 +142,7 @@ describe('useCatalog filter contract', () =>
             'getBuilderFurniPlaceableStatus',
             'getNodeById',
             'getNodeByName',
+            'getNodesByOfferId',
             'openCatalogByType',
             'openPageById',
             'openPageByName',


### PR DESCRIPTION
## Summary

Two small follow-ups to V3.5.0 (commits ` a08c002c`/`9c7f630d`/`03795f97`) that block `yarn typecheck` and `yarn test --run` on a fresh Dev checkout.

**`fix(draggable-window)`** — `useRef<HTMLDivElement>()` with no initial value is a TS6 error (`TS2554: Expected 1 arguments, but got 0`). The V3.5.0 commit introduced this call site; pass `null` so it matches the React 19 `RefObject<HTMLDivElement | null>` shape.

**`test(catalog)`** — V3.5.0's "Fix Buy when search" added `getNodesByOfferId` to `useCatalogActions` but didn't refresh `useCatalog.filters.test.tsx`'s actions-shape contract. Add the key so the test reflects the current public surface (was failing with `expected ... toEqual ...` showing the new key as added).

## Test plan

- [ ] `yarn typecheck` → clean (was erroring on `DraggableWindow.tsx:33`)
- [ ] `yarn test --run` → 214/214 (was failing 1/214 on `useCatalog.filters.test.tsx`)