### PR TITLE
fix(navigator): keep navigator tabs (incl. create-room +) on a single row

### DIFF
--- a/src/components/navigator/NavigatorView.tsx
+++ b/src/components/navigator/NavigatorView.tsx
@@ -110,7 +110,7 @@ export const NavigatorView: FC<{}> = (props) => {
         <>
             {isVisible && (
                 <NitroCard
-                    className={`${isOpenSavesSearches ? 'w-[min(600px,calc(100vw-16px))]' : 'w-[min(var(--navigator-width,430px),calc(100vw-16px))]'} min-w-0 max-w-[calc(100vw-16px)] h-[min(var(--navigator-height,600px),calc(100vh-16px))] min-h-0 max-h-[calc(100vh-16px)] has-classic-scrollbar`}
+                    className={`${isOpenSavesSearches ? 'w-[min(600px,calc(100vw-16px))]' : 'w-[min(var(--navigator-width,480px),calc(100vw-16px))]'} min-w-0 max-w-[calc(100vw-16px)] h-[min(var(--navigator-height,600px),calc(100vh-16px))] min-h-0 max-h-[calc(100vh-16px)] has-classic-scrollbar`}
                     uniqueKey="navigator"
                 >
                     <NitroCard.Header

--- a/src/css/nitrocard/NitroCardView.css
+++ b/src/css/nitrocard/NitroCardView.css
@@ -117,7 +117,7 @@
     .nitro-card-tabs,
     .nitro-card-tabs-shell {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 4px;
         min-height: auto;
         max-height: none;


### PR DESCRIPTION
## Problem
In the Navigator the create-room (`+`) tab wrapped onto a second line below the `Public / All Rooms / Events / My World` tabs, because the card tab bar wrapped and the default Navigator width was too narrow to fit all tabs.

## Fix
- `NitroCardView.css`: card tab bars use `flex-wrap: nowrap` so tabs stay on one row (the catalog keeps its own `.nitro-catalog-tabs-shell` scroll override, so it is unaffected).
- `NavigatorView.tsx`: bump the default Navigator width `430px → 480px` so the saves-search toggle + the 4 context tabs + the `+` button all fit on a single row.

CSS/layout only; no behaviour change.