### PR TITLE
fix(room): name-bubble, pet-fertilize chat & word-quiz bugs

### DIFF
--- a/src/hooks/rooms/widgets/useAvatarInfoWidget.ts
+++ b/src/hooks/rooms/widgets/useAvatarInfoWidget.ts
@@ -361,7 +361,7 @@ const useAvatarInfoWidgetState = () =>
         {
             let index = nameBubbles.findIndex(bubble => (bubble.roomIndex === event.id));
 
-            if(index > -1) setNameBubbles(prevValue => prevValue.filter(bubble => (bubble.roomIndex === event.id)));
+            if(index > -1) setNameBubbles(prevValue => prevValue.filter(bubble => (bubble.roomIndex !== event.id)));
 
             index = productBubbles.findIndex(bubble => (bubble.id === event.id));
 

--- a/src/hooks/rooms/widgets/useChatWidget.ts
+++ b/src/hooks/rooms/widgets/useChatWidget.ts
@@ -148,7 +148,7 @@ const useChatWidgetState = () =>
 
                 if(chatType === RoomSessionChatEvent.CHAT_TYPE_PET_REBREED_FERTILIZE)
                 {
-                    textKey = 'widget.chatbubble.petrefertilized;';
+                    textKey = 'widget.chatbubble.petrefertilized';
                 }
 
                 else if(chatType === RoomSessionChatEvent.CHAT_TYPE_PET_SPEED_FERTILIZE)
@@ -162,7 +162,7 @@ const useChatWidgetState = () =>
 
                 if(newRoomObject)
                 {
-                    const newUserData = roomSession.userDataManager.getUserDataByIndex(roomObject.id);
+                    const newUserData = roomSession.userDataManager.getUserDataByIndex(newRoomObject.id);
 
                     if(newUserData) targetUserName = newUserData.name;
                 }

--- a/src/hooks/rooms/widgets/useWordQuizWidget.ts
+++ b/src/hooks/rooms/widgets/useWordQuizWidget.ts
@@ -112,19 +112,21 @@ const useWordQuizWidgetState = () =>
         {
             setUserAnswers(prevValue =>
             {
-                const keysToRemove: number[] = [];
+                if(prevValue.size === 0) return prevValue;
 
-                prevValue.forEach((value, key) =>
+                // Build new value objects + a new Map — don't decrement
+                // secondsLeft on the objects still referenced by prevValue
+                // (in-place mutation breaks memoization / StrictMode replay).
+                const next = new Map(prevValue);
+
+                next.forEach((value, key) =>
                 {
-                    value.secondsLeft--;
+                    const secondsLeft = value.secondsLeft - 1;
 
-                    if(value.secondsLeft <= 0) keysToRemove.push(key);
+                    if(secondsLeft <= 0) next.delete(key);
+                    else next.set(key, { ...value, secondsLeft });
                 });
 
-                if(keysToRemove.length === 0) return prevValue;
-
-                const next = new Map(prevValue);
-                keysToRemove.forEach(key => next.delete(key));
                 return next;
             });
         };


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(room): name bubbles cleared for the wrong user on USER_REMOVED
- fix(room): pet-fertilize chat bubble — bad localization key + wrong target user
- fix(room): word-quiz countdown mutates Map value objects in place

> Draft.
