### PR TITLE
fix(mod-tools): default-sanction topic id & alert typos

### DIFF
--- a/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
@@ -75,14 +75,16 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = pro
     {
         if(isSendingRef.current) return;
 
+        if(selectedTopic === -1) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
+
         const category = topics[selectedTopic];
 
-        if(selectedTopic === -1) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
+        if(!category) return sendAlert(LocalizeText('modtools.user.modaction.error.no.topic'));
 
         const messageOrDefault = (message.trim().length === 0) ? LocalizeText(`help.cfh.topic.${ category.id }`) : message;
 
         isSendingRef.current = true;
-        SendMessageComposer(new DefaultSanctionMessageComposer(user.userId, selectedTopic, messageOrDefault));
+        SendMessageComposer(new DefaultSanctionMessageComposer(user.userId, category.id, messageOrDefault));
         onCloseClick();
     };
 

--- a/src/hooks/mod-tools/useModTools.ts
+++ b/src/hooks/mod-tools/useModTools.ts
@@ -183,8 +183,8 @@ const useModToolsState = () =>
     {
         const parser = event.getParser();
 
-        if(parser.success) simpleAlert('Moderation action was successfull', NotificationAlertType.MODERATION, null, null, 'Success');
-        else simpleAlert('There was a problem applying tht moderation action', NotificationAlertType.MODERATION, null, null, 'Error');
+        if(parser.success) simpleAlert('Moderation action was successful', NotificationAlertType.MODERATION, null, null, 'Success');
+        else simpleAlert('There was a problem applying the moderation action', NotificationAlertType.MODERATION, null, null, 'Error');
     });
 
     useMessageEvent<CfhTopicsInitEvent>(CfhTopicsInitEvent, event =>


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(mod-tools): default-sanction sent the topic array index, not the topic id
- fix(mod-tools): typos in moderation-action result alerts

> Draft.
