### PR TITLE
feat(purse): add chat translation toggle button to the purse box

### DIFF
--- a/src/components/purse/PurseView.tsx
+++ b/src/components/purse/PurseView.tsx
@@ -1,6 +1,6 @@
 import { CreateLinkEvent } from '@nitrots/nitro-renderer';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { FaChartBar, FaCog, FaSignOutAlt } from 'react-icons/fa';
+import { FaChartBar, FaCog, FaLanguage, FaSignOutAlt } from 'react-icons/fa';
 import { ClearRememberLogin, GetConfigurationValue, GetRememberLogin, LocalizeText, localizeWithFallback } from '../../api';
 import { Column, LayoutCurrencyIcon } from '../../common';
 import { usePurse } from '../../hooks';
@@ -104,6 +104,17 @@ export const PurseView: FC<{}> = (props) => {
                         </button>
                     </div>
                     <div className="nitro-purse__col nitro-purse__col--actions">
+                        <button
+                            type="button"
+                            className="nitro-purse__btn nitro-purse__btn--icon nitro-purse__btn--translate"
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                CreateLinkEvent('translation-settings/toggle');
+                            }}
+                            title="Google Translate"
+                        >
+                            <FaLanguage className="nitro-purse__btn-icon" />
+                        </button>
                         <button
                             type="button"
                             className="nitro-purse__btn nitro-purse__btn--help"

--- a/src/css/purse/PurseView.css
+++ b/src/css/purse/PurseView.css
@@ -145,13 +145,19 @@
     background: #716a85;
 }
 
+.nitro-purse__btn--translate {
+    border-color: #565064;
+    background: #716a85;
+}
+
 /* Action column buttons: square corners */
 .nitro-purse__col--actions .nitro-purse__btn {
     border-radius: 0;
 }
 
-/* Gear icon rendered white */
-.nitro-purse__btn--settings svg {
+/* Gear + translate icons rendered white */
+.nitro-purse__btn--settings svg,
+.nitro-purse__btn--translate svg {
     color: #ffffff;
 }
 


### PR DESCRIPTION
## What
Adds a chat-translation toggle button to the purse box action row (before Help). Clicking it fires `translation-settings/toggle`, which opens the existing `TranslationSettingsView` ("Google Translate") panel — already mounted in `MainView` but previously had no UI entry point in this box.

## Details
- `PurseView.tsx`: a `FaLanguage` icon button (`nitro-purse__btn--icon nitro-purse__btn--translate`, title "Google Translate") in the actions column.
- `PurseView.css`: `--translate` variant styled like the settings gear (neutral grey, white icon).

No new logic — reuses the existing translation feature/link-event.