### PR TITLE
fix(toolbar): add missing CSS rule for the mentions icon

### DIFF
--- a/src/css/icons/icons.css
+++ b/src/css/icons/icons.css
@@ -36,6 +36,13 @@
     height: 36px;
 }
 
+.nitro-icon.icon-mentions {
+    background-image: url("@/assets/images/toolbar/icons/mentions.png");
+    background-size: contain;
+    width: 36px;
+    height: 32px;
+}
+
 .nitro-icon.icon-buildersclub {
     background-image: url("@/assets/images/toolbar/icons/buildersclub.png");
     background-size: contain;


### PR DESCRIPTION
## Problem

The toolbar renders a mentions button — `ToolbarItemView icon="mentions"` → `<div class="nitro-icon icon-mentions">` — and the asset `src/assets/images/toolbar/icons/mentions.png` (72×64) exists, but `src/css/icons/icons.css` had **no** `.nitro-icon.icon-mentions` rule.

The base `.nitro-icon` sets no width/height/background, so without an icon-specific rule the element had no background image and rendered at **0×0 → invisible**. That is why the mentions icon never appeared in the toolbar (the `mentions_ui.enabled` config defaults to `true`, so it was not the gate).

## Fix

Add the missing rule, sized at half the asset (36×32, preserving its 9:8 aspect) with `background-size: contain`, consistent with the other toolbar icon definitions:

```css
.nitro-icon.icon-mentions {
    background-image: url("@/assets/images/toolbar/icons/mentions.png");
    background-size: contain;
    width: 36px;
    height: 32px;
}
```

One file, +7 lines. No JS/TS change.

## Verification

- `yarn test --run` → 527/527 pass
- ESLint / typecheck unaffected (CSS-only change)