### PR TITLE
ci: dynamically resolve renderer pairing by client context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
       - main
       - 'feat/**'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      renderer_repo:
+        description: 'Renderer repo (owner/name). Empty = auto from client branch.'
+        required: false
+        default: ''
+      renderer_ref:
+        description: 'Renderer git ref. Empty = auto from client branch.'
+        required: false
+        default: ''
 
 # Opt into the Node.js 24 runtime for the JavaScript actions
 # (actions/checkout, actions/setup-node, …). Node 20 will be removed
@@ -29,17 +39,61 @@ jobs:
         with:
           path: Nitro-V3
 
-      # The client tracks renderer changes that are pushed to the
-      # `feat/react19-event-bus` branch of `simoleo89/Nitro_Render_V3`
-      # (allowUnderpass + sendBackgroundMessage + Window NitroConfig
-      # alignment, etc.). `duckietm/Nitro_Render_V3:main` doesn't yet
-      # have those, so tsgo would fail right away if we checked that
-      # out instead.
+      # Pick the renderer ref dynamically based on the client context.
+      # Renderer repo is always upstream `duckietm/Nitro_Render_V3` —
+      # the two repos must stay wire-aligned (composer/parser
+      # signatures); pairing `main` with a stale branch is what
+      # produced the "Expected 14-15 arguments, but got 16" failure on
+      # the catalog edit composer.
+      #
+      # Mapping:
+      #   client `main`             → duckietm/Nitro_Render_V3 @ main
+      #   client `feat/**`          → duckietm/Nitro_Render_V3 @ Dev
+      #   PR base `main`            → duckietm/Nitro_Render_V3 @ main
+      #   PR base `Dev` (upstream)  → duckietm/Nitro_Render_V3 @ Dev
+      #   PR base `feat/**`         → duckietm/Nitro_Render_V3 @ Dev
+      #
+      # Override via workflow_dispatch inputs when you need an ad-hoc
+      # pairing.
+      - name: Resolve renderer ref
+        id: renderer
+        run: |
+          REPO="${{ github.event.inputs.renderer_repo }}"
+          REF="${{ github.event.inputs.renderer_ref }}"
+
+          if [ -z "$REPO" ] || [ -z "$REF" ]; then
+            case "${GITHUB_EVENT_NAME}" in
+              pull_request)
+                CTX="${GITHUB_BASE_REF}"
+                ;;
+              *)
+                CTX="${GITHUB_REF_NAME}"
+                ;;
+            esac
+
+            AUTO_REPO="duckietm/Nitro_Render_V3"
+            case "$CTX" in
+              main)
+                AUTO_REF="main"
+                ;;
+              *)
+                AUTO_REF="Dev"
+                ;;
+            esac
+
+            [ -z "$REPO" ] && REPO="$AUTO_REPO"
+            [ -z "$REF" ]  && REF="$AUTO_REF"
+          fi
+
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF"   >> "$GITHUB_OUTPUT"
+          echo "Resolved renderer pairing: $REPO @ $REF (client ctx: ${GITHUB_BASE_REF:-$GITHUB_REF_NAME}, event: ${GITHUB_EVENT_NAME})"
+
       - name: Checkout Nitro_Render_V3 (sibling)
         uses: actions/checkout@v4
         with:
-          repository: simoleo89/Nitro_Render_V3
-          ref: feat/react19-event-bus
+          repository: ${{ steps.renderer.outputs.repo }}
+          ref: ${{ steps.renderer.outputs.ref }}
           path: Nitro_Render_V3
 
       - name: Setup Node 22


### PR DESCRIPTION
## Summary

- The CI job hard-coded `simoleo89/Nitro_Render_V3 @ feat/react19-event-bus` as the renderer sibling regardless of the client branch under test. When `main` (a mirror of `duckietm/Nitro-V3:main`) absorbed the upstream Catalog Editor change — which calls `CatalogAdminSavePageComposer` with 16 args (new `pageText1` trailing field) — the paired renderer fork still had the 15-arg signature, so tsgo failed with `TS2554: Expected 14-15 arguments, but got 16` on every `main` push.
- This PR resolves the renderer ref dynamically from the client context, so contract changes that land together on `duckietm/Nitro-V3` + `duckietm/Nitro_Render_V3` are tested against each other.

## Mapping

| Client context | Renderer pairing |
|---|---|
| push `main` | `duckietm/Nitro_Render_V3 @ main` |
| push `feat/**` | `duckietm/Nitro_Render_V3 @ Dev` |
| PR base `main` | `duckietm/Nitro_Render_V3 @ main` |
| PR base `Dev` | `duckietm/Nitro_Render_V3 @ Dev` |
| PR base `feat/**` | `duckietm/Nitro_Render_V3 @ Dev` |
| `workflow_dispatch` | manual override via `renderer_repo` / `renderer_ref` inputs |

The renderer repo is always upstream `duckietm/Nitro_Render_V3` — no fork hard-codes left.

## Notes

- A `workflow_dispatch` trigger with optional `renderer_repo` / `renderer_ref` inputs lets us pin an ad-hoc renderer ref (useful when validating a renderer branch before pushing the client side).
- The resolved pairing is echoed to the job log for easier debugging of failing CI runs.

## Test plan

- [ ] Push to a `feat/**` branch → resolved pairing logs `duckietm/Nitro_Render_V3 @ Dev`, typecheck/lint/tests pass.
- [ ] Sync `main` from upstream → resolved pairing logs `duckietm/Nitro_Render_V3 @ main`, no more `TS2554` on `CatalogAdminSavePageComposer`.
- [ ] Open a PR with base `Dev` → resolved pairing logs `duckietm/Nitro_Render_V3 @ Dev`.
- [ ] Trigger via "Run workflow" with custom `renderer_ref` → override is honored.