### PR TITLE
Implement PurseView UI with actions and menu

### DIFF
--- a/src/components/purse/PurseView.tsx
+++ b/src/components/purse/PurseView.tsx
@@ -1,7 +1,153 @@
-import { FC } from 'react';
-import { PurseModernView } from './PurseModernView';
+import { CreateLinkEvent } from '@nitrots/nitro-renderer';
+import { FC, useCallback, useMemo, useState } from 'react';
+import { FaChartBar, FaCog, FaLanguage, FaSignOutAlt } from 'react-icons/fa';
+import { ClearRememberLogin, GetConfigurationValue, GetRememberLogin, localizeWithFallback, LocalizeText } from '../../api';
+import { Column, LayoutCurrencyIcon } from '../../common';
+import { usePurse } from '../../hooks';
+import { CurrencyView } from './views/CurrencyView';
+import { SeasonalView } from './views/SeasonalView';
 
 export const PurseView: FC<{}> = props =>
 {
-    return <PurseModernView />;
+    const { purse = null, hcDisabled = false } = usePurse();
+    const [ settingsMenuOpen, setSettingsMenuOpen ] = useState(false);
+
+    const openSettingsSection = useCallback((section: string) =>
+    {
+        CreateLinkEvent('user-settings/show/' + section);
+        setSettingsMenuOpen(false);
+    }, []);
+
+    const displayedCurrencies = useMemo(() => GetConfigurationValue<number[]>('system.currency.types', []), []);
+    const currencyDisplayNumberShort = useMemo(() => GetConfigurationValue<boolean>('currency.display.number.short', false), []);
+
+    const currencyTypes = useMemo(() =>
+    {
+        if (!purse || !purse.activityPoints || !purse.activityPoints.size) return [];
+
+        const types = Array.from(purse.activityPoints.keys()).filter(type => (displayedCurrencies.indexOf(type) >= 0));
+        types.sort((a, b) =>
+        {
+            if (a === 0) return -1;
+            if (b === 0) return 1;
+            if (a === 5) return -1;
+            if (b === 5) return 1;
+            return a - b;
+        });
+
+        return types;
+    }, [ displayedCurrencies, purse ]);
+
+    const hasDiamonds = currencyTypes.indexOf(5) >= 0;
+    const hasDuckets = currencyTypes.indexOf(0) >= 0;
+    const otherCurrencies = currencyTypes.filter(type => (type !== 0 && type !== 5));
+
+    const joinLabel = useMemo(() => localizeWithFallback('purse.join', 'Join'), []);
+    const earningsLabel = useMemo(() => localizeWithFallback('earnings.title', 'Earnings'), []);
+    const helpLabel = useMemo(() => localizeWithFallback('help.button.name', 'Help'), []);
+
+    const openClub = useCallback((event: React.MouseEvent) =>
+    {
+        event.stopPropagation();
+        CreateLinkEvent('habboUI/open/hccenter');
+    }, []);
+
+    const openEarnings = useCallback((event: React.MouseEvent) =>
+    {
+        event.stopPropagation();
+        CreateLinkEvent('habboUI/open/vault');
+    }, []);
+
+    const handleLogout = useCallback(async (event: React.MouseEvent) =>
+    {
+        event.stopPropagation();
+
+        const logoutUrl = GetConfigurationValue<string>('login.logout.endpoint', '/api/auth/logout');
+        const ssoTicket = (window.NitroConfig?.['sso.ticket'] as string) ?? '';
+        const rememberToken = GetRememberLogin()?.token || '';
+
+        try
+        {
+            await fetch(logoutUrl, {
+                method: 'POST',
+                credentials: 'include',
+                keepalive: true,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'NitroPurseLogout'
+                },
+                body: JSON.stringify({ ssoTicket, rememberToken })
+            });
+        }
+        catch
+        { /* best-effort — proceed with local logout regardless */ }
+
+        ClearRememberLogin();
+        if(window.NitroConfig) window.NitroConfig['sso.ticket'] = '';
+        window.location.reload();
+    }, []);
+
+    if (!purse) return null;
+
+    return (
+        <Column alignItems="end" className="nitro-purse-container" gap={ 0 }>
+            <div className="nitro-purse">
+                <div className="nitro-purse__body">
+                    <div className="nitro-purse__currencies">
+                        { hasDiamonds && <CurrencyView type={ 5 } amount={ purse.activityPoints.get(5) || 0 } short={ currencyDisplayNumberShort } /> }
+                        <CurrencyView type={ -1 } amount={ purse.credits } short={ currencyDisplayNumberShort } />
+                        { hasDuckets && <CurrencyView type={ 0 } amount={ purse.activityPoints.get(0) || 0 } short={ currencyDisplayNumberShort } /> }
+                    </div>
+                    <div className="nitro-purse__col nitro-purse__col--primary">
+                        { !hcDisabled &&
+                            <button type="button" className="nitro-purse__btn nitro-purse__btn--join" onClick={ openClub } title={ joinLabel }>
+                                <LayoutCurrencyIcon type="hc" />
+                                <span>{ joinLabel }</span>
+                            </button> }
+                        <button type="button" className="nitro-purse__btn nitro-purse__btn--earnings" onClick={ openEarnings } title={ earningsLabel }>
+                            <FaChartBar className="nitro-purse__btn-icon" />
+                            <span>{ earningsLabel }</span>
+                        </button>
+                    </div>
+                    <div className="nitro-purse__col nitro-purse__col--actions">
+                        <button type="button" className="nitro-purse__btn nitro-purse__btn--help" onClick={ event =>
+                        {
+                            event.stopPropagation(); CreateLinkEvent('help/show');
+                        } } title={ helpLabel }>
+                            <span>{ helpLabel }</span>
+                        </button>
+                        <button type="button" className="nitro-purse__btn nitro-purse__btn--icon nitro-purse__btn--translate" onClick={ event =>
+                        {
+                            event.stopPropagation(); CreateLinkEvent('translation-settings/toggle');
+                        } } title="Google Translate">
+                            <FaLanguage />
+                        </button>
+                        <button type="button" className="nitro-purse__btn nitro-purse__btn--icon nitro-purse__btn--logout" onClick={ handleLogout } title="Log out">
+                            <FaSignOutAlt />
+                        </button>
+                        <button type="button" className="nitro-purse__btn nitro-purse__btn--icon nitro-purse__btn--settings" onClick={ event =>
+                        {
+                            event.stopPropagation(); setSettingsMenuOpen(value => !value);
+                        } } title={ LocalizeText('widget.memenu.settings.title') }>
+                            <FaCog />
+                        </button>
+                    </div>
+                </div>
+            </div>
+            { settingsMenuOpen &&
+                <div className="nitro-purse-menu">
+                    <button type="button" className="nitro-purse-menu__item" onClick={ () => openSettingsSection('audio') }>Impostazioni Audio</button>
+                    <button type="button" className="nitro-purse-menu__item nitro-purse-menu__item--disabled" disabled>Impostazioni Discord</button>
+                    <button type="button" className="nitro-purse-menu__item" onClick={ () => openSettingsSection('chat') }>Impostazioni Chat</button>
+                    <button type="button" className="nitro-purse-menu__item" onClick={ () => openSettingsSection('other') }>Altre Impostazioni</button>
+                    <button type="button" className="nitro-purse-menu__item" onClick={ () => { CreateLinkEvent('user-account-settings/show'); setSettingsMenuOpen(false); } }>Gestione Account</button>
+                    <button type="button" className="nitro-purse-menu__item nitro-purse-menu__item--disabled" disabled>Filtro Parole</button>
+                </div> }
+            { otherCurrencies.length > 0 &&
+                <div className="nitro-purse__other">
+                    { otherCurrencies.map(type => <SeasonalView key={ type } type={ type } amount={ purse.activityPoints.get(type) || 0 } />) }
+                </div> }
+        </Column>
+    );
 };

--- a/src/css/purse/PurseView.css
+++ b/src/css/purse/PurseView.css
@@ -121,18 +121,23 @@
 }
 
 .nitro-purse__btn--join {
-    border-color: rgba(255, 255, 255, 0.1);
-    background: #33312c;
+    border-color: #4f7a22;
+    background: linear-gradient(180deg, #72b03a 0%, #5a8c2a 100%);
 }
 
 .nitro-purse__btn--earnings {
-    border-color: rgba(255, 255, 255, 0.1);
-    background: #33312c;
+    border-color: #4f7a22;
+    background: linear-gradient(180deg, #72b03a 0%, #5a8c2a 100%);
 }
 
 .nitro-purse__btn--help {
     border-color: #14526b;
     background: linear-gradient(180deg, #2790b6 0%, #1e7295 100%);
+}
+
+.nitro-purse__btn--translate {
+    border-color: #3d6e91;
+    background: linear-gradient(180deg, #4a8bb8 0%, #3d6e91 100%);
 }
 
 .nitro-purse__btn--logout {
@@ -228,6 +233,46 @@
     width: auto;
     height: 14px;
     object-fit: contain;
+}
+
+/* ---- Settings dropdown (gear menu) ---- */
+.nitro-purse-menu {
+    width: 100%;
+    max-width: 234px;
+    margin-top: 4px;
+    margin-left: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 2px solid #41403c;
+    border-radius: 8px;
+    background: rgba(10, 10, 12, 0.92);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+    pointer-events: all;
+}
+
+.nitro-purse-menu__item {
+    padding: 2px 10px;
+    text-align: left;
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: rgba(255, 255, 255, 0.9);
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    transition: background 0.12s ease;
+}
+
+.nitro-purse-menu__item:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.nitro-purse-menu__item--disabled,
+.nitro-purse-menu__item--disabled:hover {
+    color: rgba(255, 255, 255, 0.35);
+    background: transparent;
+    cursor: default;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Replace simple PurseModernView with a full PurseView component: integrates usePurse, displays credits/activity currencies (ordered with priority for diamonds/duckets), reads config for displayed currency types and short-number formatting, and uses CurrencyView/SeasonalView. Adds action buttons (Join HC, Earnings, Help, Translate, Logout, Settings) with icons and handlers (including a POST logout attempt and local cleanup). Introduces a settings dropdown with quick links to settings sections. Update PurseView CSS: new button gradients (join/earnings/translate), translate button styles, and styles for the settings dropdown and disabled items.