### PR TITLE
fix(client): restore chat-input TEXT mode + align tsconfig resolution with vite alias

### DIFF
--- a/src/api/room/events/RoomWidgetUpdateChatInputContentEvent.ts
+++ b/src/api/room/events/RoomWidgetUpdateChatInputContentEvent.ts
@@ -5,6 +5,7 @@ export class RoomWidgetUpdateChatInputContentEvent extends RoomWidgetUpdateEvent
     public static CHAT_INPUT_CONTENT: string = 'RWUCICE_CHAT_INPUT_CONTENT';
     public static WHISPER: string = 'whisper';
     public static SHOUT: string = 'shout';
+    public static TEXT: string = 'text';
 
     private _chatMode: string = '';
     private _userName: string = '';

--- a/src/components/room/widgets/chat-input/ChatInputView.tsx
+++ b/src/components/room/widgets/chat-input/ChatInputView.tsx
@@ -236,6 +236,10 @@ export const ChatInputView: FC<{}> = props =>
     {
         switch(event.chatMode)
         {
+            case RoomWidgetUpdateChatInputContentEvent.TEXT:
+                setChatValue(event.userName);
+                inputRef.current?.focus();
+                return;
             case RoomWidgetUpdateChatInputContentEvent.WHISPER: {
                 setChatValue(`${ chatModeIdWhisper } ${ event.userName } `);
                 return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,48 @@
             ],
             "pixi.js": [
                 "../Nitro_Render_V3/node_modules/pixi.js"
+            ],
+            "@nitrots/nitro-renderer": [
+                "../Nitro_Render_V3/index.ts"
+            ],
+            "@nitrots/api": [
+                "../Nitro_Render_V3/packages/api/src/index.ts"
+            ],
+            "@nitrots/assets": [
+                "../Nitro_Render_V3/packages/assets/src/index.ts"
+            ],
+            "@nitrots/avatar": [
+                "../Nitro_Render_V3/packages/avatar/src/index.ts"
+            ],
+            "@nitrots/camera": [
+                "../Nitro_Render_V3/packages/camera/src/index.ts"
+            ],
+            "@nitrots/communication": [
+                "../Nitro_Render_V3/packages/communication/src/index.ts"
+            ],
+            "@nitrots/configuration": [
+                "../Nitro_Render_V3/packages/configuration/src/index.ts"
+            ],
+            "@nitrots/events": [
+                "../Nitro_Render_V3/packages/events/src/index.ts"
+            ],
+            "@nitrots/localization": [
+                "../Nitro_Render_V3/packages/localization/src/index.ts"
+            ],
+            "@nitrots/room": [
+                "../Nitro_Render_V3/packages/room/src/index.ts"
+            ],
+            "@nitrots/session": [
+                "../Nitro_Render_V3/packages/session/src/index.ts"
+            ],
+            "@nitrots/sound": [
+                "../Nitro_Render_V3/packages/sound/src/index.ts"
+            ],
+            "@nitrots/utils/src": [
+                "../Nitro_Render_V3/packages/utils/src"
+            ],
+            "@nitrots/utils": [
+                "../Nitro_Render_V3/packages/utils/src/index.ts"
             ]
         }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,44 +32,8 @@
             "@nitrots/nitro-renderer": [
                 "../Nitro_Render_V3/index.ts"
             ],
-            "@nitrots/api": [
-                "../Nitro_Render_V3/packages/api/src/index.ts"
-            ],
-            "@nitrots/assets": [
-                "../Nitro_Render_V3/packages/assets/src/index.ts"
-            ],
-            "@nitrots/avatar": [
-                "../Nitro_Render_V3/packages/avatar/src/index.ts"
-            ],
-            "@nitrots/camera": [
-                "../Nitro_Render_V3/packages/camera/src/index.ts"
-            ],
-            "@nitrots/communication": [
-                "../Nitro_Render_V3/packages/communication/src/index.ts"
-            ],
-            "@nitrots/configuration": [
-                "../Nitro_Render_V3/packages/configuration/src/index.ts"
-            ],
-            "@nitrots/events": [
-                "../Nitro_Render_V3/packages/events/src/index.ts"
-            ],
-            "@nitrots/localization": [
-                "../Nitro_Render_V3/packages/localization/src/index.ts"
-            ],
-            "@nitrots/room": [
-                "../Nitro_Render_V3/packages/room/src/index.ts"
-            ],
-            "@nitrots/session": [
-                "../Nitro_Render_V3/packages/session/src/index.ts"
-            ],
-            "@nitrots/sound": [
-                "../Nitro_Render_V3/packages/sound/src/index.ts"
-            ],
-            "@nitrots/utils/src": [
-                "../Nitro_Render_V3/packages/utils/src"
-            ],
-            "@nitrots/utils": [
-                "../Nitro_Render_V3/packages/utils/src/index.ts"
+            "@nitrots/*": [
+                "../Nitro_Render_V3/packages/*/src/index.ts"
             ]
         }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
             ],
             "@/*": [
                 "./src/*"
+            ],
+            "pixi.js": [
+                "../Nitro_Render_V3/node_modules/pixi.js"
             ]
         }
     },


### PR DESCRIPTION
Three client type-check fixes after syncing upstream:

### 1. `TS2339: Property 'TEXT' does not exist on type 'typeof RoomWidgetUpdateChatInputContentEvent'`
`NotificationDefaultAlertView` (command-template "copy command to chat input") dispatches `RoomWidgetUpdateChatInputContentEvent.TEXT`, but the `TEXT` constant + its `ChatInputView` handler case were removed in `7007752` while migrating the in-component command-selector to call `setChatValue` directly. The `CHAT_INPUT_CONTENT` event is the only cross-component way to set the chat input, so the notification path is left broken (and no longer compiles). Restores the constant and the handler case (`setChatValue` + focus, matching the command-selector path).

### 2 & 3. tsconfig module resolution out of sync with the vite alias
`vite.config.mjs` already aliases `pixi.js` and every `@nitrots/*` package to the source-linked renderer (`../Nitro_Render_V3`), so dev/runtime resolve fine. But `tsconfig.json` had no matching `paths`, so `tsgo`/`tsc` resolved them differently:
- `src/pixiPatch.ts` → `TS2307: Cannot find module 'pixi.js'`
- `useFriends.ts` / `useMessenger.ts` → `TS2305: '@nitrots/nitro-renderer' has no exported member 'AddFriendCategoryComposer' / 'ConsoleTypingComposer' / 'FriendIsTypingEvent' / …` (the composers/events exist in fresh renderer source but typecheck resolved `@nitrots` to a stale target)

Fix: mirror the vite alias in `tsconfig.json` `paths` (`pixi.js` + all `@nitrots/*` → renderer source), so type-check reads the same source as runtime.

Result: `yarn typecheck` clean (0 errors), `yarn test` 545/545 green.

Note: the tsconfig changes assume the documented source-linked renderer setup (`../Nitro_Render_V3`), matching the existing vite alias — happy to split the TEXT fix into its own PR if you'd prefer to keep the build-config alignment separate.