### PR TITLE
feat(radio): make the radio widget toggleable from ui-config

### DIFF
--- a/public/configuration/renderer-config.example
+++ b/public/configuration/renderer-config.example
@@ -32,7 +32,6 @@
     "badge.asset.url": "${image.library.url}album1584/%badgename%.gif",
 	"radio.url": "${gamedata.url}/radio-stations.json5?t=%timestamp%",
 	"soundboard.url": "${gamedata.url}/soundboard-sounds.json5?t=%timestamp%",
-	"radio_ui": false,
     "furni.rotation.bounce.steps": 20,
 	"furni.rotation.bounce.height": 0.0625,
 	"enable.avatar.arrow": false,

--- a/public/configuration/ui-config.example
+++ b/public/configuration/ui-config.example
@@ -24,6 +24,7 @@
     "wired.action.kick.from.room.max.length": 100,
     "wired.action.mute.user.max.length": 100,
     "game.center.enabled": false,
+    "radio_ui.enabled": false,
     "guides.enabled": true,
 	"housekeeping.enabled": true,
     "toolbar.hide.quests": true,

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -184,7 +184,7 @@ export const MainView: FC<{}> = props =>
             <RareValuesView />
             <FortuneWheelView />
             <SoundboardView />
-            { GetConfigurationValue<boolean>('radio_ui', true) && <RadioView /> }
+            { GetConfigurationValue<boolean>('radio_ui.enabled', false) && <RadioView /> }
             <ExternalPluginLoader />
         </>
     );


### PR DESCRIPTION
## Summary
- Move the radio on/off switch out of `renderer-config` (where it sat next to asset/data URLs) into `ui-config`, next to the other UI feature toggles (`game.center.enabled`, `guides.enabled`, …) — the natural home for a widget switch.
- Rename the key to the dotted convention used by the rest of `ui-config`: **`radio_ui.enabled`**.
- The `MainView` gate now defaults to **`false`**, so the radio widget is opt-in: an absent key keeps it hidden (no more stray widget showing untranslated `radio.*` keys on hotels that never configured it).
- `radio.url` (the stations data source) stays in `renderer-config`, since it's a data URL, not a UI toggle.

## How to enable
Set `"radio_ui.enabled": true` in `ui-config.json`.

## Test plan
- [ ] With no `radio_ui.enabled` key (or `false`): the radio widget does not render.
- [ ] With `"radio_ui.enabled": true`: the radio widget renders top-left as before.
- [ ] `yarn typecheck` passes.