### PR TITLE
fix(youtube): interpolate videoId in the share-to-X tweet text

### DIFF
--- a/src/components/toolbar/YouTubePlayerView.tsx
+++ b/src/components/toolbar/YouTubePlayerView.tsx
@@ -637,7 +637,7 @@ export const YouTubePlayerView: FC<{}> = () =>
                                         if (videoId)
                                         {
                                             const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                                                'Now watching: https://youtube.com/watch?v=${videoId}',
+                                                `Now watching: https://youtube.com/watch?v=${videoId}`,
                                             )}`;
                                             window.open(url, '_blank');
                                         }


### PR DESCRIPTION
The YouTube widget's share-to-X button built the tweet text from a **single-quoted** string containing `${videoId}`, so it shared the literal `watch?v=${videoId}` instead of the actual video URL. Switched the inner string to a template literal so `videoId` interpolates.

One-line correctness fix. `yarn typecheck` 0.

(Two nearby TODOs were reviewed and left as-is: `CatalogLayoutRoomAdsView` "fix this for morningstar" is an emulator-behaviour unknown, and `useNotification`'s commented-out `event.connection.dispose()` ("fix dispose") was disabled deliberately — neither is a safe mechanical fix.)