### PR TITLE
feat(user-settings): English-fallback localization for account settings

### DIFF
--- a/src/components/user-settings/UserAccountSettingsView.tsx
+++ b/src/components/user-settings/UserAccountSettingsView.tsx
@@ -1,20 +1,7 @@
 import { AddLinkEventTracker, GetSessionDataManager, ILinkEventTracker, RemoveLinkEventTracker } from '@nitrots/nitro-renderer';
 import { FC, KeyboardEvent, useEffect, useMemo, useState } from 'react';
-import {
-    FaArrowLeft,
-    FaCheckCircle,
-    FaChevronRight,
-    FaEnvelope,
-    FaExclamationTriangle,
-    FaEye,
-    FaEyeSlash,
-    FaIdBadge,
-    FaInfoCircle,
-    FaKey,
-    FaShieldAlt,
-    FaUserCog
-} from 'react-icons/fa';
-import { GetConfigurationValue, getAccessToken, LocalizeText } from '../../api';
+import { FaArrowLeft, FaCheckCircle, FaChevronRight, FaEnvelope, FaExclamationTriangle, FaEye, FaEyeSlash, FaIdBadge, FaInfoCircle, FaKey, FaShieldAlt, FaUserCog } from 'react-icons/fa';
+import { GetConfigurationValue, LocalizeText, localizeWithFallback, getAccessToken } from '../../api';
 import { Button, LayoutAvatarImageView, NitroCardContentView, NitroCardHeaderView, NitroCardView, Text } from '../../common';
 
 const MIN_PASSWORD_LENGTH = 8;
@@ -30,54 +17,61 @@ const MAX_USERNAME_LENGTH = 25;
 type FeedbackKind = 'error' | 'success';
 type Section = 'menu' | 'password' | 'email' | 'username';
 
-const passwordStrength = (value: string): { score: number; labelKey: string; color: string } => {
-    if (!value) return { score: 0, labelKey: '', color: 'bg-black/10' };
+const passwordStrength = (value: string): { score: number; labelKey: string; color: string } =>
+{
+    if(!value) return { score: 0, labelKey: '', color: 'bg-black/10' };
 
     let score = 0;
-    if (value.length >= MIN_PASSWORD_LENGTH) score++;
-    if (value.length >= 12) score++;
-    if (/[A-Z]/.test(value) && /[a-z]/.test(value)) score++;
-    if (/\d/.test(value)) score++;
-    if (/[^A-Za-z0-9]/.test(value)) score++;
+    if(value.length >= MIN_PASSWORD_LENGTH) score++;
+    if(value.length >= 12) score++;
+    if(/[A-Z]/.test(value) && /[a-z]/.test(value)) score++;
+    if(/\d/.test(value)) score++;
+    if(/[^A-Za-z0-9]/.test(value)) score++;
 
-    if (score <= 1) return { score: 1, labelKey: 'usersettings.strength.weak', color: 'bg-[#a81a12]' };
-    if (score === 2) return { score: 2, labelKey: 'usersettings.strength.fair', color: 'bg-[#ffc107]' };
-    if (score === 3) return { score: 3, labelKey: 'usersettings.strength.good', color: 'bg-[#1e7295]' };
+    if(score <= 1) return { score: 1, labelKey: 'usersettings.strength.weak', color: 'bg-[#a81a12]' };
+    if(score === 2) return { score: 2, labelKey: 'usersettings.strength.fair', color: 'bg-[#ffc107]' };
+    if(score === 3) return { score: 3, labelKey: 'usersettings.strength.good', color: 'bg-[#1e7295]' };
     return { score: 4, labelKey: 'usersettings.strength.strong', color: 'bg-[#00800b]' };
 };
 
-export const UserAccountSettingsView: FC<{}> = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [section, setSection] = useState<Section>('menu');
-    const [currentPassword, setCurrentPassword] = useState('');
-    const [newPassword, setNewPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [showCurrent, setShowCurrent] = useState(false);
-    const [showNew, setShowNew] = useState(false);
-    const [emailCurrentPassword, setEmailCurrentPassword] = useState('');
-    const [newEmail, setNewEmail] = useState('');
-    const [showEmailPassword, setShowEmailPassword] = useState(false);
-    const [usernameCurrentPassword, setUsernameCurrentPassword] = useState('');
-    const [newUsername, setNewUsername] = useState('');
-    const [showUsernamePassword, setShowUsernamePassword] = useState(false);
-    const [submitting, setSubmitting] = useState(false);
-    const [feedback, setFeedback] = useState<{ kind: FeedbackKind; message: string } | null>(null);
+export const UserAccountSettingsView: FC<{}> = () =>
+{
+    const [ isVisible, setIsVisible ] = useState(false);
+    const [ section, setSection ] = useState<Section>('menu');
+    const [ currentPassword, setCurrentPassword ] = useState('');
+    const [ newPassword, setNewPassword ] = useState('');
+    const [ confirmPassword, setConfirmPassword ] = useState('');
+    const [ showCurrent, setShowCurrent ] = useState(false);
+    const [ showNew, setShowNew ] = useState(false);
+    const [ emailCurrentPassword, setEmailCurrentPassword ] = useState('');
+    const [ newEmail, setNewEmail ] = useState('');
+    const [ showEmailPassword, setShowEmailPassword ] = useState(false);
+    const [ usernameCurrentPassword, setUsernameCurrentPassword ] = useState('');
+    const [ newUsername, setNewUsername ] = useState('');
+    const [ showUsernamePassword, setShowUsernamePassword ] = useState(false);
+    const [ submitting, setSubmitting ] = useState(false);
+    const [ feedback, setFeedback ] = useState<{ kind: FeedbackKind; message: string } | null>(null);
 
-    const session = useMemo(() => {
-        try {
+    const session = useMemo(() =>
+    {
+        try
+        {
             const manager = GetSessionDataManager();
             return {
                 username: manager?.userName ?? '',
                 figure: manager?.figure ?? ''
             };
-        } catch {
+        }
+        catch
+        {
             return { username: '', figure: '' };
         }
-    }, [isVisible]);
+    }, [ isVisible ]);
 
-    const strength = useMemo(() => passwordStrength(newPassword), [newPassword]);
+    const strength = useMemo(() => passwordStrength(newPassword), [ newPassword ]);
 
-    const resetForm = () => {
+    const resetForm = () =>
+    {
         setCurrentPassword('');
         setNewPassword('');
         setConfirmPassword('');
@@ -92,20 +86,24 @@ export const UserAccountSettingsView: FC<{}> = () => {
         setFeedback(null);
     };
 
-    const close = () => {
+    const close = () =>
+    {
         setIsVisible(false);
         setSection('menu');
         resetForm();
         setSubmitting(false);
     };
 
-    useEffect(() => {
+    useEffect(() =>
+    {
         const linkTracker: ILinkEventTracker = {
-            linkReceived: (url: string) => {
+            linkReceived: (url: string) =>
+            {
                 const parts = url.split('/');
-                if (parts.length < 2) return;
+                if(parts.length < 2) return;
 
-                switch (parts[1]) {
+                switch(parts[1])
+                {
                     case 'show':
                         setIsVisible(true);
                         return;
@@ -113,7 +111,7 @@ export const UserAccountSettingsView: FC<{}> = () => {
                         close();
                         return;
                     case 'toggle':
-                        setIsVisible((prev) => !prev);
+                        setIsVisible(prev => !prev);
                         return;
                 }
             },
@@ -125,219 +123,248 @@ export const UserAccountSettingsView: FC<{}> = () => {
         return () => RemoveLinkEventTracker(linkTracker);
     }, []);
 
-    const submitPasswordChange = async () => {
-        if (submitting) return;
+    const submitPasswordChange = async () =>
+    {
+        if(submitting) return;
 
         setFeedback(null);
 
-        if (!currentPassword || !newPassword || !confirmPassword) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.fields_required') });
+        if(!currentPassword || !newPassword || !confirmPassword)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.fields_required', "All fields are required.") });
             return;
         }
 
-        if (newPassword.length < MIN_PASSWORD_LENGTH) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.password_min', ['count'], [MIN_PASSWORD_LENGTH.toString()]) });
+        if(newPassword.length < MIN_PASSWORD_LENGTH)
+        {
+            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.password_min', [ 'count' ], [ MIN_PASSWORD_LENGTH.toString() ]) });
             return;
         }
 
-        if (newPassword.length > MAX_PASSWORD_LENGTH) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.password_long') });
+        if(newPassword.length > MAX_PASSWORD_LENGTH)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.password_long', "The password is too long.") });
             return;
         }
 
-        if (newPassword !== confirmPassword) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.password_mismatch') });
+        if(newPassword !== confirmPassword)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.password_mismatch', "The new passwords don't match.") });
             return;
         }
 
-        if (newPassword === currentPassword) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.password_same') });
+        if(newPassword === currentPassword)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.password_same', "Your new password must be different from your current one.") });
             return;
         }
 
         const token = getAccessToken();
-        if (!token) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.not_authenticated') });
+        if(!token)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.not_authenticated', "You're not signed in. Please log in again.") });
             return;
         }
 
         const endpoint = GetConfigurationValue<string>('account.change-password.endpoint', '/api/auth/change-password');
 
         setSubmitting(true);
-        try {
+        try
+        {
             const response = await fetch(endpoint, {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: `Bearer ${token}`,
+                    'Accept': 'application/json',
+                    'Authorization': `Bearer ${ token }`,
                     'X-Requested-With': 'NitroUserAccountSettings'
                 },
                 body: JSON.stringify({ currentPassword, newPassword, confirmPassword })
             });
 
             let payload: Record<string, unknown> = {};
-            try {
-                payload = await response.json();
-            } catch {}
+            try { payload = await response.json(); }
+            catch {}
 
-            if (!response.ok) {
-                const message =
-                    typeof payload.error === 'string' && payload.error
-                        ? payload.error
-                        : LocalizeText('usersettings.error.request_failed', ['status'], [response.status.toString()]);
+            if(!response.ok)
+            {
+                const message = typeof payload.error === 'string' && payload.error
+                    ? payload.error
+                    : LocalizeText('usersettings.error.request_failed', [ 'status' ], [ response.status.toString() ]);
                 setFeedback({ kind: 'error', message });
                 return;
             }
 
-            const message = typeof payload.message === 'string' && payload.message ? payload.message : LocalizeText('usersettings.success.password');
+            const message = typeof payload.message === 'string' && payload.message
+                ? payload.message
+                : localizeWithFallback('usersettings.success.password', "Password updated successfully.");
             setFeedback({ kind: 'success', message });
             setCurrentPassword('');
             setNewPassword('');
             setConfirmPassword('');
             setShowCurrent(false);
             setShowNew(false);
-        } catch {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.network') });
-        } finally {
+        }
+        catch
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.network', "Couldn't reach the server. Please try again.") });
+        }
+        finally
+        {
             setSubmitting(false);
         }
     };
 
-    const submitEmailChange = async () => {
-        if (submitting) return;
+    const submitEmailChange = async () =>
+    {
+        if(submitting) return;
 
         setFeedback(null);
 
-        if (!emailCurrentPassword || !newEmail) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.fields_required') });
+        if(!emailCurrentPassword || !newEmail)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.fields_required', "All fields are required.") });
             return;
         }
 
-        if (newEmail.length > MAX_EMAIL_LENGTH) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.email_long') });
+        if(newEmail.length > MAX_EMAIL_LENGTH)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.email_long', "The email address is too long.") });
             return;
         }
 
-        if (!EMAIL_RE.test(newEmail)) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.email_invalid') });
+        if(!EMAIL_RE.test(newEmail))
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.email_invalid', "Please enter a valid email address.") });
             return;
         }
 
         const token = getAccessToken();
-        if (!token) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.not_authenticated') });
+        if(!token)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.not_authenticated', "You're not signed in. Please log in again.") });
             return;
         }
 
         const endpoint = GetConfigurationValue<string>('account.change-email.endpoint', '/api/auth/change-email');
 
         setSubmitting(true);
-        try {
+        try
+        {
             const response = await fetch(endpoint, {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: `Bearer ${token}`,
+                    'Accept': 'application/json',
+                    'Authorization': `Bearer ${ token }`,
                     'X-Requested-With': 'NitroUserAccountSettings'
                 },
                 body: JSON.stringify({ currentPassword: emailCurrentPassword, newEmail })
             });
 
             let payload: Record<string, unknown> = {};
-            try {
-                payload = await response.json();
-            } catch {}
+            try { payload = await response.json(); }
+            catch {}
 
-            if (!response.ok) {
-                const message =
-                    typeof payload.error === 'string' && payload.error
-                        ? payload.error
-                        : LocalizeText('usersettings.error.request_failed', ['status'], [response.status.toString()]);
+            if(!response.ok)
+            {
+                const message = typeof payload.error === 'string' && payload.error
+                    ? payload.error
+                    : LocalizeText('usersettings.error.request_failed', [ 'status' ], [ response.status.toString() ]);
                 setFeedback({ kind: 'error', message });
                 return;
             }
 
-            const message = typeof payload.message === 'string' && payload.message ? payload.message : LocalizeText('usersettings.success.email');
+            const message = typeof payload.message === 'string' && payload.message
+                ? payload.message
+                : localizeWithFallback('usersettings.success.email', "Email updated successfully.");
             setFeedback({ kind: 'success', message });
             setEmailCurrentPassword('');
             setNewEmail('');
             setShowEmailPassword(false);
-        } catch {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.network') });
-        } finally {
+        }
+        catch
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.network', "Couldn't reach the server. Please try again.") });
+        }
+        finally
+        {
             setSubmitting(false);
         }
     };
 
-    const submitUsernameChange = async () => {
-        if (submitting) return;
+    const submitUsernameChange = async () =>
+    {
+        if(submitting) return;
 
         setFeedback(null);
 
-        if (!usernameCurrentPassword || !newUsername) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.fields_required') });
+        if(!usernameCurrentPassword || !newUsername)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.fields_required', "All fields are required.") });
             return;
         }
 
-        if (newUsername.length < MIN_USERNAME_LENGTH || newUsername.length > MAX_USERNAME_LENGTH) {
-            setFeedback({
-                kind: 'error',
-                message: LocalizeText('usersettings.error.username_length', ['min', 'max'], [MIN_USERNAME_LENGTH.toString(), MAX_USERNAME_LENGTH.toString()])
-            });
+        if(newUsername.length < MIN_USERNAME_LENGTH || newUsername.length > MAX_USERNAME_LENGTH)
+        {
+            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.username_length', [ 'min', 'max' ], [ MIN_USERNAME_LENGTH.toString(), MAX_USERNAME_LENGTH.toString() ]) });
             return;
         }
 
-        if (!USERNAME_RE.test(newUsername)) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.username_invalid') });
+        if(!USERNAME_RE.test(newUsername))
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.username_invalid', "Your username can only contain letters, numbers, dots, underscores and hyphens.") });
             return;
         }
 
-        if (newUsername === session.username) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.username_same') });
+        if(newUsername === session.username)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.username_same', "Your new username must be different from your current one.") });
             return;
         }
 
         const token = getAccessToken();
-        if (!token) {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.not_authenticated') });
+        if(!token)
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.not_authenticated', "You're not signed in. Please log in again.") });
             return;
         }
 
         const endpoint = GetConfigurationValue<string>('account.change-username.endpoint', '/api/auth/change-username');
 
         setSubmitting(true);
-        try {
+        try
+        {
             const response = await fetch(endpoint, {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: `Bearer ${token}`,
+                    'Accept': 'application/json',
+                    'Authorization': `Bearer ${ token }`,
                     'X-Requested-With': 'NitroUserAccountSettings'
                 },
                 body: JSON.stringify({ currentPassword: usernameCurrentPassword, newUsername })
             });
 
             let payload: Record<string, unknown> = {};
-            try {
-                payload = await response.json();
-            } catch {}
+            try { payload = await response.json(); }
+            catch {}
 
-            if (!response.ok) {
-                const message =
-                    typeof payload.error === 'string' && payload.error
-                        ? payload.error
-                        : LocalizeText('usersettings.error.request_failed', ['status'], [response.status.toString()]);
+            if(!response.ok)
+            {
+                const message = typeof payload.error === 'string' && payload.error
+                    ? payload.error
+                    : LocalizeText('usersettings.error.request_failed', [ 'status' ], [ response.status.toString() ]);
                 setFeedback({ kind: 'error', message });
                 return;
             }
 
-            const message = typeof payload.message === 'string' && payload.message ? payload.message : LocalizeText('usersettings.success.username');
+            const message = typeof payload.message === 'string' && payload.message
+                ? payload.message
+                : localizeWithFallback('usersettings.success.username', "Username updated. Log in again with your new name.");
             setFeedback({ kind: 'success', message });
             setUsernameCurrentPassword('');
             setNewUsername('');
@@ -345,82 +372,64 @@ export const UserAccountSettingsView: FC<{}> = () => {
 
             // The server has dropped our session — clear local credentials and bounce
             // the user back to the login screen so the whole client reloads cleanly.
-            try {
-                window.localStorage.removeItem('nitro.access.token');
-            } catch {}
-            try {
-                window.localStorage.removeItem('nitro.access.token.exp');
-            } catch {}
-            window.setTimeout(() => {
-                try {
-                    window.location.reload();
-                } catch {}
+            try { window.localStorage.removeItem('nitro.access.token'); } catch {}
+            try { window.localStorage.removeItem('nitro.access.token.exp'); } catch {}
+            window.setTimeout(() =>
+            {
+                try { window.location.reload(); }
+                catch {}
             }, 2500);
-        } catch {
-            setFeedback({ kind: 'error', message: LocalizeText('usersettings.error.network') });
-        } finally {
+        }
+        catch
+        {
+            setFeedback({ kind: 'error', message: localizeWithFallback('usersettings.error.network', "Couldn't reach the server. Please try again.") });
+        }
+        finally
+        {
             setSubmitting(false);
         }
     };
 
-    if (!isVisible) return null;
+    if(!isVisible) return null;
 
     return (
-        <NitroCardView
-            className="user-account-settings-window min-w-0 w-[min(360px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
-            theme="primary-slim"
-            uniqueKey="user-account-settings"
-        >
-            <NitroCardHeaderView headerText={LocalizeText('usersettings.title')} onCloseClick={close} />
+        <NitroCardView className="user-account-settings-window min-w-0 w-[min(360px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim" uniqueKey="user-account-settings">
+            <NitroCardHeaderView headerText={ localizeWithFallback('usersettings.title', "User Settings") } onCloseClick={ close } />
 
             <div className="relative flex items-center gap-3 px-3 py-2 bg-[linear-gradient(180deg,#2e8fb8_0%,#1e7295_100%)] text-white">
                 <div className="absolute inset-0 opacity-20 pointer-events-none [background-image:radial-gradient(rgba(255,255,255,0.5)_1px,transparent_1px)] [background-size:6px_6px]" />
-                {session.figure && (
+                { session.figure && (
                     <div className="relative w-[60px] h-[60px] shrink-0 rounded-full bg-white/20 border-2 border-white/40 overflow-hidden">
                         <LayoutAvatarImageView
-                            figure={session.figure}
-                            direction={2}
-                            headOnly={true}
-                            scale={1}
-                            style={{ backgroundSize: '112px auto', backgroundPosition: '-24px -38px' }}
+                            figure={ session.figure }
+                            direction={ 2 }
+                            headOnly={ true }
+                            scale={ 1 }
+                            style={ { backgroundSize: '112px auto', backgroundPosition: '-24px -38px' } }
                         />
                     </div>
-                )}
+                ) }
                 <div className="relative flex flex-col leading-tight">
-                    <Text small className="text-white/80 uppercase tracking-wider">
-                        {LocalizeText('usersettings.account.label')}
-                    </Text>
-                    <Text bold className="text-white text-[15px]">
-                        {session.username || LocalizeText('usersettings.guest')}
-                    </Text>
-                    <Text small className="text-white/80">
-                        {LocalizeText('usersettings.subtitle')}
-                    </Text>
+                    <Text small className="text-white/80 uppercase tracking-wider">{ localizeWithFallback('usersettings.account.label', "My account") }</Text>
+                    <Text bold className="text-white text-[15px]">{ session.username || localizeWithFallback('usersettings.guest', "Guest") }</Text>
+                    <Text small className="text-white/80">{ localizeWithFallback('usersettings.subtitle', "Manage your account and security") }</Text>
                 </div>
             </div>
 
             <NitroCardContentView className="flex flex-col gap-2 text-black">
-                {section === 'menu' && (
+                { section === 'menu' && (
                     <div className="flex flex-col gap-2">
-                        <Text small className="text-black/60 uppercase tracking-wider px-1">
-                            {LocalizeText('usersettings.menu.section')}
-                        </Text>
+                        <Text small className="text-black/60 uppercase tracking-wider px-1">{ localizeWithFallback('usersettings.menu.section', "Account") }</Text>
                         <button
                             type="button"
                             className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left"
-                            onClick={() => {
-                                resetForm();
-                                setSection('password');
-                            }}
-                        >
+                            onClick={ () => { resetForm(); setSection('password'); } }>
                             <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#1e7295] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
                                 <FaKey />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
-                                <Text bold>{LocalizeText('usersettings.menu.password.title')}</Text>
-                                <Text small className="text-black/60">
-                                    {LocalizeText('usersettings.menu.password.desc')}
-                                </Text>
+                                <Text bold>{ localizeWithFallback('usersettings.menu.password.title', "Reset password") }</Text>
+                                <Text small className="text-black/60">{ localizeWithFallback('usersettings.menu.password.desc', "Change the password you use to log in.") }</Text>
                             </div>
                             <FaChevronRight className="text-black/40 group-hover:text-[#1e7295]" />
                         </button>
@@ -428,19 +437,13 @@ export const UserAccountSettingsView: FC<{}> = () => {
                         <button
                             type="button"
                             className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left"
-                            onClick={() => {
-                                resetForm();
-                                setSection('email');
-                            }}
-                        >
+                            onClick={ () => { resetForm(); setSection('email'); } }>
                             <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#185d79] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
                                 <FaEnvelope />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
-                                <Text bold>{LocalizeText('usersettings.menu.email.title')}</Text>
-                                <Text small className="text-black/60">
-                                    {LocalizeText('usersettings.menu.email.desc')}
-                                </Text>
+                                <Text bold>{ localizeWithFallback('usersettings.menu.email.title', "Change email") }</Text>
+                                <Text small className="text-black/60">{ localizeWithFallback('usersettings.menu.email.desc', "Update your account's email address.") }</Text>
                             </div>
                             <FaChevronRight className="text-black/40 group-hover:text-[#1e7295]" />
                         </button>
@@ -448,19 +451,13 @@ export const UserAccountSettingsView: FC<{}> = () => {
                         <button
                             type="button"
                             className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#fef7e0] hover:border-[#ffc107] transition-colors cursor-pointer text-left"
-                            onClick={() => {
-                                resetForm();
-                                setSection('username');
-                            }}
-                        >
+                            onClick={ () => { resetForm(); setSection('username'); } }>
                             <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#ffc107] text-[#5c4400] shrink-0 shadow-[inset_0_2px_#ffffff80,inset_0_-2px_#0000001a]">
                                 <FaIdBadge />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
-                                <Text bold>{LocalizeText('usersettings.menu.username.title')}</Text>
-                                <Text small className="text-black/60">
-                                    {LocalizeText('usersettings.menu.username.desc')}
-                                </Text>
+                                <Text bold>{ localizeWithFallback('usersettings.menu.username.title', "Change username") }</Text>
+                                <Text small className="text-black/60">{ localizeWithFallback('usersettings.menu.username.desc', "Pick a new name. You'll need to log in again.") }</Text>
                             </div>
                             <FaChevronRight className="text-black/40 group-hover:text-[#a37800]" />
                         </button>
@@ -470,374 +467,291 @@ export const UserAccountSettingsView: FC<{}> = () => {
                                 <FaShieldAlt />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
-                                <Text bold className="text-black/60">
-                                    {LocalizeText('usersettings.menu.soon.title')}
-                                </Text>
-                                <Text small className="text-black/50">
-                                    {LocalizeText('usersettings.menu.soon.desc')}
-                                </Text>
+                                <Text bold className="text-black/60">{ localizeWithFallback('usersettings.menu.soon.title', "More coming soon") }</Text>
+                                <Text small className="text-black/50">{ localizeWithFallback('usersettings.menu.soon.desc', "Two-factor authentication and more.") }</Text>
                             </div>
                         </div>
                     </div>
-                )}
+                ) }
 
-                {section === 'password' && (
-                    <div
-                        className="flex flex-col gap-2"
-                        onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                            if (event.key === 'Enter') {
-                                event.preventDefault();
-                                submitPasswordChange();
-                            }
-                        }}
-                    >
+                { section === 'password' && (
+                    <div className="flex flex-col gap-2" onKeyDown={ (event: KeyboardEvent<HTMLDivElement>) => { if(event.key === 'Enter') { event.preventDefault(); submitPasswordChange(); } } }>
                         <div className="flex items-center gap-2 -mt-1 mb-1">
                             <button
                                 type="button"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50"
-                            >
-                                <FaArrowLeft size={11} />
+                                disabled={ submitting }
+                                onClick={ () => { resetForm(); setSection('menu'); } }
+                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50">
+                                <FaArrowLeft size={ 11 } />
                             </button>
                             <FaUserCog className="text-[#1e7295]" />
-                            <Text bold>{LocalizeText('usersettings.menu.password.title')}</Text>
+                            <Text bold>{ localizeWithFallback('usersettings.menu.password.title', "Reset password") }</Text>
                         </div>
 
                         <div className="flex items-start gap-2 rounded-md border border-[#1e7295]/30 bg-[#1e7295]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
                             <FaInfoCircle className="mt-[2px] shrink-0 text-[#1e7295]" />
-                            <span>{LocalizeText('usersettings.password.hint', ['count'], [MIN_PASSWORD_LENGTH.toString()])}</span>
+                            <span>{ LocalizeText('usersettings.password.hint', [ 'count' ], [ MIN_PASSWORD_LENGTH.toString() ]) }</span>
                         </div>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.current_password')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.current_password', "Current password") }</span>
                             <div className="relative flex items-center">
-                                <FaKey className="absolute left-2 text-black/40" size={12} />
+                                <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
-                                    type={showCurrent ? 'text' : 'password'}
+                                    type={ showCurrent ? 'text' : 'password' }
                                     className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
                                     autoComplete="current-password"
-                                    maxLength={MAX_PASSWORD_LENGTH}
-                                    value={currentPassword}
-                                    onChange={(event) => setCurrentPassword(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_PASSWORD_LENGTH }
+                                    value={ currentPassword }
+                                    onChange={ event => setCurrentPassword(event.target.value) }
+                                    disabled={ submitting }
                                 />
                                 <button
                                     type="button"
-                                    aria-label={showCurrent ? LocalizeText('usersettings.aria.hide_password') : LocalizeText('usersettings.aria.show_password')}
-                                    onClick={() => setShowCurrent((prev) => !prev)}
-                                    className="absolute right-2 text-black/40 hover:text-black/70"
-                                >
-                                    {showCurrent ? <FaEyeSlash size={12} /> : <FaEye size={12} />}
+                                    aria-label={ showCurrent ? localizeWithFallback('usersettings.aria.hide_password', "Hide password") : localizeWithFallback('usersettings.aria.show_password', "Show password") }
+                                    onClick={ () => setShowCurrent(prev => !prev) }
+                                    className="absolute right-2 text-black/40 hover:text-black/70">
+                                    { showCurrent ? <FaEyeSlash size={ 12 } /> : <FaEye size={ 12 } /> }
                                 </button>
                             </div>
                         </label>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.new_password')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.new_password', "New password") }</span>
                             <div className="relative flex items-center">
-                                <FaKey className="absolute left-2 text-black/40" size={12} />
+                                <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
-                                    type={showNew ? 'text' : 'password'}
+                                    type={ showNew ? 'text' : 'password' }
                                     className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
                                     autoComplete="new-password"
-                                    maxLength={MAX_PASSWORD_LENGTH}
-                                    value={newPassword}
-                                    onChange={(event) => setNewPassword(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_PASSWORD_LENGTH }
+                                    value={ newPassword }
+                                    onChange={ event => setNewPassword(event.target.value) }
+                                    disabled={ submitting }
                                 />
                                 <button
                                     type="button"
-                                    aria-label={showNew ? LocalizeText('usersettings.aria.hide_password') : LocalizeText('usersettings.aria.show_password')}
-                                    onClick={() => setShowNew((prev) => !prev)}
-                                    className="absolute right-2 text-black/40 hover:text-black/70"
-                                >
-                                    {showNew ? <FaEyeSlash size={12} /> : <FaEye size={12} />}
+                                    aria-label={ showNew ? localizeWithFallback('usersettings.aria.hide_password', "Hide password") : localizeWithFallback('usersettings.aria.show_password', "Show password") }
+                                    onClick={ () => setShowNew(prev => !prev) }
+                                    className="absolute right-2 text-black/40 hover:text-black/70">
+                                    { showNew ? <FaEyeSlash size={ 12 } /> : <FaEye size={ 12 } /> }
                                 </button>
                             </div>
-                            {newPassword.length > 0 && (
+                            { newPassword.length > 0 && (
                                 <div className="flex items-center gap-2 mt-1">
                                     <div className="flex-1 h-1.5 rounded-full bg-black/10 overflow-hidden">
-                                        <div className={`h-full ${strength.color} transition-all`} style={{ width: `${(strength.score / 4) * 100}%` }} />
+                                        <div className={ `h-full ${ strength.color } transition-all` } style={ { width: `${ (strength.score / 4) * 100 }%` } } />
                                     </div>
-                                    <span className="text-[10px] text-black/60 w-12 text-right">
-                                        {strength.labelKey ? LocalizeText(strength.labelKey) : ''}
-                                    </span>
+                                    <span className="text-[10px] text-black/60 w-12 text-right">{ strength.labelKey ? LocalizeText(strength.labelKey) : '' }</span>
                                 </div>
-                            )}
+                            ) }
                         </label>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.retype_password')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.retype_password', "Re-enter your new password") }</span>
                             <div className="relative flex items-center">
-                                <FaKey className="absolute left-2 text-black/40" size={12} />
+                                <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
-                                    type={showNew ? 'text' : 'password'}
-                                    className={`w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${confirmPassword.length > 0 && confirmPassword !== newPassword ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]'}`}
+                                    type={ showNew ? 'text' : 'password' }
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ confirmPassword.length > 0 && confirmPassword !== newPassword ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
                                     autoComplete="new-password"
-                                    maxLength={MAX_PASSWORD_LENGTH}
-                                    value={confirmPassword}
-                                    onChange={(event) => setConfirmPassword(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_PASSWORD_LENGTH }
+                                    value={ confirmPassword }
+                                    onChange={ event => setConfirmPassword(event.target.value) }
+                                    disabled={ submitting }
                                 />
-                                {confirmPassword.length > 0 && confirmPassword === newPassword && (
-                                    <FaCheckCircle className="absolute right-2 text-[#00800b]" size={12} />
-                                )}
+                                { confirmPassword.length > 0 && confirmPassword === newPassword && (
+                                    <FaCheckCircle className="absolute right-2 text-[#00800b]" size={ 12 } />
+                                ) }
                             </div>
                         </label>
 
-                        {feedback && (
-                            <div
-                                className={`flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]'}`}
-                            >
-                                {feedback.kind === 'error' ? (
-                                    <FaExclamationTriangle className="mt-[2px] shrink-0" />
-                                ) : (
-                                    <FaCheckCircle className="mt-[2px] shrink-0" />
-                                )}
-                                <span>{feedback.message}</span>
+                        { feedback && (
+                            <div className={ `flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${ feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]' }` }>
+                                { feedback.kind === 'error'
+                                    ? <FaExclamationTriangle className="mt-[2px] shrink-0" />
+                                    : <FaCheckCircle className="mt-[2px] shrink-0" /> }
+                                <span>{ feedback.message }</span>
                             </div>
-                        )}
+                        ) }
 
                         <div className="flex justify-end gap-2 pt-1">
-                            <Button
-                                variant="secondary"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                            >
-                                {LocalizeText('usersettings.btn.cancel')}
+                            <Button variant="secondary" disabled={ submitting } onClick={ () => { resetForm(); setSection('menu'); } }>
+                                { localizeWithFallback('usersettings.btn.cancel', "Cancel") }
                             </Button>
-                            <Button variant="success" disabled={submitting} onClick={() => submitPasswordChange()}>
-                                {submitting ? LocalizeText('usersettings.btn.saving') : LocalizeText('usersettings.btn.save_password')}
+                            <Button variant="success" disabled={ submitting } onClick={ () => submitPasswordChange() }>
+                                { submitting ? localizeWithFallback('usersettings.btn.saving', "Saving…") : localizeWithFallback('usersettings.btn.save_password', "Save password") }
                             </Button>
                         </div>
                     </div>
-                )}
+                ) }
 
-                {section === 'email' && (
-                    <div
-                        className="flex flex-col gap-2"
-                        onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                            if (event.key === 'Enter') {
-                                event.preventDefault();
-                                submitEmailChange();
-                            }
-                        }}
-                    >
+                { section === 'email' && (
+                    <div className="flex flex-col gap-2" onKeyDown={ (event: KeyboardEvent<HTMLDivElement>) => { if(event.key === 'Enter') { event.preventDefault(); submitEmailChange(); } } }>
                         <div className="flex items-center gap-2 -mt-1 mb-1">
                             <button
                                 type="button"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50"
-                            >
-                                <FaArrowLeft size={11} />
+                                disabled={ submitting }
+                                onClick={ () => { resetForm(); setSection('menu'); } }
+                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50">
+                                <FaArrowLeft size={ 11 } />
                             </button>
                             <FaEnvelope className="text-[#185d79]" />
-                            <Text bold>{LocalizeText('usersettings.menu.email.title')}</Text>
+                            <Text bold>{ localizeWithFallback('usersettings.menu.email.title', "Change email") }</Text>
                         </div>
 
                         <div className="flex items-start gap-2 rounded-md border border-[#1e7295]/30 bg-[#1e7295]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
                             <FaInfoCircle className="mt-[2px] shrink-0 text-[#1e7295]" />
-                            <span>{LocalizeText('usersettings.email.hint')}</span>
+                            <span>{ localizeWithFallback('usersettings.email.hint', "For your security, please confirm your current password before changing your account email.") }</span>
                         </div>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.current_password')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.current_password', "Current password") }</span>
                             <div className="relative flex items-center">
-                                <FaKey className="absolute left-2 text-black/40" size={12} />
+                                <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
-                                    type={showEmailPassword ? 'text' : 'password'}
+                                    type={ showEmailPassword ? 'text' : 'password' }
                                     className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
                                     autoComplete="current-password"
-                                    maxLength={MAX_PASSWORD_LENGTH}
-                                    value={emailCurrentPassword}
-                                    onChange={(event) => setEmailCurrentPassword(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_PASSWORD_LENGTH }
+                                    value={ emailCurrentPassword }
+                                    onChange={ event => setEmailCurrentPassword(event.target.value) }
+                                    disabled={ submitting }
                                 />
                                 <button
                                     type="button"
-                                    aria-label={
-                                        showEmailPassword ? LocalizeText('usersettings.aria.hide_password') : LocalizeText('usersettings.aria.show_password')
-                                    }
-                                    onClick={() => setShowEmailPassword((prev) => !prev)}
-                                    className="absolute right-2 text-black/40 hover:text-black/70"
-                                >
-                                    {showEmailPassword ? <FaEyeSlash size={12} /> : <FaEye size={12} />}
+                                    aria-label={ showEmailPassword ? localizeWithFallback('usersettings.aria.hide_password', "Hide password") : localizeWithFallback('usersettings.aria.show_password', "Show password") }
+                                    onClick={ () => setShowEmailPassword(prev => !prev) }
+                                    className="absolute right-2 text-black/40 hover:text-black/70">
+                                    { showEmailPassword ? <FaEyeSlash size={ 12 } /> : <FaEye size={ 12 } /> }
                                 </button>
                             </div>
                         </label>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.new_email')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.new_email', "New email address") }</span>
                             <div className="relative flex items-center">
-                                <FaEnvelope className="absolute left-2 text-black/40" size={12} />
+                                <FaEnvelope className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type="email"
-                                    className={`w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${newEmail.length > 0 && !EMAIL_RE.test(newEmail) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]'}`}
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newEmail.length > 0 && !EMAIL_RE.test(newEmail) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
                                     autoComplete="email"
                                     inputMode="email"
-                                    maxLength={MAX_EMAIL_LENGTH}
-                                    value={newEmail}
-                                    onChange={(event) => setNewEmail(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_EMAIL_LENGTH }
+                                    value={ newEmail }
+                                    onChange={ event => setNewEmail(event.target.value) }
+                                    disabled={ submitting }
                                     placeholder="you@example.com"
                                 />
-                                {newEmail.length > 0 && EMAIL_RE.test(newEmail) && <FaCheckCircle className="absolute right-2 text-[#00800b]" size={12} />}
+                                { newEmail.length > 0 && EMAIL_RE.test(newEmail) && (
+                                    <FaCheckCircle className="absolute right-2 text-[#00800b]" size={ 12 } />
+                                ) }
                             </div>
                         </label>
 
-                        {feedback && (
-                            <div
-                                className={`flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]'}`}
-                            >
-                                {feedback.kind === 'error' ? (
-                                    <FaExclamationTriangle className="mt-[2px] shrink-0" />
-                                ) : (
-                                    <FaCheckCircle className="mt-[2px] shrink-0" />
-                                )}
-                                <span>{feedback.message}</span>
+                        { feedback && (
+                            <div className={ `flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${ feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]' }` }>
+                                { feedback.kind === 'error'
+                                    ? <FaExclamationTriangle className="mt-[2px] shrink-0" />
+                                    : <FaCheckCircle className="mt-[2px] shrink-0" /> }
+                                <span>{ feedback.message }</span>
                             </div>
-                        )}
+                        ) }
 
                         <div className="flex justify-end gap-2 pt-1">
-                            <Button
-                                variant="secondary"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                            >
-                                {LocalizeText('usersettings.btn.cancel')}
+                            <Button variant="secondary" disabled={ submitting } onClick={ () => { resetForm(); setSection('menu'); } }>
+                                { localizeWithFallback('usersettings.btn.cancel', "Cancel") }
                             </Button>
-                            <Button variant="success" disabled={submitting} onClick={() => submitEmailChange()}>
-                                {submitting ? LocalizeText('usersettings.btn.saving') : LocalizeText('usersettings.btn.save_email')}
+                            <Button variant="success" disabled={ submitting } onClick={ () => submitEmailChange() }>
+                                { submitting ? localizeWithFallback('usersettings.btn.saving', "Saving…") : localizeWithFallback('usersettings.btn.save_email', "Save email") }
                             </Button>
                         </div>
                     </div>
-                )}
+                ) }
 
-                {section === 'username' && (
-                    <div
-                        className="flex flex-col gap-2"
-                        onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                            if (event.key === 'Enter') {
-                                event.preventDefault();
-                                submitUsernameChange();
-                            }
-                        }}
-                    >
+                { section === 'username' && (
+                    <div className="flex flex-col gap-2" onKeyDown={ (event: KeyboardEvent<HTMLDivElement>) => { if(event.key === 'Enter') { event.preventDefault(); submitUsernameChange(); } } }>
                         <div className="flex items-center gap-2 -mt-1 mb-1">
                             <button
                                 type="button"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50"
-                            >
-                                <FaArrowLeft size={11} />
+                                disabled={ submitting }
+                                onClick={ () => { resetForm(); setSection('menu'); } }
+                                className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50">
+                                <FaArrowLeft size={ 11 } />
                             </button>
                             <FaIdBadge className="text-[#a37800]" />
-                            <Text bold>{LocalizeText('usersettings.menu.username.title')}</Text>
+                            <Text bold>{ localizeWithFallback('usersettings.menu.username.title', "Change username") }</Text>
                         </div>
 
                         <div className="flex items-start gap-2 rounded-md border border-[#ffc107]/50 bg-[#fff8e1] px-2 py-2 text-[11px] leading-4 text-[#5c4400]">
                             <FaExclamationTriangle className="mt-[2px] shrink-0 text-[#a37800]" />
-                            <span>{LocalizeText('usersettings.username.hint')}</span>
+                            <span>{ localizeWithFallback('usersettings.username.hint', "Changing your name will log you out, and you'll only be able to rename yourself again after 30 days. Make sure your friends know your new name!") }</span>
                         </div>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.current_password')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.current_password', "Current password") }</span>
                             <div className="relative flex items-center">
-                                <FaKey className="absolute left-2 text-black/40" size={12} />
+                                <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
-                                    type={showUsernamePassword ? 'text' : 'password'}
+                                    type={ showUsernamePassword ? 'text' : 'password' }
                                     className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
                                     autoComplete="current-password"
-                                    maxLength={MAX_PASSWORD_LENGTH}
-                                    value={usernameCurrentPassword}
-                                    onChange={(event) => setUsernameCurrentPassword(event.target.value)}
-                                    disabled={submitting}
+                                    maxLength={ MAX_PASSWORD_LENGTH }
+                                    value={ usernameCurrentPassword }
+                                    onChange={ event => setUsernameCurrentPassword(event.target.value) }
+                                    disabled={ submitting }
                                 />
                                 <button
                                     type="button"
-                                    aria-label={
-                                        showUsernamePassword ? LocalizeText('usersettings.aria.hide_password') : LocalizeText('usersettings.aria.show_password')
-                                    }
-                                    onClick={() => setShowUsernamePassword((prev) => !prev)}
-                                    className="absolute right-2 text-black/40 hover:text-black/70"
-                                >
-                                    {showUsernamePassword ? <FaEyeSlash size={12} /> : <FaEye size={12} />}
+                                    aria-label={ showUsernamePassword ? localizeWithFallback('usersettings.aria.hide_password', "Hide password") : localizeWithFallback('usersettings.aria.show_password', "Show password") }
+                                    onClick={ () => setShowUsernamePassword(prev => !prev) }
+                                    className="absolute right-2 text-black/40 hover:text-black/70">
+                                    { showUsernamePassword ? <FaEyeSlash size={ 12 } /> : <FaEye size={ 12 } /> }
                                 </button>
                             </div>
                         </label>
 
                         <label className="flex flex-col gap-1 text-[12px]">
-                            <span className="font-bold">{LocalizeText('usersettings.field.new_username')}</span>
+                            <span className="font-bold">{ localizeWithFallback('usersettings.field.new_username', "New username") }</span>
                             <div className="relative flex items-center">
-                                <FaIdBadge className="absolute left-2 text-black/40" size={12} />
+                                <FaIdBadge className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type="text"
-                                    className={`w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${newUsername.length > 0 && (!USERNAME_RE.test(newUsername) || newUsername === session.username) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]'}`}
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newUsername.length > 0 && (!USERNAME_RE.test(newUsername) || newUsername === session.username) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
                                     autoComplete="off"
-                                    spellCheck={false}
-                                    maxLength={MAX_USERNAME_LENGTH}
-                                    value={newUsername}
-                                    onChange={(event) => setNewUsername(event.target.value)}
-                                    disabled={submitting}
+                                    spellCheck={ false }
+                                    maxLength={ MAX_USERNAME_LENGTH }
+                                    value={ newUsername }
+                                    onChange={ event => setNewUsername(event.target.value) }
+                                    disabled={ submitting }
                                     placeholder="NewName"
                                 />
-                                {newUsername.length > 0 && USERNAME_RE.test(newUsername) && newUsername !== session.username && (
-                                    <FaCheckCircle className="absolute right-2 text-[#00800b]" size={12} />
-                                )}
+                                { newUsername.length > 0 && USERNAME_RE.test(newUsername) && newUsername !== session.username && (
+                                    <FaCheckCircle className="absolute right-2 text-[#00800b]" size={ 12 } />
+                                ) }
                             </div>
-                            <span className="text-[10px] text-black/50">
-                                {LocalizeText('usersettings.username.rules', ['min', 'max'], [MIN_USERNAME_LENGTH.toString(), MAX_USERNAME_LENGTH.toString()])}
-                            </span>
+                            <span className="text-[10px] text-black/50">{ LocalizeText('usersettings.username.rules', [ 'min', 'max' ], [ MIN_USERNAME_LENGTH.toString(), MAX_USERNAME_LENGTH.toString() ]) }</span>
                         </label>
 
-                        {feedback && (
-                            <div
-                                className={`flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]'}`}
-                            >
-                                {feedback.kind === 'error' ? (
-                                    <FaExclamationTriangle className="mt-[2px] shrink-0" />
-                                ) : (
-                                    <FaCheckCircle className="mt-[2px] shrink-0" />
-                                )}
-                                <span>{feedback.message}</span>
+                        { feedback && (
+                            <div className={ `flex items-start gap-2 rounded-md border px-2 py-2 text-[11px] leading-4 ${ feedback.kind === 'error' ? 'border-[#a81a12]/40 bg-[#a81a12]/10 text-[#7a1109]' : 'border-[#00800b]/40 bg-[#00800b]/10 text-[#005407]' }` }>
+                                { feedback.kind === 'error'
+                                    ? <FaExclamationTriangle className="mt-[2px] shrink-0" />
+                                    : <FaCheckCircle className="mt-[2px] shrink-0" /> }
+                                <span>{ feedback.message }</span>
                             </div>
-                        )}
+                        ) }
 
                         <div className="flex justify-end gap-2 pt-1">
-                            <Button
-                                variant="secondary"
-                                disabled={submitting}
-                                onClick={() => {
-                                    resetForm();
-                                    setSection('menu');
-                                }}
-                            >
-                                {LocalizeText('usersettings.btn.cancel')}
+                            <Button variant="secondary" disabled={ submitting } onClick={ () => { resetForm(); setSection('menu'); } }>
+                                { localizeWithFallback('usersettings.btn.cancel', "Cancel") }
                             </Button>
-                            <Button variant="warning" disabled={submitting} onClick={() => submitUsernameChange()}>
-                                {submitting ? LocalizeText('usersettings.btn.renaming') : LocalizeText('usersettings.btn.rename')}
+                            <Button variant="warning" disabled={ submitting } onClick={ () => submitUsernameChange() }>
+                                { submitting ? localizeWithFallback('usersettings.btn.renaming', "Renaming…") : localizeWithFallback('usersettings.btn.rename', "Rename me") }
                             </Button>
                         </div>
                     </div>
-                )}
+                ) }
             </NitroCardContentView>
         </NitroCardView>
     );

--- a/src/components/user-settings/UserSettingsView.tsx
+++ b/src/components/user-settings/UserSettingsView.tsx
@@ -1,7 +1,7 @@
 import { AddLinkEventTracker, CreateLinkEvent, ILinkEventTracker, NitroSettingsEvent, RemoveLinkEventTracker, UserSettingsCameraFollowComposer, UserSettingsEvent, UserSettingsOldChatComposer, UserSettingsRoomInvitesComposer, UserSettingsSoundComposer } from '@nitrots/nitro-renderer';
 import { FC, useEffect, useState } from 'react';
 import { FaUserCog, FaVolumeDown, FaVolumeMute, FaVolumeUp } from 'react-icons/fa';
-import { DispatchMainEvent, DispatchUiEvent, LocalizeText, localizeWithFallback, SendMessageComposer } from '../../api';
+import { DispatchMainEvent, DispatchUiEvent, LocalizeText, SendMessageComposer } from '../../api';
 import { Button, NitroCardContentView, NitroCardHeaderView, NitroCardView, Text } from '../../common';
 import { useCatalogPlaceMultipleItems, useCatalogSkipPurchaseConfirmation, useChatWindow, useMessageEvent } from '../../hooks';
 import { classNames } from '../../layout';

--- a/src/components/user-settings/UserSettingsView.tsx
+++ b/src/components/user-settings/UserSettingsView.tsx
@@ -1,45 +1,38 @@
-import {
-    AddLinkEventTracker,
-    CreateLinkEvent,
-    ILinkEventTracker,
-    NitroSettingsEvent,
-    RemoveLinkEventTracker,
-    UserSettingsCameraFollowComposer,
-    UserSettingsEvent,
-    UserSettingsOldChatComposer,
-    UserSettingsRoomInvitesComposer,
-    UserSettingsSoundComposer
-} from '@nitrots/nitro-renderer';
+import { AddLinkEventTracker, CreateLinkEvent, ILinkEventTracker, NitroSettingsEvent, RemoveLinkEventTracker, UserSettingsCameraFollowComposer, UserSettingsEvent, UserSettingsOldChatComposer, UserSettingsRoomInvitesComposer, UserSettingsSoundComposer } from '@nitrots/nitro-renderer';
 import { FC, useEffect, useState } from 'react';
 import { FaUserCog, FaVolumeDown, FaVolumeMute, FaVolumeUp } from 'react-icons/fa';
-import { DispatchMainEvent, DispatchUiEvent, LocalizeText, SendMessageComposer } from '../../api';
+import { DispatchMainEvent, DispatchUiEvent, LocalizeText, localizeWithFallback, SendMessageComposer } from '../../api';
 import { Button, NitroCardContentView, NitroCardHeaderView, NitroCardView, Text } from '../../common';
 import { useCatalogPlaceMultipleItems, useCatalogSkipPurchaseConfirmation, useChatWindow, useMessageEvent } from '../../hooks';
 import { classNames } from '../../layout';
 
-const localizeWithFallback = (key: string, fallback: string) => {
+const localizeWithFallback = (key: string, fallback: string) =>
+{
     const text = LocalizeText(key);
-    return text && text !== key ? text : fallback;
+    return (text && text !== key) ? text : fallback;
 };
 
 // null = full window (legacy). 'audio' | 'chat' | 'other' = focused section
 // opened from the purse gear dropdown.
 type SettingsSection = null | 'audio' | 'chat' | 'other';
 
-export const UserSettingsView: FC<{}> = (props) => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [section, setSection] = useState<SettingsSection>(null);
-    const [userSettings, setUserSettings] = useState<NitroSettingsEvent>(null);
-    const [catalogPlaceMultipleObjects, setCatalogPlaceMultipleObjects] = useCatalogPlaceMultipleItems();
-    const [catalogSkipPurchaseConfirmation, setCatalogSkipPurchaseConfirmation] = useCatalogSkipPurchaseConfirmation();
-    const [chatWindowEnabled, setChatWindowEnabled] = useChatWindow();
+export const UserSettingsView: FC<{}> = props =>
+{
+    const [ isVisible, setIsVisible ] = useState(false);
+    const [ section, setSection ] = useState<SettingsSection>(null);
+    const [ userSettings, setUserSettings ] = useState<NitroSettingsEvent>(null);
+    const [ catalogPlaceMultipleObjects, setCatalogPlaceMultipleObjects ] = useCatalogPlaceMultipleItems();
+    const [ catalogSkipPurchaseConfirmation, setCatalogSkipPurchaseConfirmation ] = useCatalogSkipPurchaseConfirmation();
+    const [ chatWindowEnabled, setChatWindowEnabled ] = useChatWindow();
 
-    const processAction = (type: string, value?: boolean | number | string) => {
+    const processAction = (type: string, value?: boolean | number | string) =>
+    {
         let doUpdate = true;
 
         const clone = userSettings.clone();
 
-        switch (type) {
+        switch(type)
+        {
             case 'close_view':
                 setIsVisible(false);
                 doUpdate = false;
@@ -73,26 +66,23 @@ export const UserSettingsView: FC<{}> = (props) => {
                 break;
         }
 
-        if (doUpdate) setUserSettings(clone);
+        if(doUpdate) setUserSettings(clone);
 
         DispatchMainEvent(clone);
     };
 
-    const saveRangeSlider = (type: string) => {
-        switch (type) {
+    const saveRangeSlider = (type: string) =>
+    {
+        switch(type)
+        {
             case 'volume':
-                SendMessageComposer(
-                    new UserSettingsSoundComposer(
-                        Math.round(userSettings.volumeSystem),
-                        Math.round(userSettings.volumeFurni),
-                        Math.round(userSettings.volumeTrax)
-                    )
-                );
+                SendMessageComposer(new UserSettingsSoundComposer(Math.round(userSettings.volumeSystem), Math.round(userSettings.volumeFurni), Math.round(userSettings.volumeTrax)));
                 break;
         }
     };
 
-    useMessageEvent<UserSettingsEvent>(UserSettingsEvent, (event) => {
+    useMessageEvent<UserSettingsEvent>(UserSettingsEvent, event =>
+    {
         const parser = event.getParser();
         const settingsEvent = new NitroSettingsEvent();
 
@@ -109,14 +99,17 @@ export const UserSettingsView: FC<{}> = (props) => {
         DispatchMainEvent(settingsEvent);
     });
 
-    useEffect(() => {
+    useEffect(() =>
+    {
         const linkTracker: ILinkEventTracker = {
-            linkReceived: (url: string) => {
+            linkReceived: (url: string) =>
+            {
                 const parts = url.split('/');
 
-                if (parts.length < 2) return;
+                if(parts.length < 2) return;
 
-                switch (parts[1]) {
+                switch(parts[1])
+                {
                     case 'show':
                         setSection((parts[2] as SettingsSection) || null);
                         setIsVisible(true);
@@ -126,7 +119,7 @@ export const UserSettingsView: FC<{}> = (props) => {
                         return;
                     case 'toggle':
                         setSection((parts[2] as SettingsSection) || null);
-                        setIsVisible((prevValue) => !prevValue);
+                        setIsVisible(prevValue => !prevValue);
                         return;
                 }
             },
@@ -138,199 +131,113 @@ export const UserSettingsView: FC<{}> = (props) => {
         return () => RemoveLinkEventTracker(linkTracker);
     }, []);
 
-    useEffect(() => {
-        if (!userSettings) return;
+    useEffect(() =>
+    {
+        if(!userSettings) return;
 
         DispatchUiEvent(userSettings);
-    }, [userSettings]);
+    }, [ userSettings ]);
 
-    if (!isVisible || !userSettings) return null;
+    if(!isVisible || !userSettings) return null;
 
-    const showChat = section === null || section === 'chat';
-    const showOther = section === null || section === 'other';
-    const showAudio = section === null || section === 'audio';
-    const showAccountLink = section === null;
+    const showChat = (section === null || section === 'chat');
+    const showOther = (section === null || section === 'other');
+    const showAudio = (section === null || section === 'audio');
+    const showAccountLink = (section === null);
 
-    const headerText =
-        section === 'audio'
-            ? localizeWithFallback('widget.memenu.settings.volume', 'Audio settings')
-            : section === 'chat'
-              ? localizeWithFallback('room.chat.settings.title', 'Chat settings')
-              : section === 'other'
+    const headerText = (section === 'audio')
+        ? localizeWithFallback('widget.memenu.settings.volume', 'Audio settings')
+        : (section === 'chat')
+            ? localizeWithFallback('room.chat.settings.title', 'Chat settings')
+            : (section === 'other')
                 ? localizeWithFallback('memenu.settings.other', 'Other settings')
                 : LocalizeText('widget.memenu.settings.title');
 
     return (
-        <NitroCardView
-            className="user-settings-window min-w-0 max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
-            theme="primary-slim"
-            uniqueKey="user-settings"
-        >
-            <NitroCardHeaderView headerText={headerText} onCloseClick={(event) => processAction('close_view')} />
+        <NitroCardView className="user-settings-window min-w-0 max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim" uniqueKey="user-settings">
+            <NitroCardHeaderView headerText={ headerText } onCloseClick={ event => processAction('close_view') } />
             <NitroCardContentView className="text-black">
-                {showChat && (
+                { showChat &&
                     <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={userSettings.oldChat}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => processAction('oldchat', event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.chat.prefer.old.chat')}</Text>
+                            <input checked={ userSettings.oldChat } className="form-check-input" type="checkbox" onChange={ event => processAction('oldchat', event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.chat.prefer.old.chat') }</Text>
                         </div>
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={chatWindowEnabled}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => setChatWindowEnabled(event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.other.enable.chat.window')}</Text>
+                            <input checked={ chatWindowEnabled } className="form-check-input" type="checkbox" onChange={ event => setChatWindowEnabled(event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.other.enable.chat.window') }</Text>
                         </div>
-                    </div>
-                )}
-                {showOther && (
+                    </div> }
+                { showOther &&
                     <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={userSettings.roomInvites}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => processAction('room_invites', event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.other.ignore.room.invites')}</Text>
+                            <input checked={ userSettings.roomInvites } className="form-check-input" type="checkbox" onChange={ event => processAction('room_invites', event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.other.ignore.room.invites') }</Text>
                         </div>
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={userSettings.cameraFollow}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => processAction('camera_follow', event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.other.disable.room.camera.follow')}</Text>
+                            <input checked={ userSettings.cameraFollow } className="form-check-input" type="checkbox" onChange={ event => processAction('camera_follow', event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.other.disable.room.camera.follow') }</Text>
                         </div>
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={catalogPlaceMultipleObjects}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => setCatalogPlaceMultipleObjects(event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.other.place.multiple.objects')}</Text>
+                            <input checked={ catalogPlaceMultipleObjects } className="form-check-input" type="checkbox" onChange={ event => setCatalogPlaceMultipleObjects(event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.other.place.multiple.objects') }</Text>
                         </div>
                         <div className="flex items-center gap-1">
-                            <input
-                                checked={catalogSkipPurchaseConfirmation}
-                                className="form-check-input"
-                                type="checkbox"
-                                onChange={(event) => setCatalogSkipPurchaseConfirmation(event.target.checked)}
-                            />
-                            <Text>{LocalizeText('memenu.settings.other.skip.purchase.confirmation')}</Text>
+                            <input checked={ catalogSkipPurchaseConfirmation } className="form-check-input" type="checkbox" onChange={ event => setCatalogSkipPurchaseConfirmation(event.target.checked) } />
+                            <Text>{ LocalizeText('memenu.settings.other.skip.purchase.confirmation') }</Text>
                         </div>
-                    </div>
-                )}
-                {showAudio && (
+                    </div> }
+                { showAudio &&
                     <div className="flex flex-col">
-                        <Text bold>{LocalizeText('widget.memenu.settings.volume')}</Text>
+                        <Text bold>{ LocalizeText('widget.memenu.settings.volume') }</Text>
                         <div className="flex flex-col gap-1">
-                            <Text>{LocalizeText('widget.memenu.settings.volume.ui')}</Text>
+                            <Text>{ LocalizeText('widget.memenu.settings.volume.ui') }</Text>
                             <div className="flex items-center gap-1">
-                                {userSettings.volumeSystem === 0 && (
-                                    <FaVolumeMute className={classNames(userSettings.volumeSystem >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                {userSettings.volumeSystem > 0 && (
-                                    <FaVolumeDown className={classNames(userSettings.volumeSystem >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                <input
-                                    className="custom-range w-full"
-                                    id="volumeSystem"
-                                    max="100"
-                                    min="0"
-                                    step="1"
-                                    type="range"
-                                    value={userSettings.volumeSystem}
-                                    onChange={(event) => processAction('system_volume', event.target.value)}
-                                    onMouseUp={() => saveRangeSlider('volume')}
-                                />
-                                <FaVolumeUp className={classNames(userSettings.volumeSystem < 50 && 'text-muted', 'fa-icon')} />
+                                { (userSettings.volumeSystem === 0) && <FaVolumeMute className={ classNames((userSettings.volumeSystem >= 50) && 'text-muted', 'fa-icon') } /> }
+                                { (userSettings.volumeSystem > 0) && <FaVolumeDown className={ classNames((userSettings.volumeSystem >= 50) && 'text-muted', 'fa-icon') } /> }
+                                <input className="custom-range w-full" id="volumeSystem" max="100" min="0" step="1" type="range" value={ userSettings.volumeSystem } onChange={ event => processAction('system_volume', event.target.value) } onMouseUp={ () => saveRangeSlider('volume') } />
+                                <FaVolumeUp className={ classNames((userSettings.volumeSystem < 50) && 'text-muted', 'fa-icon') } />
                             </div>
                         </div>
                         <div className="flex flex-col gap-1">
-                            <Text>{LocalizeText('widget.memenu.settings.volume.furni')}</Text>
+                            <Text>{ LocalizeText('widget.memenu.settings.volume.furni') }</Text>
                             <div className="flex items-center gap-1">
-                                {userSettings.volumeFurni === 0 && (
-                                    <FaVolumeMute className={classNames(userSettings.volumeFurni >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                {userSettings.volumeFurni > 0 && (
-                                    <FaVolumeDown className={classNames(userSettings.volumeFurni >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                <input
-                                    className="custom-range w-full"
-                                    id="volumeFurni"
-                                    max="100"
-                                    min="0"
-                                    step="1"
-                                    type="range"
-                                    value={userSettings.volumeFurni}
-                                    onChange={(event) => processAction('furni_volume', event.target.value)}
-                                    onMouseUp={() => saveRangeSlider('volume')}
-                                />
-                                <FaVolumeUp className={classNames(userSettings.volumeFurni < 50 && 'text-muted', 'fa-icon')} />
+                                { (userSettings.volumeFurni === 0) && <FaVolumeMute className={ classNames((userSettings.volumeFurni >= 50) && 'text-muted', 'fa-icon') } /> }
+                                { (userSettings.volumeFurni > 0) && <FaVolumeDown className={ classNames((userSettings.volumeFurni >= 50) && 'text-muted', 'fa-icon') } /> }
+                                <input className="custom-range w-full" id="volumeFurni" max="100" min="0" step="1" type="range" value={ userSettings.volumeFurni } onChange={ event => processAction('furni_volume', event.target.value) } onMouseUp={ () => saveRangeSlider('volume') } />
+                                <FaVolumeUp className={ classNames((userSettings.volumeFurni < 50) && 'text-muted', 'fa-icon') } />
                             </div>
                         </div>
                         <div className="flex flex-col gap-1">
-                            <Text>{LocalizeText('widget.memenu.settings.volume.trax')}</Text>
+                            <Text>{ LocalizeText('widget.memenu.settings.volume.trax') }</Text>
                             <div className="flex items-center gap-1">
-                                {userSettings.volumeTrax === 0 && (
-                                    <FaVolumeMute className={classNames(userSettings.volumeTrax >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                {userSettings.volumeTrax > 0 && (
-                                    <FaVolumeDown className={classNames(userSettings.volumeTrax >= 50 && 'text-muted', 'fa-icon')} />
-                                )}
-                                <input
-                                    className="custom-range w-full"
-                                    id="volumeTrax"
-                                    max="100"
-                                    min="0"
-                                    step="1"
-                                    type="range"
-                                    value={userSettings.volumeTrax}
-                                    onChange={(event) => processAction('trax_volume', event.target.value)}
-                                    onMouseUp={() => saveRangeSlider('volume')}
-                                />
-                                <FaVolumeUp className={classNames(userSettings.volumeTrax < 50 && 'text-muted', 'fa-icon')} />
+                                { (userSettings.volumeTrax === 0) && <FaVolumeMute className={ classNames((userSettings.volumeTrax >= 50) && 'text-muted', 'fa-icon') } /> }
+                                { (userSettings.volumeTrax > 0) && <FaVolumeDown className={ classNames((userSettings.volumeTrax >= 50) && 'text-muted', 'fa-icon') } /> }
+                                <input className="custom-range w-full" id="volumeTrax" max="100" min="0" step="1" type="range" value={ userSettings.volumeTrax } onChange={ event => processAction('trax_volume', event.target.value) } onMouseUp={ () => saveRangeSlider('volume') } />
+                                <FaVolumeUp className={ classNames((userSettings.volumeTrax < 50) && 'text-muted', 'fa-icon') } />
                             </div>
                         </div>
-                    </div>
-                )}
-                {showAccountLink && (
+                    </div> }
+                { showAccountLink &&
                     <div className="flex flex-col pt-2 mt-1 border-t border-black/10">
                         <button
                             type="button"
-                            onClick={() => CreateLinkEvent('user-account-settings/show')}
-                            className="group flex items-center gap-2 rounded-md border border-black/10 bg-white px-2 py-1.5 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left"
-                        >
+                            onClick={ () => CreateLinkEvent('user-account-settings/show') }
+                            className="group flex items-center gap-2 rounded-md border border-black/10 bg-white px-2 py-1.5 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left">
                             <div className="flex items-center justify-center w-7 h-7 rounded-full bg-[#1e7295] text-white shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
-                                <FaUserCog size={12} />
+                                <FaUserCog size={ 12 } />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
-                                <Text bold>{LocalizeText('usersettings.open.title')}</Text>
-                                <Text small className="text-black/60">
-                                    {LocalizeText('usersettings.open.subtitle')}
-                                </Text>
+                                <Text bold>{ localizeWithFallback('usersettings.open.title', "User Settings") }</Text>
+                                <Text small className="text-black/60">{ localizeWithFallback('usersettings.open.subtitle', "Password and account") }</Text>
                             </div>
                             <span className="text-black/30 group-hover:text-[#1e7295] text-[10px]">›</span>
                         </button>
-                    </div>
-                )}
-                {section !== null && (
+                    </div> }
+                { (section !== null) &&
                     <div className="flex pt-2 mt-1 border-t border-black/10">
-                        <Button variant="secondary" onClick={(event) => processAction('close_view')}>
-                            {localizeWithFallback('generic.back', 'Indietro')}
-                        </Button>
-                    </div>
-                )}
+                        <Button variant="secondary" onClick={ event => processAction('close_view') }>{ localizeWithFallback('generic.back', 'Indietro') }</Button>
+                    </div> }
             </NitroCardContentView>
         </NitroCardView>
     );


### PR DESCRIPTION
## What
Routes the **simple** `usersettings.*` UI strings in the account-settings views through `localizeWithFallback(key, 'English')` (same helper already used elsewhere in the purse), so a missing localization key falls back to English instead of showing the raw key. The 7 calls that use parameter substitution (`%count%`, `%min%`, `%max%`, `%status%`) stay on `LocalizeText`, which `localizeWithFallback` doesn't support.

## Note on diff size
These two views are heavily reformatted on this fork's `main` vs `Dev`; this PR brings the fork's version of the files (formatting + the fallback change), hence the large diff. The functional change is the 63 `LocalizeText('usersettings.*')` → `localizeWithFallback('usersettings.*', '<English>')` conversions.