### PR TITLE
Remove trailing comma in ui-config.example

### DIFF
--- a/public/configuration/ui-config.example
+++ b/public/configuration/ui-config.example
@@ -47,7 +47,7 @@
             "left": "${asset.url}/c_images/reception/ts.png",
             "right": "${asset.url}/c_images/reception/US_right.png",
             "right.repeat": "${asset.url}/c_images/reception/US_top_right.png"
-        },
+        }
     },
     "navigator.room.models": [
         {


### PR DESCRIPTION
Remove a trailing comma after the closing object in public/configuration/ui-config.example. This fixes invalid JSON syntax that could cause parsing errors when loading the UI configuration.