### PR TITLE
fix(client): logic bugs from ui↔renderer audit (inventory, room, wired, mod-tools, camera, groups, purse, marketplace)

### DIFF
--- a/src/components/camera/CameraWidgetView.tsx
+++ b/src/components/camera/CameraWidgetView.tsx
@@ -14,7 +14,7 @@ export const CameraWidgetView: FC<{}> = props =>
 {
     const [ mode, setMode ] = useState<number>(MODE_NONE);
     const [ base64Url, setSavedPictureUrl ] = useState<string>(null);
-    const { availableEffects = [], selectedPictureIndex = -1, cameraRoll = [], setCameraRoll = null, myLevel = 0, price = { credits: 0, duckets: 0, publishDucketPrice: 0 } } = useCamera();
+    const { availableEffects = [], selectedPictureIndex = -1, setSelectedPictureIndex = null, cameraRoll = [], setCameraRoll = null, myLevel = 0, price = { credits: 0, duckets: 0, publishDucketPrice: 0 } } = useCamera();
 
 
     const processAction = (type: string) =>
@@ -28,14 +28,11 @@ export const CameraWidgetView: FC<{}> = props =>
                 setMode(MODE_EDITOR);
                 return;
             case 'delete':
-                setCameraRoll(prevValue =>
-                {
-                    const clone = [ ...prevValue ];
-
-                    clone.splice(selectedPictureIndex, 1);
-
-                    return clone;
-                });
+                setCameraRoll(prevValue => prevValue.filter((_, index) => (index !== selectedPictureIndex)));
+                // Without this the index keeps pointing at the slot the deleted
+                // photo vacated (now a different picture, or past the end) — move
+                // the selection back one so the preview stays in sync.
+                if(setSelectedPictureIndex) setSelectedPictureIndex(prev => (prev > 0 ? (prev - 1) : 0));
                 return;
             case 'editor_cancel':
                 setMode(MODE_CAPTURE);

--- a/src/components/camera/views/CameraWidgetCaptureView.tsx
+++ b/src/components/camera/views/CameraWidgetCaptureView.tsx
@@ -46,9 +46,11 @@ export const CameraWidgetCaptureView: FC<CameraWidgetCaptureViewProps> = props =
 
         if(clone.length >= CAMERA_ROLL_LIMIT)
         {
+            // Roll is full — block the shot (the old code did clone.pop(), which
+            // discarded the NEWEST photo and pinned the roll at the limit forever).
             simpleAlert(LocalizeText('camera.full.body'));
 
-            clone.pop();
+            return;
         }
 
         PlaySound(SoundNames.CAMERA_SHUTTER);

--- a/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplaceOwnItemsView.tsx
+++ b/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplaceOwnItemsView.tsx
@@ -67,6 +67,10 @@ export const CatalogLayoutMarketplaceOwnItemsView: FC<CatalogLayoutProps> = prop
             return prevValue.filter(value => (idsToDelete.indexOf(value.offerId) === -1));
         });
 
+        // Without this the redeem panel stays visible (creditsWaiting > 0) after
+        // the sold offers are optimistically removed, showing "get 0 sold items".
+        setCreditsWaiting(0);
+
         SendMessageComposer(new RedeemMarketplaceOfferCreditsMessageComposer());
 
         setTimeout(() => isRedeemingRef.current = false, 3000);

--- a/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplacePublicItemsView.tsx
+++ b/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplacePublicItemsView.tsx
@@ -115,13 +115,18 @@ export const CatalogLayoutMarketplacePublicItemsView: FC<CatalogLayoutMarketplac
                     const item = newVal.get(parser.requestedOfferId);
                     if(item)
                     {
+                        // Delete the OLD key first, then set under the (possibly
+                        // unchanged) new id. The old code did set()-then-delete(),
+                        // so when the server returned the same id for the re-priced
+                        // offer the set was immediately undone and the offer vanished.
+                        newVal.delete(parser.requestedOfferId);
+
                         item.offerId = parser.offerId;
                         item.price = parser.newPrice;
                         item.offerCount--;
                         newVal.set(item.offerId, item);
                     }
 
-                    newVal.delete(parser.requestedOfferId);
                     return newVal;
                 });
 

--- a/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadView.tsx
+++ b/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadView.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { MessengerThread } from '../../../../../api';
 import { FriendsMessengerThreadGroup } from './FriendsMessengerThreadGroup';
 
@@ -6,7 +6,15 @@ export const FriendsMessengerThreadView: FC<{ thread: MessengerThread }> = props
 {
     const { thread = null } = props;
 
-    thread.setRead();
+    // Mark the thread read after commit, not during render — render must stay
+    // side-effect free. No dep array: faithfully re-marks on every re-render
+    // (e.g. a new message arriving in the active thread), same as before.
+    useEffect(() =>
+    {
+        if(thread) thread.setRead();
+    });
+
+    if(!thread) return null;
 
     return (
         <>

--- a/src/components/groups/views/tabs/GroupTabColorsView.tsx
+++ b/src/components/groups/views/tabs/GroupTabColorsView.tsx
@@ -113,7 +113,7 @@ export const GroupTabColorsView: FC<GroupTabColorsViewProps> = props =>
                 <AutoGrid columnCount={ 7 } columnMinHeight={ 16 } columnMinWidth={ 16 } gap={ 1 }>
                     { groupData.groupColors && groupCustomize?.groupColorsA && groupCustomize.groupColorsA.map((item, index) =>
                     {
-                        return <div key={ index } className={ classNames('relative rounded-[.25rem] w-[16px] h-[16px] bg-[#fff] border-2 border-[solid] border-[#fff] [box-shadow:inset_3px_3px_#0000001a] [box-shadow:inset_2px_2px_#0003] cursor-pointer', ((groupData.groupColors[0] === item.id) && 'bg-primary [box-shadow:none]')) } style={ { backgroundColor: '#' + item.color } } onClick={ () => selectColor(0, item.id) }></div>;
+                        return <div key={ index } className={ classNames('relative rounded-[.25rem] w-[16px] h-[16px] bg-[#fff] border-2 border-[solid] border-[#fff] [box-shadow:inset_3px_3px_#0000001a] [box-shadow:inset_2px_2px_#0003] cursor-pointer', ((colors[0] === item.id) && 'bg-primary [box-shadow:none]')) } style={ { backgroundColor: '#' + item.color } } onClick={ () => selectColor(0, item.id) }></div>;
                     }) }
                 </AutoGrid>
             </Column>
@@ -122,7 +122,7 @@ export const GroupTabColorsView: FC<GroupTabColorsViewProps> = props =>
                 <AutoGrid columnCount={ 7 } columnMinHeight={ 16 } columnMinWidth={ 16 } gap={ 1 }>
                     { groupData.groupColors && groupCustomize?.groupColorsB && groupCustomize.groupColorsB.map((item, index) =>
                     {
-                        return <div key={ index } className={ classNames('relative rounded-[.25rem] w-[16px] h-[16px] bg-[#fff] border-2 border-[solid] border-[#fff] [box-shadow:inset_3px_3px_#0000001a] [box-shadow:inset_2px_2px_#0003] cursor-pointer', ((groupData.groupColors[1] === item.id) && 'bg-primary [box-shadow:none]')) } style={ { backgroundColor: '#' + item.color } } onClick={ () => selectColor(1, item.id) }></div>;
+                        return <div key={ index } className={ classNames('relative rounded-[.25rem] w-[16px] h-[16px] bg-[#fff] border-2 border-[solid] border-[#fff] [box-shadow:inset_3px_3px_#0000001a] [box-shadow:inset_2px_2px_#0003] cursor-pointer', ((colors[1] === item.id) && 'bg-primary [box-shadow:none]')) } style={ { backgroundColor: '#' + item.color } } onClick={ () => selectColor(1, item.id) }></div>;
                     }) }
                 </AutoGrid>
             </Column>

--- a/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
@@ -75,14 +75,16 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = pro
     {
         if(isSendingRef.current) return;
 
+        if(selectedTopic === -1) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
+
         const category = topics[selectedTopic];
 
-        if(selectedTopic === -1) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
+        if(!category) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
 
         const messageOrDefault = (message.trim().length === 0) ? LocalizeText(`help.cfh.topic.${ category.id }`) : message;
 
         isSendingRef.current = true;
-        SendMessageComposer(new DefaultSanctionMessageComposer(user.userId, selectedTopic, messageOrDefault));
+        SendMessageComposer(new DefaultSanctionMessageComposer(user.userId, category.id, messageOrDefault));
         onCloseClick();
     };
 

--- a/src/components/wired-tools/WiredCreatorToolsView.tsx
+++ b/src/components/wired-tools/WiredCreatorToolsView.tsx
@@ -1181,7 +1181,7 @@ export const WiredCreatorToolsView: FC<{}> = () =>
             { key: '@position_x', value: String(liveState?.positionX ?? 0), editable: canEditInspection },
             { key: '@position_y', value: String(liveState?.positionY ?? 0), editable: canEditInspection },
             { key: '@rotation', value: String(liveState?.rotation ?? 0), editable: canEditInspection },
-            { key: '@altitude', value: String(Math.round((liveState?.altitude ?? 0) * 100)), editable: canEditInspection },
+            { key: '@altitude', value: String(liveState?.altitude ?? 0), editable: canEditInspection },
             { key: '@is_invisible', value: '0' },
             ...(wallItemOffset ? [ { key: '@wallitem_offset', value: wallItemOffset, editable: canEditInspection } ] : []),
             { key: '@type', value: `${ selectedFurnitureData?.availableForBuildersClub ? 1 : 0 }${ selectedFurnitureData?.availableForBuildersClub ? ' (BC)' : ' (Normal)' }` },
@@ -1294,7 +1294,7 @@ export const WiredCreatorToolsView: FC<{}> = () =>
             { key: '@position_x', value: String(liveState?.positionX ?? 0), editable: canEditSelectedUser },
             { key: '@position_y', value: String(liveState?.positionY ?? 0), editable: canEditSelectedUser },
             { key: '@direction', value: String(liveState?.direction ?? 0), editable: canEditSelectedUser },
-            { key: '@altitude', value: String(Math.round((liveState?.altitude ?? 0) * 100)) },
+            { key: '@altitude', value: String(liveState?.altitude ?? 0) },
             ...((Number(selectedUser.favouriteGroupId ?? 0) > 0)
                 ? [ { key: '@favourite_group_id', value: String(selectedUser.favouriteGroupId) } ]
                 : []),

--- a/src/components/wired/views/conditions/WiredConditionDateRangeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionDateRangeView.tsx
@@ -13,35 +13,34 @@ export const WiredConditionDateRangeView: FC<{}> = props =>
 
     const save = () =>
     {
-        let startDateMili = 0;
-        let endDateMili = 0;
-
         const startDateInstance = new Date(startDate);
         const endDateInstance = new Date(endDate);
 
-        if(startDateInstance && endDateInstance)
-        {
-            startDateMili = startDateInstance.getTime() / 1000;
-            endDateMili = endDateInstance.getTime() / 1000;
-        }
+        // new Date('garbage') is a truthy *Invalid Date*, not null — the old
+        // `if(startDateInstance && endDateInstance)` was always true, so an
+        // unparseable input wrote NaN as the int param. Guard on getTime().
+        const startDateMili = isNaN(startDateInstance.getTime()) ? 0 : Math.floor(startDateInstance.getTime() / 1000);
+        const endDateMili = isNaN(endDateInstance.getTime()) ? 0 : Math.floor(endDateInstance.getTime() / 1000);
 
         setIntParams([ startDateMili, endDateMili ]);
     };
 
     useEffect(() =>
     {
+        // Seed both inputs (default "now") even for a never-configured furni so
+        // the first save can't send new Date('') → NaN.
+        let startDate = new Date();
+        let endDate = new Date();
+
         if(trigger.intData.length >= 2)
         {
-            let startDate = new Date();
-            let endDate = new Date();
-
             if(trigger.intData[0] > 0) startDate = new Date((trigger.intData[0] * 1000));
 
             if(trigger.intData[1] > 0) endDate = new Date((trigger.intData[1] * 1000));
-
-            setStartDate(WiredDateToString(startDate));
-            setEndDate(WiredDateToString(endDate));
         }
+
+        setStartDate(WiredDateToString(startDate));
+        setEndDate(WiredDateToString(endDate));
     }, [ trigger ]);
 
     return (

--- a/src/hooks/inventory/useInventoryBadges.ts
+++ b/src/hooks/inventory/useInventoryBadges.ts
@@ -1,5 +1,5 @@
 import { BadgeReceivedEvent, BadgesEvent, RequestBadgesComposer, SetActivatedBadgesComposer } from '@nitrots/nitro-renderer';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useBetween } from 'use-between';
 import { GetConfigurationValue, SendMessageComposer, UnseenItemCategory } from '../../api';
 import { useMessageEvent } from '../events';
@@ -17,7 +17,6 @@ const useInventoryBadgesState = () =>
     const { isUnseen = null, resetCategory = null } = useInventoryUnseenTracker();
 
     const maxBadgeCount = GetConfigurationValue<number>('user.badges.max.slots', 5);
-    const pendingUpdatesRef = useRef(0);
     const isWearingBadge = (badgeCode: string) => activeBadgeCodes.some(code => code === badgeCode);
     const canWearBadges = () => (activeBadgeCodes.filter(Boolean).length < maxBadgeCount);
 
@@ -35,7 +34,6 @@ const useInventoryBadgesState = () =>
 
     const sendActiveBadges = (badges: (string | null)[]) =>
     {
-        pendingUpdatesRef.current++;
         const composer = new SetActivatedBadgesComposer();
         for(let i = 0; i < maxBadgeCount; i++) composer.addActivatedBadge(badges[i] ?? '');
         SendMessageComposer(composer);
@@ -93,16 +91,14 @@ const useInventoryBadgesState = () =>
             return newValue;
         });
 
-        // Skip overwriting activeBadgeCodes if we have pending local changes
-        if(pendingUpdatesRef.current > 0)
-        {
-            pendingUpdatesRef.current--;
-        }
-        else
-        {
-            const serverBadges = parser.getActiveBadgeCodes();
-            setActiveBadgeCodes(toFixedSlots(serverBadges));
-        }
+        // The emulator answers SetActivatedBadges (UserWearBadgeEvent) with a
+        // UserBadgesComposer room broadcast, NOT a BadgesEvent — so there is no
+        // echo to suppress and the old pendingUpdatesRef counter only ever
+        // leaked (incremented on every edit, never decremented), which then
+        // silently dropped legitimate later BadgesEvent updates. The server is
+        // authoritative here (edits are already persisted), so always apply it.
+        const serverBadges = parser.getActiveBadgeCodes();
+        setActiveBadgeCodes(toFixedSlots(serverBadges));
 
         setBadgeCodes(allBadgeCodes);
     });

--- a/src/hooks/inventory/useInventoryPrefixes.ts
+++ b/src/hooks/inventory/useInventoryPrefixes.ts
@@ -78,25 +78,29 @@ const useInventoryPrefixesState = () =>
 
         setPrefixes(prevValue =>
         {
-            return prevValue.map(p => ({
+            const next = prevValue.map(p => ({
                 ...p,
                 active: p.id === parser.prefixId
             }));
-        });
 
-        if(parser.prefixId === 0)
-        {
-            setActivePrefix(null);
-        }
-        else
-        {
-            setActivePrefix(prev =>
+            // Derive the active prefix from the freshly-mapped list, not from
+            // the `prefixes` closure (which lags a render and is stale when the
+            // prefix was added earlier in the same event batch).
+            if(parser.prefixId === 0)
             {
-                const found = prefixes.find(p => p.id === parser.prefixId);
-                if(found) return { ...found, active: true, font: parser.font || found.font || '' };
-                return { id: parser.prefixId, text: parser.text, color: parser.color, icon: parser.icon || '', effect: parser.effect || '', font: parser.font || '', active: true };
-            });
-        }
+                setActivePrefix(null);
+            }
+            else
+            {
+                const found = next.find(p => p.id === parser.prefixId);
+
+                setActivePrefix(found
+                    ? { ...found, active: true, font: parser.font || found.font || '' }
+                    : { id: parser.prefixId, text: parser.text, color: parser.color, icon: parser.icon || '', effect: parser.effect || '', font: parser.font || '', active: true });
+            }
+
+            return next;
+        });
     });
 
     const activatePrefix = (prefixId: number) =>

--- a/src/hooks/inventory/useInventoryUnseenTracker.ts
+++ b/src/hooks/inventory/useInventoryUnseenTracker.ts
@@ -63,7 +63,10 @@ const useInventoryUnseenTrackerState = () =>
             const newValue = new Map(prevValue);
             const existing = newValue.get(category);
 
-            if(existing) for(const itemId of itemIds) existing.splice(existing.indexOf(itemId), 1);
+            // Replace the per-category array instead of splicing the one still
+            // referenced by the previous Map, and filter (an absent id used to
+            // splice(indexOf=-1) and drop the wrong last element).
+            if(existing) newValue.set(category, existing.filter(id => !itemIds.includes(id)));
 
             sendResetItemsMessage(category, itemIds);
 
@@ -90,9 +93,9 @@ const useInventoryUnseenTrackerState = () =>
 
             const newValue = new Map(prevValue);
             const items = newValue.get(category);
-            const index = items.indexOf(itemId);
 
-            if(index >= 0) items.splice(index, 1);
+            // Clone the array rather than splicing the one shared with prevValue.
+            if(items && items.indexOf(itemId) >= 0) newValue.set(category, items.filter(id => id !== itemId));
 
             return newValue;
         });
@@ -108,18 +111,15 @@ const useInventoryUnseenTrackerState = () =>
 
             for(const category of parser.categories)
             {
-                let existing = newValue.get(category);
-
-                if(!existing)
-                {
-                    existing = [];
-
-                    newValue.set(category, existing);
-                }
+                // Clone the existing array so we never push into the one still
+                // referenced by the previous (shallow-copied) Map.
+                const merged = [ ...(newValue.get(category) ?? []) ];
 
                 const itemIds = parser.getItemsByCategory(category);
 
-                for(const itemId of itemIds) ((existing.indexOf(itemId) === -1) && existing.push(itemId));
+                for(const itemId of itemIds) if(merged.indexOf(itemId) === -1) merged.push(itemId);
+
+                newValue.set(category, merged);
             }
 
             return newValue;

--- a/src/hooks/mod-tools/useModTools.ts
+++ b/src/hooks/mod-tools/useModTools.ts
@@ -183,8 +183,8 @@ const useModToolsState = () =>
     {
         const parser = event.getParser();
 
-        if(parser.success) simpleAlert('Moderation action was successfull', NotificationAlertType.MODERATION, null, null, 'Success');
-        else simpleAlert('There was a problem applying tht moderation action', NotificationAlertType.MODERATION, null, null, 'Error');
+        if(parser.success) simpleAlert('Moderation action was successful', NotificationAlertType.MODERATION, null, null, 'Success');
+        else simpleAlert('There was a problem applying the moderation action', NotificationAlertType.MODERATION, null, null, 'Error');
     });
 
     useMessageEvent<CfhTopicsInitEvent>(CfhTopicsInitEvent, event =>

--- a/src/hooks/purse/usePurse.ts
+++ b/src/hooks/purse/usePurse.ts
@@ -13,7 +13,7 @@ const usePurseState = () =>
     {
         if(hcDisabled || (purse.clubDays > 0)) return ClubStatus.ACTIVE;
 
-        if((purse.pastVipDays > 0) || (purse.pastVipDays > 0)) return ClubStatus.EXPIRED;
+        if((purse.pastClubDays > 0) || (purse.pastVipDays > 0)) return ClubStatus.EXPIRED;
 
         return ClubStatus.NONE;
     }, [ purse, hcDisabled ]);

--- a/src/hooks/rooms/widgets/useAvatarInfoWidget.ts
+++ b/src/hooks/rooms/widgets/useAvatarInfoWidget.ts
@@ -361,7 +361,7 @@ const useAvatarInfoWidgetState = () =>
         {
             let index = nameBubbles.findIndex(bubble => (bubble.roomIndex === event.id));
 
-            if(index > -1) setNameBubbles(prevValue => prevValue.filter(bubble => (bubble.roomIndex === event.id)));
+            if(index > -1) setNameBubbles(prevValue => prevValue.filter(bubble => (bubble.roomIndex !== event.id)));
 
             index = productBubbles.findIndex(bubble => (bubble.id === event.id));
 

--- a/src/hooks/rooms/widgets/useChatWidget.ts
+++ b/src/hooks/rooms/widgets/useChatWidget.ts
@@ -148,7 +148,7 @@ const useChatWidgetState = () =>
 
                 if(chatType === RoomSessionChatEvent.CHAT_TYPE_PET_REBREED_FERTILIZE)
                 {
-                    textKey = 'widget.chatbubble.petrefertilized;';
+                    textKey = 'widget.chatbubble.petrefertilized';
                 }
 
                 else if(chatType === RoomSessionChatEvent.CHAT_TYPE_PET_SPEED_FERTILIZE)
@@ -162,7 +162,7 @@ const useChatWidgetState = () =>
 
                 if(newRoomObject)
                 {
-                    const newUserData = roomSession.userDataManager.getUserDataByIndex(roomObject.id);
+                    const newUserData = roomSession.userDataManager.getUserDataByIndex(newRoomObject.id);
 
                     if(newUserData) targetUserName = newUserData.name;
                 }

--- a/src/hooks/rooms/widgets/useWordQuizWidget.ts
+++ b/src/hooks/rooms/widgets/useWordQuizWidget.ts
@@ -112,19 +112,21 @@ const useWordQuizWidgetState = () =>
         {
             setUserAnswers(prevValue =>
             {
-                const keysToRemove: number[] = [];
+                if(prevValue.size === 0) return prevValue;
 
-                prevValue.forEach((value, key) =>
+                // Build new value objects + a new Map — don't decrement
+                // secondsLeft on the objects still referenced by prevValue
+                // (in-place mutation breaks memoization / StrictMode replay).
+                const next = new Map(prevValue);
+
+                next.forEach((value, key) =>
                 {
-                    value.secondsLeft--;
+                    const secondsLeft = value.secondsLeft - 1;
 
-                    if(value.secondsLeft <= 0) keysToRemove.push(key);
+                    if(secondsLeft <= 0) next.delete(key);
+                    else next.set(key, { ...value, secondsLeft });
                 });
 
-                if(keysToRemove.length === 0) return prevValue;
-
-                const next = new Map(prevValue);
-                keysToRemove.forEach(key => next.delete(key));
                 return next;
             });
         };


### PR DESCRIPTION
Client-side logic bugs found during the ui↔renderer audit — the kind a TypeScript compiler doesn't catch. Independent of the renderer-side PR. **Draft on purpose.** All verified: `tsgo` clean, `vitest` **545/545**, `lint:hooks` clean.

### Inventory
- 🔴 Unseen-tracker mutates shared state arrays in place + `splice(indexOf=-1)` (`useInventoryUnseenTracker`).
- 🔴 Badge active-set pending-counter leaks → drops later server updates (`useInventoryBadges`).
- 🟠 Active prefix derived from a stale closure (`useInventoryPrefixes`).

### Room widgets
- 🔴 Name bubbles cleared for the wrong user on `USER_REMOVED` — inverted filter (`useAvatarInfoWidget`).
- 🟡 Pet-fertilize chat: stray `;` in loc key + wrong target user (`useChatWidget`).
- 🟡 Word-quiz countdown mutates Map value objects in place (`useWordQuizWidget`).
- 🟡 Thread marked read during render (`FriendsMessengerThreadView`).

### Wired
- 🔴 `@altitude` shown 100× too large & round-trip-edited wrong (`WiredCreatorToolsView`).
- 🟠 Date-range condition saved `NaN` for empty/invalid dates (`WiredConditionDateRangeView`) — `new Date('garbage')` is a truthy Invalid Date; guard on `isNaN(getTime())` + seed inputs.

### Mod-tools
- 🔴 Default-sanction sent the topic array index, not `topics[i].id` → wrong CFH topic (`ModToolsUserModActionView`).
- 🟡 Typos in moderation result alerts (`useModTools`).

### Camera
- 🔴 Selected picture index not reset after delete (`CameraWidgetView`).
- 🟠 Full roll discarded the newest photo (`clone.pop()`) (`CameraWidgetCaptureView`).

### Groups
- 🟠 Colour-picker highlight read `groupData` (only written on save) instead of live `colors` (`GroupTabColorsView`).

### Purse / HC
- 🔴 HC status never reports EXPIRED for ex-Club (non-VIP) users — `(pastVipDays > 0) || (pastVipDays > 0)`, the first should be `pastClubDays` (`usePurse`).

### Marketplace
- 🟠 `creditsWaiting` not reset after redeeming sold offers → stale "get 0 sold items" panel (`CatalogLayoutMarketplaceOwnItemsView`).
- 🟠 Re-priced offer vanished when the server kept the same id — `set()` then unconditional `delete()` (`CatalogLayoutMarketplacePublicItemsView`).
