### PR TITLE
fix(wired): @altitude scale & date-range NaN

### DIFF
--- a/src/components/wired-tools/WiredCreatorToolsView.tsx
+++ b/src/components/wired-tools/WiredCreatorToolsView.tsx
@@ -1181,7 +1181,7 @@ export const WiredCreatorToolsView: FC<{}> = () =>
             { key: '@position_x', value: String(liveState?.positionX ?? 0), editable: canEditInspection },
             { key: '@position_y', value: String(liveState?.positionY ?? 0), editable: canEditInspection },
             { key: '@rotation', value: String(liveState?.rotation ?? 0), editable: canEditInspection },
-            { key: '@altitude', value: String(Math.round((liveState?.altitude ?? 0) * 100)), editable: canEditInspection },
+            { key: '@altitude', value: String(liveState?.altitude ?? 0), editable: canEditInspection },
             { key: '@is_invisible', value: '0' },
             ...(wallItemOffset ? [ { key: '@wallitem_offset', value: wallItemOffset, editable: canEditInspection } ] : []),
             { key: '@type', value: `${ selectedFurnitureData?.availableForBuildersClub ? 1 : 0 }${ selectedFurnitureData?.availableForBuildersClub ? ' (BC)' : ' (Normal)' }` },
@@ -1294,7 +1294,7 @@ export const WiredCreatorToolsView: FC<{}> = () =>
             { key: '@position_x', value: String(liveState?.positionX ?? 0), editable: canEditSelectedUser },
             { key: '@position_y', value: String(liveState?.positionY ?? 0), editable: canEditSelectedUser },
             { key: '@direction', value: String(liveState?.direction ?? 0), editable: canEditSelectedUser },
-            { key: '@altitude', value: String(Math.round((liveState?.altitude ?? 0) * 100)) },
+            { key: '@altitude', value: String(liveState?.altitude ?? 0) },
             ...((Number(selectedUser.favouriteGroupId ?? 0) > 0)
                 ? [ { key: '@favourite_group_id', value: String(selectedUser.favouriteGroupId) } ]
                 : []),

--- a/src/components/wired/views/conditions/WiredConditionDateRangeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionDateRangeView.tsx
@@ -13,35 +13,34 @@ export const WiredConditionDateRangeView: FC<{}> = props =>
 
     const save = () =>
     {
-        let startDateMili = 0;
-        let endDateMili = 0;
-
         const startDateInstance = new Date(startDate);
         const endDateInstance = new Date(endDate);
 
-        if(startDateInstance && endDateInstance)
-        {
-            startDateMili = startDateInstance.getTime() / 1000;
-            endDateMili = endDateInstance.getTime() / 1000;
-        }
+        // new Date('garbage') is a truthy *Invalid Date*, not null — the old
+        // `if(startDateInstance && endDateInstance)` was always true, so an
+        // unparseable input wrote NaN as the int param. Guard on getTime().
+        const startDateMili = isNaN(startDateInstance.getTime()) ? 0 : Math.floor(startDateInstance.getTime() / 1000);
+        const endDateMili = isNaN(endDateInstance.getTime()) ? 0 : Math.floor(endDateInstance.getTime() / 1000);
 
         setIntParams([ startDateMili, endDateMili ]);
     };
 
     useEffect(() =>
     {
+        // Seed both inputs (default "now") even for a never-configured furni so
+        // the first save can't send new Date('') → NaN.
+        let startDate = new Date();
+        let endDate = new Date();
+
         if(trigger.intData.length >= 2)
         {
-            let startDate = new Date();
-            let endDate = new Date();
-
             if(trigger.intData[0] > 0) startDate = new Date((trigger.intData[0] * 1000));
 
             if(trigger.intData[1] > 0) endDate = new Date((trigger.intData[1] * 1000));
-
-            setStartDate(WiredDateToString(startDate));
-            setEndDate(WiredDateToString(endDate));
         }
+
+        setStartDate(WiredDateToString(startDate));
+        setEndDate(WiredDateToString(endDate));
     }, [ trigger ]);
 
     return (


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(wired): @altitude shown 100x too large and round-trip-edited wrong
- fix(wired): date-range condition saved NaN for empty/invalid dates

> Draft.
