### PR TITLE
i18n(purse): localize settings menu items with English fallback

### DIFF
--- a/src/components/purse/PurseView.tsx
+++ b/src/components/purse/PurseView.tsx
@@ -140,16 +140,16 @@ export const PurseView: FC<{}> = (props) => {
             {settingsMenuOpen && (
                 <div className="nitro-purse-menu">
                     <button type="button" className="nitro-purse-menu__item" onClick={() => openSettingsSection('audio')}>
-                        Impostazioni Audio
+                        {localizeWithFallback('purse.settings.audio', 'Audio Settings')}
                     </button>
                     <button type="button" className="nitro-purse-menu__item nitro-purse-menu__item--disabled" disabled>
-                        Impostazioni Discord
+                        {localizeWithFallback('purse.settings.discord', 'Discord Settings')}
                     </button>
                     <button type="button" className="nitro-purse-menu__item" onClick={() => openSettingsSection('chat')}>
-                        Impostazioni Chat
+                        {localizeWithFallback('purse.settings.chat', 'Chat Settings')}
                     </button>
                     <button type="button" className="nitro-purse-menu__item" onClick={() => openSettingsSection('other')}>
-                        Altre Impostazioni
+                        {localizeWithFallback('purse.settings.other', 'Other Settings')}
                     </button>
                     <button
                         type="button"
@@ -159,10 +159,10 @@ export const PurseView: FC<{}> = (props) => {
                             setSettingsMenuOpen(false);
                         }}
                     >
-                        Gestione Account
+                        {localizeWithFallback('purse.settings.account', 'Account Management')}
                     </button>
                     <button type="button" className="nitro-purse-menu__item nitro-purse-menu__item--disabled" disabled>
-                        Filtro Parole
+                        {localizeWithFallback('purse.settings.wordfilter', 'Word Filter')}
                     </button>
                 </div>
             )}


### PR DESCRIPTION
## What
The purse settings dropdown (gear menu) had hard-coded Italian labels. This routes them through `localizeWithFallback(key, fallback)` — the same helper already used for Join / Help / Earnings in this component — with **English fallbacks**, so the menu is translatable and shows English by default.

| Key | Fallback |
|---|---|
| `purse.settings.audio` | Audio Settings |
| `purse.settings.discord` | Discord Settings |
| `purse.settings.chat` | Chat Settings |
| `purse.settings.other` | Other Settings |
| `purse.settings.account` | Account Management |
| `purse.settings.wordfilter` | Word Filter |

No keys added to the localization files yet, so the English fallback renders until/unless translations are supplied.