### PR TITLE
fix(purse): HC status EXPIRED for ex-Club non-VIP users

### DIFF
--- a/src/hooks/purse/usePurse.ts
+++ b/src/hooks/purse/usePurse.ts
@@ -13,7 +13,7 @@ const usePurseState = () =>
     {
         if(hcDisabled || (purse.clubDays > 0)) return ClubStatus.ACTIVE;
 
-        if((purse.pastVipDays > 0) || (purse.pastVipDays > 0)) return ClubStatus.EXPIRED;
+        if((purse.pastClubDays > 0) || (purse.pastVipDays > 0)) return ClubStatus.EXPIRED;
 
         return ClubStatus.NONE;
     }, [ purse, hcDisabled ]);


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(purse): HC status never reports EXPIRED for ex-Club (non-VIP) users

> Draft.
