### PR TITLE
Restore client release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  NITRO_SINGLE_BUNDLE: '1'
   NITRO_JSON_MODE: 'legacy'
 
 jobs:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,82 @@
+name: Build & Publish Client Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  NITRO_JSON_MODE: 'legacy'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout client
+        uses: actions/checkout@v4
+        with:
+          path: Nitro-V3
+
+      - name: Checkout renderer
+        uses: actions/checkout@v4
+        with:
+          repository: duckethotel/ducket-render
+          ref: main
+          path: Nitro_Render_V3
+          token: ${{ secrets.DUCKET_REPO_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: yarn
+          cache-dependency-path: |
+            Nitro-V3/yarn.lock
+            Nitro_Render_V3/yarn.lock
+
+      - name: Install renderer dependencies
+        working-directory: Nitro_Render_V3
+        run: yarn install --frozen-lockfile
+
+      - name: Link renderer
+        working-directory: Nitro_Render_V3
+        run: yarn link
+
+      - name: Install client dependencies
+        working-directory: Nitro-V3
+        run: yarn install --frozen-lockfile
+
+      - name: Link renderer into client
+        working-directory: Nitro-V3
+        run: yarn link "@nitrots/nitro-renderer"
+
+      - name: Build client
+        working-directory: Nitro-V3
+        run: yarn build
+
+      - name: Read package version
+        id: version
+        working-directory: Nitro-V3
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=${GITHUB_SHA::7}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Package dist
+        working-directory: Nitro-V3
+        run: |
+          zip -r "../ducket-client-dist-${{ steps.version.outputs.short_sha }}.zip" dist
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: client-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}
+          name: Ducket Client ${{ steps.version.outputs.version }} (${{ steps.version.outputs.short_sha }})
+          generate_release_notes: true
+          files: ducket-client-dist-${{ steps.version.outputs.short_sha }}.zip

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -93,7 +93,9 @@ const resolveJsonMode = () =>
 };
 
 const nitroJsonMode = resolveJsonMode();
+const nitroSingleBundle = process.env.NITRO_SINGLE_BUNDLE === '1';
 process.stdout.write(`[vite] __NITRO_JSON_MODE__ = ${ nitroJsonMode }\n`);
+process.stdout.write(`[vite] NITRO_SINGLE_BUNDLE = ${ nitroSingleBundle ? '1' : '0' }\n`);
 
 export default defineConfig({
     base: process.env.VITE_BASE || './',
@@ -165,7 +167,11 @@ export default defineConfig({
             checks: {
                 pluginTimings: false
             },
-            output: {
+            output: nitroSingleBundle ? {
+                assetFileNames: 'src/assets/[name]-[hash].[ext]',
+                entryFileNames: 'assets/app.js',
+                inlineDynamicImports: true
+            } : {
                 assetFileNames: 'src/assets/[name]-[hash].[ext]',
                 // Granular chunking: split the monolithic vendor / nitro-renderer
                 // bundles into smaller chunks so the browser can fetch them in


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the client with the linked renderer and publishes the dist folder as a release asset on pushes to main or manual dispatch.