### PR TITLE
feat(mentions): show sender avatar head in the mentions panel rows

### DIFF
--- a/src/components/mentions/MentionRowView.tsx
+++ b/src/components/mentions/MentionRowView.tsx
@@ -32,8 +32,8 @@ export const MentionRowView: FC<MentionRowViewProps> = props =>
             <span
                 className={ `inline-block w-[8px] h-[8px] rounded-full shrink-0 ${ mention.read ? 'bg-transparent' : 'bg-[#1e7295]' }` }
                 title={ mention.read ? '' : LocalizeText('mentions.filter.unread') } />
-            <div className="relative shrink-0 w-[32px] h-[32px] overflow-hidden rounded bg-black/10" title={ typeTitle }>
-                <LayoutAvatarImageView headOnly direction={ 2 } figure={ mention.senderFigure } style={ { backgroundSize: '80px auto', backgroundPosition: '-24px -18px' } } />
+            <div className="relative shrink-0 w-[36px] h-[36px] overflow-hidden rounded bg-black/10" title={ typeTitle }>
+                <LayoutAvatarImageView headOnly direction={ 2 } figure={ mention.senderFigure } style={ { backgroundSize: 'auto', backgroundPosition: '-22px -32px' } } />
                 <span
                     className={ `absolute bottom-0 right-0 flex items-center justify-center w-[14px] h-[14px] rounded-full text-[8px] font-bold leading-none text-white ring-2 ring-white ${ isRoom ? 'bg-[#d08a1e]' : 'bg-[#1e7295]' }` }>
                     { isRoom ? '∗' : '@' }

--- a/src/components/mentions/MentionRowView.tsx
+++ b/src/components/mentions/MentionRowView.tsx
@@ -32,8 +32,8 @@ export const MentionRowView: FC<MentionRowViewProps> = props =>
             <span
                 className={ `inline-block w-[8px] h-[8px] rounded-full shrink-0 ${ mention.read ? 'bg-transparent' : 'bg-[#1e7295]' }` }
                 title={ mention.read ? '' : LocalizeText('mentions.filter.unread') } />
-            <div className="relative shrink-0 w-[36px] h-[36px] overflow-hidden rounded bg-black/10" title={ typeTitle }>
-                <LayoutAvatarImageView headOnly direction={ 2 } figure={ mention.senderFigure } style={ { backgroundSize: 'auto', backgroundPosition: '-22px -32px' } } />
+            <div className="relative shrink-0 w-[40px] h-[40px] overflow-hidden rounded bg-black/10" title={ typeTitle }>
+                <LayoutAvatarImageView headOnly direction={ 2 } figure={ mention.senderFigure } style={ { backgroundSize: 'auto', backgroundPosition: '-24px -34px' } } />
                 <span
                     className={ `absolute bottom-0 right-0 flex items-center justify-center w-[14px] h-[14px] rounded-full text-[8px] font-bold leading-none text-white ring-2 ring-white ${ isRoom ? 'bg-[#d08a1e]' : 'bg-[#1e7295]' }` }>
                     { isRoom ? '∗' : '@' }

--- a/src/components/mentions/MentionRowView.tsx
+++ b/src/components/mentions/MentionRowView.tsx
@@ -1,6 +1,6 @@
 import { FC, MouseEvent } from 'react';
 import { IMentionEntry, LocalizeText, MentionType } from '../../api';
-import { Flex, Text } from '../../common';
+import { Flex, LayoutAvatarImageView, Text } from '../../common';
 import { MentionMessageView } from './MentionMessageView';
 import { formatMentionTime } from './mentionsFormat';
 
@@ -32,11 +32,13 @@ export const MentionRowView: FC<MentionRowViewProps> = props =>
             <span
                 className={ `inline-block w-[8px] h-[8px] rounded-full shrink-0 ${ mention.read ? 'bg-transparent' : 'bg-[#1e7295]' }` }
                 title={ mention.read ? '' : LocalizeText('mentions.filter.unread') } />
-            <span
-                title={ typeTitle }
-                className={ `flex items-center justify-center shrink-0 w-[18px] h-[18px] rounded text-[10px] font-bold leading-none text-white ${ isRoom ? 'bg-[#d08a1e]' : 'bg-[#1e7295]' }` }>
-                { isRoom ? '@∗' : '@' }
-            </span>
+            <div className="relative shrink-0 w-[32px] h-[32px] overflow-hidden rounded bg-black/10" title={ typeTitle }>
+                <LayoutAvatarImageView headOnly direction={ 2 } figure={ mention.senderFigure } style={ { backgroundSize: '80px auto', backgroundPosition: '-24px -18px' } } />
+                <span
+                    className={ `absolute bottom-0 right-0 flex items-center justify-center w-[14px] h-[14px] rounded-full text-[8px] font-bold leading-none text-white ring-2 ring-white ${ isRoom ? 'bg-[#d08a1e]' : 'bg-[#1e7295]' }` }>
+                    { isRoom ? '∗' : '@' }
+                </span>
+            </div>
             <Flex grow column className="min-w-0" gap={ 0 }>
                 <Flex alignItems="center" gap={ 1 } className="min-w-0">
                     <Text bold={ !mention.read } truncate variant="primary">{ mention.senderUsername }</Text>


### PR DESCRIPTION
## Summary

The mentions **toasts** and the **@-autocomplete dropdown** already render the sender via the local renderer (`LayoutAvatarImageView`). The mentions **panel list rows** (`MentionRowView`) did not — they showed only a generic `@` / `@∗` type square, even though each `IMentionEntry` already carries `senderFigure`.

## Change

`src/components/mentions/MentionRowView.tsx`:
- Lead each row with the renderer-backed avatar head (`LayoutAvatarImageView headOnly direction={2}`), matching the toast style.
- Fold the direct/room type into a small colour-coded corner marker (blue = direct, orange = room), with the type label kept as the avatar container `title` (tooltip) — no information lost.
- Head crop via inline `backgroundSize` / `backgroundPosition` style (same recipe as `GroupForumThreadView`) — no new CSS file.

Single file, +8 / -6.

## Verification

- ESLint (changed file) → clean (0 problems)
- `yarn typecheck` → only the pre-existing `@nitrots/nitro-renderer` sandbox baseline, nothing in this file
- `yarn test --run` → 527/527 pass

> Note: the head-crop offsets (`80px auto`, `-24px -18px`) are an estimate and may warrant a small pixel nudge after visual review in-client.