### PR TITLE
fix(marketplace): creditsWaiting reset & re-priced offer vanish

### DIFF
--- a/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplaceOwnItemsView.tsx
+++ b/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplaceOwnItemsView.tsx
@@ -67,6 +67,10 @@ export const CatalogLayoutMarketplaceOwnItemsView: FC<CatalogLayoutProps> = prop
             return prevValue.filter(value => (idsToDelete.indexOf(value.offerId) === -1));
         });
 
+        // Without this the redeem panel stays visible (creditsWaiting > 0) after
+        // the sold offers are optimistically removed, showing "get 0 sold items".
+        setCreditsWaiting(0);
+
         SendMessageComposer(new RedeemMarketplaceOfferCreditsMessageComposer());
 
         setTimeout(() => isRedeemingRef.current = false, 3000);

--- a/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplacePublicItemsView.tsx
+++ b/src/components/catalog/views/page/layout/marketplace/CatalogLayoutMarketplacePublicItemsView.tsx
@@ -115,13 +115,18 @@ export const CatalogLayoutMarketplacePublicItemsView: FC<CatalogLayoutMarketplac
                     const item = newVal.get(parser.requestedOfferId);
                     if(item)
                     {
+                        // Delete the OLD key first, then set under the (possibly
+                        // unchanged) new id. The old code did set()-then-delete(),
+                        // so when the server returned the same id for the re-priced
+                        // offer the set was immediately undone and the offer vanished.
+                        newVal.delete(parser.requestedOfferId);
+
                         item.offerId = parser.offerId;
                         item.price = parser.newPrice;
                         item.offerCount--;
                         newVal.set(item.offerId, item);
                     }
 
-                    newVal.delete(parser.requestedOfferId);
                     return newVal;
                 });
 


### PR DESCRIPTION
Split from #236 — one PR per area. Logic bugs from the ui↔renderer audit (TypeScript-clean; vitest 545/545; lint:hooks clean).

- fix(marketplace): reset creditsWaiting after redeeming sold offers
- fix(marketplace): re-priced offer vanished when the server kept the same id

> Draft.
