### PR TITLE
fix(badge): uniform rarity frame size + even infostand spacing

### DIFF
--- a/src/common/layout/LayoutBadgeImageView.tsx
+++ b/src/common/layout/LayoutBadgeImageView.tsx
@@ -68,31 +68,44 @@ export const LayoutBadgeImageView: FC<LayoutBadgeImageViewProps> = props =>
     {
         let newStyle: CSSProperties = {};
 
+        // When we highlight rarity we draw a UNIFORM frame: the element keeps its
+        // fixed box size (w-[40px]/h-[40px] from the class list) and the badge is
+        // centered inside it, so every frame is identical regardless of the badge
+        // PNG's native dimensions. Without this the ring hugs the natural image
+        // size, and smaller badges end up with a visibly smaller frame.
+        const uniformFrame = highlightRarity;
+
         if(imageElement)
         {
             newStyle.backgroundImage = `url(${ (isGroup) ? imageElement.src : GetConfigurationValue<string>('badge.asset.url').replace('%badgename%', badgeCode.toString()) })`;
-            newStyle.width = imageElement.width;
-            newStyle.height = imageElement.height;
 
-            if(scale !== 1)
+            if(!uniformFrame)
             {
-                newStyle.transform = `scale(${ scale })`;
+                newStyle.width = imageElement.width;
+                newStyle.height = imageElement.height;
 
-                if(!(scale % 1)) newStyle.imageRendering = 'pixelated';
+                if(scale !== 1)
+                {
+                    newStyle.transform = `scale(${ scale })`;
 
-                newStyle.width = (imageElement.width * scale);
-                newStyle.height = (imageElement.height * scale);
+                    if(!(scale % 1)) newStyle.imageRendering = 'pixelated';
+
+                    newStyle.width = (imageElement.width * scale);
+                    newStyle.height = (imageElement.height * scale);
+                }
             }
         }
 
-        if(highlightRarity && badgeRarityStat)
+        if(uniformFrame && badgeRarityStat)
         {
             const colors = BADGE_RARITY_COLORS[badgeRarityStat.rarity];
 
             if(colors)
             {
                 newStyle.borderRadius = 8;
-                newStyle.boxShadow = `0 0 0 1px ${ colors.glow }, 0 0 14px ${ colors.glow }`;
+                // Contained glow: inset rings stay inside the fixed frame, so the
+                // colored ring + glow never bleed onto neighbouring badges.
+                newStyle.boxShadow = `inset 0 0 0 1px ${ colors.glow }, inset 0 0 8px ${ colors.glow }`;
             }
         }
 

--- a/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetUserView.tsx
+++ b/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetUserView.tsx
@@ -193,7 +193,7 @@ export const InfoStandWidgetUserView: FC<InfoStandWidgetUserViewProps> = props =
                   aria-label="Edit profile background"
                 />
               )}
-              <Column grow alignItems="center" gap={0}>
+              <Column grow alignItems="center" gap={1}>
                 { (() => {
                   const maxSlots = GetConfigurationValue<number>('user.badges.max.slots', 5);
                   const isOwnUser = avatarInfo.type === AvatarInfoUser.OWN_USER;


### PR DESCRIPTION
## Problem

Rarity-highlighted badges drew their frame (the `box-shadow` ring + glow in `LayoutBadgeImageView`) on an element sized to the **badge PNG's native dimensions**. Since badges aren''t all the same native size, a badge with a smaller PNG got a visibly smaller frame than its neighbours.

## Changes

- **Uniform frame** — when `highlightRarity` is set, the badge element keeps its fixed box size (`w-[40px]/h-[40px]` from the class list) and the badge is centered inside it, instead of shrinking the box to the image. Every rarity frame is now identical regardless of native image size.
- **Contained glow** — the rarity glow is now an `inset` box-shadow, so the colored ring + glow stay inside the frame and no longer bleed onto neighbouring badges.
- **Even spacing** — the infostand badge grid had `gap={0}` between rows and `gap={1}` within rows; bumped the row `Column` to `gap={1}` so spacing is even on all sides.

Affects both surfaces that use the rarity highlight (same component): the in-room infostand badge slots and the extended-profile selected badges. Group badge slots are unaffected (they don''t use the rarity highlight).

## Testing

`yarn typecheck` clean. Visual behaviour verified in-client (uniform frames, glow contained, even spacing).