### PR TITLE
feat(furni-editor): read-only resolver preview section

### DIFF
--- a/src/components/furni-editor/FurniEditorView.tsx
+++ b/src/components/furni-editor/FurniEditorView.tsx
@@ -17,6 +17,7 @@ export const FurniEditorView: FC<{}> = () =>
     const {
         items, total, page, loading, error, clearError,
         selectedItem, setSelectedItem, furniDataEntry,
+        resolverPreview,
         interactions,
         searchItems, loadDetail, loadBySpriteId, updateItem, deleteItem, loadInteractions
     } = useFurniEditor();
@@ -150,6 +151,7 @@ export const FurniEditorView: FC<{}> = () =>
                     <FurniEditorEditView
                         item={ selectedItem }
                         furniDataEntry={ furniDataEntry }
+                        resolverPreview={ resolverPreview }
                         interactions={ interactions }
                         loading={ loading }
                         onUpdate={ updateItem }

--- a/src/components/furni-editor/views/FurniEditorEditView.tsx
+++ b/src/components/furni-editor/views/FurniEditorEditView.tsx
@@ -1,11 +1,12 @@
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Column, Flex, LayoutFurniIconImageView, Text } from '../../../common';
-import { FurniDetail } from '../../../hooks/furni-editor';
+import { FurniDetail, FurniResolverPreview } from '../../../hooks/furni-editor';
 
 interface FurniEditorEditViewProps
 {
     item: FurniDetail;
     furniDataEntry: Record<string, unknown> | null;
+    resolverPreview: FurniResolverPreview | null;
     interactions: string[];
     loading: boolean;
     onUpdate: (id: number, fields: Record<string, unknown>) => void;
@@ -65,7 +66,7 @@ const Tip: FC<{ field: string }> = ({ field }) =>
 
 export const FurniEditorEditView: FC<FurniEditorEditViewProps> = props =>
 {
-    const { item, furniDataEntry, interactions, loading, onUpdate, onDelete, onBack } = props;
+    const { item, furniDataEntry, resolverPreview, interactions, loading, onUpdate, onDelete, onBack } = props;
     const saveRef = useRef<() => void>(null);
 
     const [ form, setForm ] = useState({
@@ -319,6 +320,27 @@ export const FurniEditorEditView: FC<FurniEditorEditViewProps> = props =>
                     <input className={ inputClass() } value={ form.customparams } onChange={ e => setField('customparams', e.target.value) } />
                 </div>
             </Section>
+
+            { resolverPreview?.fields?.length > 0 &&
+                <Section title="Resolver Preview" defaultOpen={ true }>
+                    <div className="grid grid-cols-[88px_1fr_1fr_1fr_72px] gap-1 text-[10px]">
+                        <span className="font-bold text-[#555]">Field</span>
+                        <span className="font-bold text-[#555]">Data</span>
+                        <span className="font-bold text-[#555]">DB</span>
+                        <span className="font-bold text-[#555]">Resolved</span>
+                        <span className="font-bold text-[#555] text-right">Source</span>
+                        { resolverPreview.fields.map(field => (
+                            <Fragment key={ field.key }>
+                                <span className="text-[#333] truncate">{ field.label }</span>
+                                <span className="bg-[#f5f5f5] px-1 py-0.5 rounded truncate">{ field.jsonValue || '-' }</span>
+                                <span className={ `px-1 py-0.5 rounded truncate ${ field.different ? 'bg-[#fff0d6] text-[#8a4b00]' : 'bg-[#f5f5f5]' }` }>{ field.dbValue || '-' }</span>
+                                <span className="bg-[#eef7ed] px-1 py-0.5 rounded truncate">{ field.resolvedValue || '-' }</span>
+                                <span className="text-[#666] text-right truncate">{ field.source }</span>
+                            </Fragment>
+                        )) }
+                    </div>
+                </Section>
+            }
 
             { furniDataEntry &&
                 <Section title="FurniData.json" defaultOpen={ false }>

--- a/src/hooks/furni-editor/useFurniEditor.ts
+++ b/src/hooks/furni-editor/useFurniEditor.ts
@@ -49,6 +49,22 @@ export interface CatalogRef
     pageName: string;
 }
 
+export interface FurniResolverPreviewField
+{
+    key: string;
+    label: string;
+    jsonValue: string;
+    dbValue: string;
+    resolvedValue: string;
+    source: string;
+    different: boolean;
+}
+
+export interface FurniResolverPreview
+{
+    fields: FurniResolverPreviewField[];
+}
+
 export const useFurniEditor = () =>
 {
     const [ items, setItems ] = useState<FurniItem[]>([]);
@@ -60,6 +76,7 @@ export const useFurniEditor = () =>
     const [ catalogItems, setCatalogItems ] = useState<CatalogRef[]>([]);
     const [ interactions, setInteractions ] = useState<string[]>([]);
     const [ furniDataEntry, setFurniDataEntry ] = useState<Record<string, unknown> | null>(null);
+    const [ resolverPreview, setResolverPreview ] = useState<FurniResolverPreview | null>(null);
     const pendingActionRef = useRef<{ action: string; itemId: number } | null>(null);
     const { simpleAlert = null } = useNotification();
 
@@ -150,6 +167,23 @@ export const useFurniEditor = () =>
         {}
 
         setFurniDataEntry(furniData);
+
+        let parsedResolverPreview: FurniResolverPreview | null = null;
+
+        try
+        {
+            if(parser.resolverPreviewJson && parser.resolverPreviewJson !== '')
+            {
+                const parsed = JSON.parse(parser.resolverPreviewJson);
+                parsedResolverPreview = {
+                    fields: Array.isArray(parsed?.fields) ? parsed.fields : []
+                };
+            }
+        }
+        catch(e)
+        {}
+
+        setResolverPreview(parsedResolverPreview);
     });
 
     // Handle interaction types list
@@ -201,6 +235,7 @@ export const useFurniEditor = () =>
             setSelectedItem(null);
             setCatalogItems([]);
             setFurniDataEntry(null);
+            setResolverPreview(null);
 
             if(simpleAlert)
             {
@@ -254,6 +289,7 @@ export const useFurniEditor = () =>
     return {
         items, total, page, loading, error, clearError,
         selectedItem, setSelectedItem, catalogItems, furniDataEntry,
+        resolverPreview,
         interactions,
         searchItems, loadDetail, loadBySpriteId, updateItem, deleteItem, loadInteractions
     };


### PR DESCRIPTION
@
## What

Adds a **read-only Resolver Preview** section to the Furni Editor edit view, showing for each core field the furnidata value, the DB (`items_base`) value, the final resolved value, and the source — with mismatches highlighted.

## How

- `useFurniEditor` parses the new `resolverPreviewJson` getter from the renderer into typed `FurniResolverPreview` state (defensive `try/catch`, defaults to empty fields), and clears it when an item is deleted.
- `FurniEditorView` forwards `resolverPreview` to the edit view.
- `FurniEditorEditView` renders a compact `Field / Data / DB / Resolved / Source` grid above the existing FurniData section; rows where furnidata and DB differ are highlighted.

## Scope

Read-only first slice — no write-path or save-behaviour changes.

## Related (merge order)

1. Emulator: duckietm/Arcturus-Morningstar-Extended#151 (appends preview string)
2. Renderer: duckietm/Nitro_Render_V3#89 (exposes `resolverPreviewJson`) — **merge before this**
3. This client PR (consumes the getter)
@