### PR TITLE
feat(badge-leaderboard): render avatar heads with the local renderer

### DIFF
--- a/src/components/badge-leaderboard/BadgeLeaderboardView.tsx
+++ b/src/components/badge-leaderboard/BadgeLeaderboardView.tsx
@@ -1,7 +1,7 @@
 import { AddLinkEventTracker, GetSessionDataManager, ILinkEventTracker, RemoveLinkEventTracker } from '@nitrots/nitro-renderer';
 import { CSSProperties, FC, useEffect, useMemo, useState } from 'react';
 import { BadgeLeaderboardBoard, BadgeLeaderboardEntry, BadgeRarityKey, fetchBadgeLeaderboard, getCachedBadgeLeaderboard, LocalizeText } from '../../api';
-import { Column, DraggableWindow, DraggableWindowPosition, Flex, Text } from '../../common';
+import { Column, DraggableWindow, DraggableWindowPosition, Flex, LayoutAvatarImageView, Text } from '../../common';
 import {
     badgeEmblemAchievement,
     badgeEmblemCommon,
@@ -40,12 +40,6 @@ const RARITY_ASSETS: Record<BadgeRarityKey, { frame: string; emblem: string }> =
 
 const RARITY_ORDER: BadgeRarityKey[] = [ 'common', 'rare', 'epic', 'legendary', 'mythical', 'unique' ];
 const PAGE_SIZE = 10;
-const getAvatarHeadUrl = (figure: string): string =>
-{
-    if(!figure) return '';
-
-    return `https://www.habbo.com/habbo-imaging/avatarimage?figure=${ encodeURIComponent(figure) }&direction=2&head_direction=2&gesture=sml&size=m&headonly=1`;
-};
 
 export const BadgeLeaderboardView: FC<{}> = props =>
 {
@@ -310,7 +304,7 @@ const LeaderboardRow: FC<LeaderboardRowProps> = props =>
         <div className={ `nitro-badge-leaderboard__row ${ isCurrentUser ? 'is-current-user' : '' } ${ ((rowIndex % 2) === 0) ? 'is-even' : 'is-odd' }` }>
             <div className={ `nitro-badge-leaderboard__rank ${ rankClassName }` }>{ entry.rank }</div>
             <div className="nitro-badge-leaderboard__avatar">
-                <img className="nitro-badge-leaderboard__avatar-image" src={ getAvatarHeadUrl(entry.figure) } alt="" loading="lazy" />
+                <LayoutAvatarImageView figure={ entry.figure } headOnly direction={ 2 } />
             </div>
             <Text className="nitro-badge-leaderboard__username" bold>{ entry.username }</Text>
             <Text className="nitro-badge-leaderboard__score" bold>{ entry.score }</Text>

--- a/src/css/badges/BadgeLeaderboardView.css
+++ b/src/css/badges/BadgeLeaderboardView.css
@@ -258,30 +258,28 @@
 }
 
 .nitro-badge-leaderboard__avatar {
-    width: 54px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
+    position: relative;
+    width: 40px;
+    height: 40px;
+    overflow: hidden;
     margin: 0 auto;
     align-self: center;
 }
 
-.nitro-badge-leaderboard__avatar .avatar-image,
-.nitro-badge-leaderboard__avatar-image {
-    display: block;
-    width: auto !important;
-    height: auto !important;
-    max-width: 54px;
-    max-height: 62px;
-    left: auto !important;
-    right: auto !important;
-    top: auto !important;
-    bottom: auto !important;
-    margin: 0 auto;
+/* The renderer-backed LayoutAvatarImageView (headOnly) draws the avatar head as
+   an absolutely-positioned background div (`.avatar-image`), not an <img>. Frame
+   it the same way the friends list does, scaled up for the larger row. */
+.nitro-badge-leaderboard__avatar .avatar-image {
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    background-repeat: no-repeat;
+    background-size: 82px auto !important;
+    background-position: -20px -24px !important;
+    transform: none !important;
     image-rendering: pixelated;
-    object-fit: contain;
 }
 
 .nitro-badge-leaderboard__username {


### PR DESCRIPTION
## Summary

The badge leaderboard pulled each avatar head from **habbo.com's imaging service** (`https://www.habbo.com/habbo-imaging/avatarimage?...&headonly=1`) via a plain `<img>`. The avatar `figure` is **already present** in the leaderboard data (served by the CMS `/api/badges/leaderboard` endpoint), so the external request is unnecessary — render it locally instead.

## Change

- Replace the `<img>` with the renderer-backed `LayoutAvatarImageView` (`headOnly`), which draws the head through `GetAvatarRenderManager().createAvatarImage(...)`.
- The head-only render is an absolutely-positioned background div (not an `<img>`), so `.nitro-badge-leaderboard__avatar` is reworked into a `relative`, `overflow:hidden` box with a head crop mirrored from the friends list.
- Remove the now-unused `getAvatarHeadUrl` helper.

Result: avatars come entirely from the local renderer — no more runtime dependency on habbo.com for this panel.

## Verification

- `yarn test --run` → 527/527 pass
- ESLint (changed files) → no new errors over the pre-existing baseline
- `yarn typecheck` → only the pre-existing `@nitrots/nitro-renderer` sandbox baseline

Two files changed: `src/components/badge-leaderboard/BadgeLeaderboardView.tsx`, `src/css/badges/BadgeLeaderboardView.css`.

> Note: the head-crop framing (`background-size` / `background-position` in the CSS) was scaled from the friends-list values and may warrant a small pixel nudge after visual review.