### PR TITLE
chore(deps): bump dompurify to 3.4.11 (fixes low-severity audit advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@tanstack/react-query": "5",
         "@tanstack/react-query-devtools": "5",
         "@tanstack/react-virtual": "^3.14.2",
-        "dompurify": "^3.4.8",
+        "dompurify": "^3.4.10",
         "emoji-mart": "^5.6.0",
         "emoji-toolkit": "10.0.0",
         "framer-motion": "^12.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,10 +2156,10 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
-dompurify@^3.4.8:
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
-  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
+dompurify@^3.4.10:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
`yarn audit` flags `dompurify@3.4.8` (npm advisory **1120805** — a Trusted Types policy survives `clearConfig()` and can poison later `RETURN_TRUSTED_TYPE` output; patched in `>=3.4.9`). Severity is **low**, and our usage (`SanitizeHtml`) doesn't touch `clearConfig`/Trusted Types, so it's not believed exploitable here — but dompurify is the library behind the client's XSS defence, so it's worth keeping current.

## Change
- `dompurify` `^3.4.8` → `^3.4.10` (resolves to **3.4.11**); lockfile updated.

## Verification
- `yarn audit` — **0 vulnerabilities** (was 1 low)
- `yarn typecheck` — 0 errors
- `yarn test` — green