### PR TITLE
fix(toolbar): apply toolbar avatar head crop over inline styles

### DIFF
--- a/src/css/toolbar/ToolBar.css
+++ b/src/css/toolbar/ToolBar.css
@@ -21,8 +21,9 @@
 }
 
 .tb-avatar-head {
-    background-size: auto;
-    background-position: -25px -38px;
+    /* LayoutAvatarImageView(headOnly) writes background-size/-position inline, so the toolbar head-crop only applies with !important. */
+    background-size: auto !important;
+    background-position: -25px -38px !important;
 }
 
 .tb-collapse {


### PR DESCRIPTION
## Problem
The user avatar head in the toolbar (`.tb-avatar-head`, rendered by `LayoutAvatarImageView` with `headOnly`) was clipped/not visible: it showed the full-body figure mis-cropped instead of the head.

## Cause
`LayoutAvatarImageView` (headOnly branch) sets `background-size: 130px auto` and `background-position: 51% 40%` as **inline** styles. Inline styles outrank class selectors, so the toolbar's `.tb-avatar-head` crop (`background-size: auto; background-position: -25px -38px;`) never applied.

## Fix
Mark the two `.tb-avatar-head` declarations `!important` so the toolbar head-crop overrides the component's inline values. CSS-only, scoped to the toolbar avatar; no component/behaviour change.