### PR TITLE
fix(messenger): mark thread read in an effect, not during render

### DIFF
--- a/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadView.tsx
+++ b/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadView.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { MessengerThread } from '../../../../../api';
 import { FriendsMessengerThreadGroup } from './FriendsMessengerThreadGroup';
 
@@ -6,7 +6,15 @@ export const FriendsMessengerThreadView: FC<{ thread: MessengerThread }> = props
 {
     const { thread = null } = props;
 
-    thread.setRead();
+    // Mark the thread read after commit, not during render — render must stay
+    // side-effect free. No dep array: faithfully re-marks on every re-render
+    // (e.g. a new message arriving in the active thread), same as before.
+    useEffect(() =>
+    {
+        if(thread) thread.setRead();
+    });
+
+    if(!thread) return null;
 
     return (
         <>


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(messenger): mark thread read in an effect, not during render

> Draft.
