### PR TITLE
fix(i18n): localize hardcoded Italian strings (toolbar/catalog/wired)

### DIFF
--- a/src/components/catalog/views/catalog-header/CatalogBuildersClubStatusView.tsx
+++ b/src/components/catalog/views/catalog-header/CatalogBuildersClubStatusView.tsx
@@ -1,75 +1,87 @@
 import { GetTickerTime } from '@nitrots/nitro-renderer';
 import { FC, useEffect, useMemo, useState } from 'react';
-import { CatalogType, FriendlyTime, GetConfigurationValue, LocalizeText } from '../../../../api';
+import { CatalogType, FriendlyTime, GetConfigurationValue, LocalizeText , localizeWithFallback} from '../../../../api';
 import buildersClubIcon from '../../../../assets/images/toolbar/icons/buildersclub.png';
 import { useCatalogData, useCatalogUiState } from '../../../../hooks';
 
-export const CatalogBuildersClubStatusView: FC = () => {
+export const CatalogBuildersClubStatusView: FC = () =>
+{
     const { furniCount = 0, furniLimit = 0, secondsLeft = 0, secondsLeftWithGrace = 0, updateTime = 0 } = useCatalogData();
     const { currentType = CatalogType.NORMAL } = useCatalogUiState();
-    const [ticker, setTicker] = useState(() => GetTickerTime());
-    const buildersClubEnabled = useMemo(
-        () => GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true)),
-        []
-    );
+    const [ ticker, setTicker ] = useState(() => GetTickerTime());
+    const buildersClubEnabled = useMemo(() => GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true)), []);
 
-    useEffect(() => {
-        if (currentType !== CatalogType.BUILDER) return;
+    useEffect(() =>
+    {
+        if(currentType !== CatalogType.BUILDER) return;
 
         const interval = window.setInterval(() => setTicker(GetTickerTime()), 1000);
 
         return () => window.clearInterval(interval);
-    }, [currentType]);
+    }, [ currentType ]);
 
-    const localizeOrDefault = (key: string, fallback: string, parameters: string[] = [], values: string[] = []) => {
+    const localizeOrDefault = (key: string, fallback: string, parameters: string[] = [], values: string[] = []) =>
+    {
         const localized = LocalizeText(key, parameters, values);
 
-        return localized && localized !== key ? localized : fallback;
+        return ((localized && (localized !== key)) ? localized : fallback);
     };
 
-    const remainingSeconds = useMemo(() => {
-        const baseSeconds = secondsLeft > 0 ? secondsLeft : secondsLeftWithGrace;
+    const remainingSeconds = useMemo(() =>
+    {
+        const baseSeconds = (secondsLeft > 0) ? secondsLeft : secondsLeftWithGrace;
 
-        if (baseSeconds <= 0) return 0;
+        if(baseSeconds <= 0) return 0;
 
-        const elapsed = updateTime > 0 ? Math.floor((ticker - updateTime) / 1000) : 0;
+        const elapsed = ((updateTime > 0) ? Math.floor((ticker - updateTime) / 1000) : 0);
 
-        return Math.max(0, baseSeconds - elapsed);
-    }, [secondsLeft, secondsLeftWithGrace, ticker, updateTime]);
+        return Math.max(0, (baseSeconds - elapsed));
+    }, [ secondsLeft, secondsLeftWithGrace, ticker, updateTime ]);
 
-    const isFullMember = secondsLeft > 0;
+    const isFullMember = (secondsLeft > 0);
     const membershipStatus = localizeOrDefault(
         isFullMember ? 'builder.header.status.member' : 'builder.header.status.trial',
-        isFullMember ? 'Membro Completo' : 'Prova Gratuita'
+        isFullMember ? localizeWithFallback('catalog.bc.member.full', 'Full Member') : localizeWithFallback('catalog.bc.member.trial', 'Free Trial')
     );
 
-    const title = localizeOrDefault('builder.header.title', `Stato Builders' Club: ${membershipStatus}`, ['BCSTATUS'], [membershipStatus]);
+    const title = localizeOrDefault(
+        'builder.header.title',
+        `Stato Builders' Club: ${ membershipStatus }`,
+        [ 'BCSTATUS' ],
+        [ membershipStatus ]
+    );
 
     const durationText = localizeOrDefault(
         'builder.header.status.membership',
-        `Tempo mancante: ${FriendlyTime.format(remainingSeconds)}`,
-        ['DURATION'],
-        [FriendlyTime.format(remainingSeconds)]
+        `Tempo mancante: ${ FriendlyTime.format(remainingSeconds) }`,
+        [ 'DURATION' ],
+        [ FriendlyTime.format(remainingSeconds) ]
     );
 
     const limitText = localizeOrDefault(
         'builder.header.status.limit',
-        `Furni usati: ${furniCount}/${furniLimit}`,
-        ['COUNT', 'LIMIT'],
-        [furniCount.toString(), furniLimit.toString()]
+        `Furni usati: ${ furniCount }/${ furniLimit }`,
+        [ 'COUNT', 'LIMIT' ],
+        [ furniCount.toString(), furniLimit.toString() ]
     );
 
-    if (!buildersClubEnabled || currentType !== CatalogType.BUILDER) return null;
+    if(!buildersClubEnabled || (currentType !== CatalogType.BUILDER)) return null;
 
     return (
         <div className="builders-club-status-shell flex items-center gap-3 px-4 py-3">
             <div className="builders-club-status-icon-shell flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-md">
-                <img alt="" className="h-[28px] w-[28px] object-contain" src={buildersClubIcon} />
+                <img alt="" className="h-[28px] w-[28px] object-contain" src={ buildersClubIcon } />
             </div>
             <div className="flex min-w-0 flex-1 flex-col">
-                <span className="truncate text-[13px] leading-none font-bold text-white">{title}</span>
-                <span className="mt-1 text-[11px] leading-tight text-white/95">{durationText}</span>
-                <span className="text-[11px] leading-tight text-[#ffba45]">{limitText}</span>
+                <span className="truncate text-[13px] leading-none font-bold text-white">
+                    { title }
+                </span>
+                <span className="mt-1 text-[11px] leading-tight text-white/95">
+                    { durationText }
+                </span>
+                <span className="text-[11px] leading-tight text-[#ffba45]">
+                    { limitText }
+                </span>
             </div>
         </div>
     );

--- a/src/components/catalog/views/page/layout/CatalogLayoutBcInfoView.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutBcInfoView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from 'react';
-import { SanitizeHtml } from '../../../../../api';
+import { SanitizeHtml , localizeWithFallback} from '../../../../../api';
 import { CatalogLayoutProps } from './CatalogLayout.types';
 
 // Info/landing layout: a logo box on top (image scaled to fit the available
@@ -7,27 +7,29 @@ import { CatalogLayoutProps } from './CatalogLayout.types';
 // Logo = page headline image (getImage(0)), text = page text 1 (getText(0)),
 // set from catalog admin (Gestione -> Modifica pagina). Hides the (empty)
 // navigation sidebar so the content uses the full width.
-export const CatalogLayoutBcInfoView: FC<CatalogLayoutProps> = (props) => {
+export const CatalogLayoutBcInfoView: FC<CatalogLayoutProps> = props =>
+{
     const { page = null, hideNavigation = null } = props;
 
     const logo = page?.localization?.getImage(0) || '';
     const text = page?.localization?.getText(0) || '';
 
-    useEffect(() => {
+    useEffect(() =>
+    {
         hideNavigation?.();
-    }, [page, hideNavigation]);
+    }, [ page, hideNavigation ]);
 
     return (
         <div className="flex flex-col h-full gap-2">
             <div className="flex-1 min-h-0 bg-white rounded border border-card-grid-item-border overflow-hidden flex items-center justify-center">
-                {logo ? (
-                    <img alt="" className="max-w-full max-h-full object-contain" src={logo} />
-                ) : (
-                    <span className="text-muted text-[11px]">Logo — imposta l'immagine headline da Gestione</span>
-                )}
+                { logo
+                    ? <img alt="" className="max-w-full max-h-full object-contain" src={ logo } />
+                    : <span className="text-muted text-[11px]">{ localizeWithFallback('catalog.bc.logo.hint', 'Logo — set the headline image in Management') }</span> }
             </div>
             <div className="shrink-0 max-h-[32%] bg-white rounded border border-card-grid-item-border p-3 overflow-auto">
-                <div className="text-black text-[12px] leading-snug" dangerouslySetInnerHTML={{ __html: SanitizeHtml(text) }} />
+                <div
+                    className="text-black text-[12px] leading-snug"
+                    dangerouslySetInnerHTML={ { __html: SanitizeHtml(text) } } />
             </div>
         </div>
     );

--- a/src/components/toolbar/ToolbarView.tsx
+++ b/src/components/toolbar/ToolbarView.tsx
@@ -1,44 +1,9 @@
-import {
-    CreateLinkEvent,
-    Dispose,
-    DropBounce,
-    EaseOut,
-    FindNewFriendsMessageComposer,
-    JumpBy,
-    Motions,
-    NitroToolbarAnimateIconEvent,
-    PerkAllowancesMessageEvent,
-    PerkEnum,
-    Queue,
-    Wait,
-    YouTubeRoomSettingsEvent
-} from '@nitrots/nitro-renderer';
+import { CreateLinkEvent, Dispose, DropBounce, EaseOut, FindNewFriendsMessageComposer, JumpBy, Motions, NitroToolbarAnimateIconEvent, PerkAllowancesMessageEvent, PerkEnum, Queue, Wait, YouTubeRoomSettingsEvent } from '@nitrots/nitro-renderer';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import { FC, useEffect, useMemo, useState } from 'react';
-import {
-    GetConfigurationValue,
-    isHousekeepingEnabled,
-    MessengerIconState,
-    OpenMessengerChat,
-    SendMessageComposer,
-    setYoutubeRoomEnabled,
-    VisitDesktop
-} from '../../api';
+import { GetConfigurationValue, isHousekeepingEnabled, MessengerIconState, OpenMessengerChat, SendMessageComposer, setYoutubeRoomEnabled, VisitDesktop , localizeWithFallback} from '../../api';
 import { Flex, LayoutAvatarImageView, LayoutItemCountView } from '../../common';
-import {
-    useAchievements,
-    useFriends,
-    useHasPermission,
-    useInventoryUnseenTracker,
-    useMentionsSnapshot,
-    useMessageEvent,
-    useMessenger,
-    useModTools,
-    useNitroEvent,
-    useSessionInfo,
-    useSoundboard,
-    useWiredTools
-} from '../../hooks';
+import { useAchievements, useFriends, useHasPermission, useInventoryUnseenTracker, useMentionsSnapshot, useMessageEvent, useMessenger, useModTools, useNitroEvent, useSessionInfo, useSoundboard, useWiredTools } from '../../hooks';
 import { ToolbarItemView } from './ToolbarItemView';
 import { ToolbarMeView } from './ToolbarMeView';
 import { YouTubePlayerView } from './YouTubePlayerView';
@@ -61,15 +26,16 @@ const SHELL_TRANSITION = { type: 'spring' as const, stiffness: 260, damping: 26 
 const NAV_TRANSITION = { type: 'spring' as const, stiffness: 300, damping: 28 };
 const ME_POPOVER_TRANSITION = { type: 'spring' as const, stiffness: 420, damping: 28 };
 
-export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
+export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
+{
     const { isInRoom } = props;
-    const [isMeExpanded, setMeExpanded] = useState(false);
-    const [isTouchLayout, setIsTouchLayout] = useState(false);
-    const [leftCollapsed, setLeftCollapsed] = useState(false);
-    const [rightCollapsed, setRightCollapsed] = useState(false);
-    const [staffStackBottom, setStaffStackBottom] = useState<number | null>(null);
-    const [useGuideTool, setUseGuideTool] = useState(false);
-    const [youtubeEnabled, setYoutubeEnabled] = useState(false);
+    const [ isMeExpanded, setMeExpanded ] = useState(false);
+    const [ isTouchLayout, setIsTouchLayout ] = useState(false);
+    const [ leftCollapsed, setLeftCollapsed ] = useState(false);
+    const [ rightCollapsed, setRightCollapsed ] = useState(false);
+    const [ staffStackBottom, setStaffStackBottom ] = useState<number | null>(null);
+    const [ useGuideTool, setUseGuideTool ] = useState(false);
+    const [ youtubeEnabled, setYoutubeEnabled ] = useState(false);
     const { userFigure = null } = useSessionInfo();
     const { getFullCount = 0 } = useInventoryUnseenTracker();
     const { getTotalUnseen = 0 } = useAchievements();
@@ -77,10 +43,7 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
     const { iconState = MessengerIconState.HIDDEN } = useMessenger();
     const { unreadCount: mentionsUnread = 0 } = useMentionsSnapshot();
     const mentionsEnabled = useMemo(() => GetConfigurationValue<boolean>('mentions_ui.enabled', true), []);
-    const buildersClubEnabled = useMemo(
-        () => GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true)),
-        []
-    );
+    const buildersClubEnabled = useMemo(() => GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true)), []);
     const rareValuesEnabled = useMemo(() => GetConfigurationValue<boolean>('toolbar.rarevalues.enabled', true), []);
     const fortuneWheelEnabled = useMemo(() => GetConfigurationValue<boolean>('toolbar.fortunewheel.enabled', true), []);
     const { openMonitor, showToolbarButton } = useWiredTools();
@@ -89,50 +52,48 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
     const isHk = useHasPermission('acc_housekeeping');
     const hkEnabled = useMemo(() => isHousekeepingEnabled(), []);
     const { tickets = [] } = useModTools();
-    const openTicketsCount = useMemo(() => (isMod ? tickets.filter((ticket) => ticket && ticket.state === 1).length : 0), [isMod, tickets]);
+    const openTicketsCount = useMemo(
+        () => isMod ? tickets.filter(ticket => ticket && (ticket.state === 1)).length : 0,
+        [ isMod, tickets ]
+    );
     const visibilityVariant = 'visible';
 
     const compactFramePosition = 'bottom-[90px] min-[1700px]:bottom-[7px]';
     const mobileOnlyClasses = isTouchLayout ? '' : 'min-[1700px]:hidden';
     const desktopBlockClasses = isTouchLayout ? 'hidden' : 'hidden min-[1700px]:block';
     const desktopFlexClasses = isTouchLayout ? 'hidden' : 'hidden min-[1700px]:flex';
-    const leftNavVariants = useMemo<Variants>(
-        () => ({
-            hidden: { opacity: 0, x: isInRoom ? -10 : 0, y: isInRoom ? 0 : 8, pointerEvents: 'none' },
-            visible: { opacity: 1, x: 0, y: 0, pointerEvents: 'auto' }
-        }),
-        [isInRoom]
-    );
-    const rightNavVariants = useMemo<Variants>(
-        () => ({
-            hidden: { opacity: 0, x: 10, pointerEvents: 'none' },
-            visible: { opacity: 1, x: 0, pointerEvents: 'auto' }
-        }),
-        []
-    );
-    const mobileNavVariants = useMemo<Variants>(
-        () => ({
-            hidden: { opacity: 0, y: 8, pointerEvents: 'none' },
-            visible: { opacity: 1, y: 0, pointerEvents: 'auto' }
-        }),
-        []
-    );
+    const leftNavVariants = useMemo<Variants>(() => ({
+        hidden: { opacity: 0, x: isInRoom ? -10 : 0, y: isInRoom ? 0 : 8, pointerEvents: 'none' },
+        visible: { opacity: 1, x: 0, y: 0, pointerEvents: 'auto' }
+    }), [ isInRoom ]);
+    const rightNavVariants = useMemo<Variants>(() => ({
+        hidden: { opacity: 0, x: 10, pointerEvents: 'none' },
+        visible: { opacity: 1, x: 0, pointerEvents: 'auto' }
+    }), []);
+    const mobileNavVariants = useMemo<Variants>(() => ({
+        hidden: { opacity: 0, y: 8, pointerEvents: 'none' },
+        visible: { opacity: 1, y: 0, pointerEvents: 'auto' }
+    }), []);
 
-    useMessageEvent<YouTubeRoomSettingsEvent>(YouTubeRoomSettingsEvent, (event) => {
+    useMessageEvent<YouTubeRoomSettingsEvent>(YouTubeRoomSettingsEvent, event =>
+    {
         const enabled = event.getParser().youtubeEnabled;
         setYoutubeEnabled(enabled);
         setYoutubeRoomEnabled(enabled);
     });
 
-    useEffect(() => {
-        if (!isInRoom) {
+    useEffect(() =>
+    {
+        if(!isInRoom)
+        {
             setYoutubeEnabled(false);
             setYoutubeRoomEnabled(false);
             resetSoundboard();
         }
-    }, [isInRoom, resetSoundboard]);
+    }, [ isInRoom, resetSoundboard ]);
 
-    useEffect(() => {
+    useEffect(() =>
+    {
         const query = window.matchMedia('(pointer: coarse), (hover: none)');
         const updateTouchLayout = () => setIsTouchLayout(query.matches);
 
@@ -145,12 +106,16 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
     // Keep the left staff-tools stack pinned 15px above the room tools rail
     // (its height is dynamic, so measure it). Falls back to null (CSS
     // default) when the room tools aren't present, e.g. outside a room.
-    useEffect(() => {
-        const measure = () => {
+    useEffect(() =>
+    {
+        const measure = () =>
+        {
             const roomTools = document.querySelector('.nitro-room-tools-container') as HTMLElement | null;
-            const next = roomTools ? Math.max(8, Math.round(window.innerHeight - roomTools.getBoundingClientRect().top + 15)) : null;
+            const next = roomTools
+                ? Math.max(8, Math.round(window.innerHeight - roomTools.getBoundingClientRect().top + 15))
+                : null;
 
-            setStaffStackBottom((prevValue) => (prevValue === next ? prevValue : next));
+            setStaffStackBottom(prevValue => (prevValue === next ? prevValue : next));
         };
 
         measure();
@@ -158,48 +123,50 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
         const interval = window.setInterval(measure, 400);
         window.addEventListener('resize', measure);
 
-        return () => {
+        return () =>
+        {
             window.clearInterval(interval);
             window.removeEventListener('resize', measure);
         };
-    }, [isInRoom]);
+    }, [ isInRoom ]);
 
     const openYouTubePlayer = () => window.dispatchEvent(new CustomEvent('youtube:toggle'));
 
-    useMessageEvent<PerkAllowancesMessageEvent>(PerkAllowancesMessageEvent, (event) => {
+    useMessageEvent<PerkAllowancesMessageEvent>(PerkAllowancesMessageEvent, event =>
+    {
         setUseGuideTool(event.getParser().isAllowed(PerkEnum.USE_GUIDE_TOOL));
     });
 
-    useNitroEvent<NitroToolbarAnimateIconEvent>(NitroToolbarAnimateIconEvent.ANIMATE_ICON, (event) => {
-        const animationIconToToolbar = (iconName: string, image: HTMLImageElement, x: number, y: number) => {
-            const target = document.body.getElementsByClassName(iconName)[0] as HTMLElement;
+    useNitroEvent<NitroToolbarAnimateIconEvent>(NitroToolbarAnimateIconEvent.ANIMATE_ICON, event =>
+    {
+        const animationIconToToolbar = (iconName: string, image: HTMLImageElement, x: number, y: number) =>
+        {
+            const target = (document.body.getElementsByClassName(iconName)[0] as HTMLElement);
 
-            if (!target) return;
+            if(!target) return;
 
             image.className = 'toolbar-icon-animation';
             image.style.visibility = 'visible';
-            image.style.left = x + 'px';
-            image.style.top = y + 'px';
+            image.style.left = (x + 'px');
+            image.style.top = (y + 'px');
 
             document.body.append(image);
 
             const targetBounds = target.getBoundingClientRect();
             const imageBounds = image.getBoundingClientRect();
-            const left = imageBounds.x - targetBounds.x;
-            const top = imageBounds.y - targetBounds.y;
-            const squared = Math.sqrt(left * left + top * top);
-            const wait = 500 - Math.abs((1 / squared) * 100 * 500 * 0.5);
+            const left = (imageBounds.x - targetBounds.x);
+            const top = (imageBounds.y - targetBounds.y);
+            const squared = Math.sqrt(((left * left) + (top * top)));
+            const wait = (500 - Math.abs(((((1 / squared) * 100) * 500) * 0.5)));
             const height = 20;
-            const motionName = `ToolbarBouncing[${iconName}]`;
+            const motionName = (`ToolbarBouncing[${ iconName }]`);
 
-            if (!Motions.getMotionByTag(motionName)) {
-                Motions.runMotion(new Queue(new Wait(wait + 8), new DropBounce(target, 400, 12))).tag = motionName;
+            if(!Motions.getMotionByTag(motionName))
+            {
+                Motions.runMotion(new Queue(new Wait((wait + 8)), new DropBounce(target, 400, 12))).tag = motionName;
             }
 
-            const motion = new Queue(
-                new EaseOut(new JumpBy(image, wait, targetBounds.x - imageBounds.x + height, targetBounds.y - imageBounds.y, 100, 1), 1),
-                new Dispose(image)
-            );
+            const motion = new Queue(new EaseOut(new JumpBy(image, wait, ((targetBounds.x - imageBounds.x) + height), (targetBounds.y - imageBounds.y), 100, 1), 1), new Dispose(image));
 
             Motions.runMotion(motion);
         };
@@ -209,356 +176,306 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = (props) => {
 
     return (
         <>
-            {youtubeEnabled && <YouTubePlayerView />}
+            { youtubeEnabled && <YouTubePlayerView /> }
 
-            {isInRoom && (
-                <div
-                    className={`tb-frame fixed ${compactFramePosition} left-1/2 -translate-x-1/2 z-40 flex h-[38px] w-[420px] max-w-[95vw] items-center px-[6px] py-[4px] pointer-events-none`}
-                >
+            { isInRoom &&
+                <div className={ `tb-frame fixed ${ compactFramePosition } left-1/2 -translate-x-1/2 z-40 flex h-[38px] w-[420px] max-w-[95vw] items-center px-[6px] py-[4px] pointer-events-none` }>
                     <Flex
                         alignItems="center"
                         justifyContent="center"
                         className="pointer-events-auto h-full w-full min-w-0 flex-1"
-                        id="toolbar-chat-input-container"
-                    />
-                </div>
-            )}
+                        id="toolbar-chat-input-container" />
+                </div> }
 
             <motion.div
                 initial="visible"
-                animate={visibilityVariant}
-                variants={shellVariants}
-                transition={SHELL_TRANSITION}
-                className={`pointer-events-none fixed bottom-0 left-0 right-0 z-[39] h-[52px] rounded-t-[12px] border border-b-0 border-white/8 bg-[rgba(62,64,72,0.55)] shadow-[0_-6px_18px_rgba(0,0,0,0.18)] ${desktopBlockClasses}`}
-            />
+                animate={ visibilityVariant }
+                variants={ shellVariants }
+                transition={ SHELL_TRANSITION }
+                className={ `pointer-events-none fixed bottom-0 left-0 right-0 z-[39] h-[52px] rounded-t-[12px] border border-b-0 border-white/8 bg-[rgba(62,64,72,0.55)] shadow-[0_-6px_18px_rgba(0,0,0,0.18)] ${ desktopBlockClasses }` } />
 
             <motion.div
                 initial="visible"
-                animate={visibilityVariant}
-                variants={leftNavVariants}
-                transition={NAV_TRANSITION}
-                className={`tb-nav-clip fixed bottom-0 left-0 z-40 h-[52px] max-w-[calc(50vw-242px)] items-center pl-3 ${desktopFlexClasses}`}
-            >
+                animate={ visibilityVariant }
+                variants={ leftNavVariants }
+                transition={ NAV_TRANSITION }
+                className={ `tb-nav-clip fixed bottom-0 left-0 z-40 h-[52px] max-w-[calc(50vw-242px)] items-center pl-3 ${ desktopFlexClasses }` }>
                 <button
                     type="button"
-                    onClick={() => setLeftCollapsed((value) => !value)}
-                    aria-label="Mostra/Nascondi icone"
-                    className="tb-collapse pointer-events-auto mt-[6px] mr-[3px]"
-                >
+                    onClick={ () => setLeftCollapsed(value => !value) }
+                    aria-label={ localizeWithFallback('toolbar.icons.toggle', 'Show/hide icons') }
+                    className="tb-collapse pointer-events-auto mt-[6px] mr-[3px]">
                     <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d={leftCollapsed ? 'M9 5l7 7-7 7' : 'M15 19l-7-7 7-7'} />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={ 3 } d={ leftCollapsed ? 'M9 5l7 7-7 7' : 'M15 19l-7-7 7-7' } />
                     </svg>
                 </button>
                 <motion.div
-                    variants={containerVariants}
-                    className="tb-open-shell flex h-[52px] max-w-full items-center gap-2 overflow-visible bg-transparent px-[8px] pt-[10px] pb-[2px]"
-                >
-                    {!leftCollapsed && (
-                        <>
-                            <motion.div variants={itemVariants}>
-                                {isInRoom ? (
-                                    <ToolbarItemView icon="habbo" onClick={() => VisitDesktop()} className="tb-icon" />
-                                ) : (
-                                    <ToolbarItemView icon="house" onClick={() => CreateLinkEvent('navigator/goto/home')} className="tb-icon" />
-                                )}
-                            </motion.div>
-                            <motion.div variants={itemVariants}>
-                                <ToolbarItemView icon="rooms" onClick={() => CreateLinkEvent('navigator/toggle')} className="tb-icon" />
-                            </motion.div>
-                            {GetConfigurationValue('game.center.enabled') && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="game" onClick={() => CreateLinkEvent('games/toggle')} className="tb-icon" />
-                                </motion.div>
-                            )}
-                        </>
-                    )}
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="catalog" onClick={() => CreateLinkEvent('catalog/toggle/normal')} className="tb-icon" />
+                    variants={ containerVariants }
+                    className="tb-open-shell flex h-[52px] max-w-full items-center gap-2 overflow-visible bg-transparent px-[8px] pt-[10px] pb-[2px]">
+                    { !leftCollapsed && (<>
+                    <motion.div variants={ itemVariants }>
+                        { isInRoom
+                            ? <ToolbarItemView icon="habbo" onClick={ () => VisitDesktop() } className="tb-icon" />
+                            : <ToolbarItemView icon="house" onClick={ () => CreateLinkEvent('navigator/goto/home') } className="tb-icon" /> }
                     </motion.div>
-                    <motion.div variants={itemVariants} className="relative">
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="rooms" onClick={ () => CreateLinkEvent('navigator/toggle') } className="tb-icon" />
+                    </motion.div>
+                    { GetConfigurationValue('game.center.enabled') &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="game" onClick={ () => CreateLinkEvent('games/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    </>) }
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="catalog" onClick={ () => CreateLinkEvent('catalog/toggle/normal') } className="tb-icon" />
+                    </motion.div>
+                    <motion.div variants={ itemVariants } className="relative">
                         <AnimatePresence>
-                            {isMeExpanded && (
+                            { isMeExpanded &&
                                 <motion.div
-                                    initial={{ opacity: 0, y: 6, scale: 0.97 }}
-                                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                                    exit={{ opacity: 0, y: 6, scale: 0.97 }}
-                                    transition={ME_POPOVER_TRANSITION}
-                                    className="pointer-events-auto absolute bottom-[calc(100%+8px)] left-1/2 z-50 -translate-x-1/2"
-                                >
-                                    <ToolbarMeView setMeExpanded={setMeExpanded} unseenAchievementCount={getTotalUnseen} useGuideTool={useGuideTool} />
-                                </motion.div>
-                            )}
+                                    initial={ { opacity: 0, y: 6, scale: 0.97 } }
+                                    animate={ { opacity: 1, y: 0, scale: 1 } }
+                                    exit={ { opacity: 0, y: 6, scale: 0.97 } }
+                                    transition={ ME_POPOVER_TRANSITION }
+                                    className="pointer-events-auto absolute bottom-[calc(100%+8px)] left-1/2 z-50 -translate-x-1/2">
+                                    <ToolbarMeView setMeExpanded={ setMeExpanded } unseenAchievementCount={ getTotalUnseen } useGuideTool={ useGuideTool } />
+                                </motion.div> }
                         </AnimatePresence>
                         <motion.div
                             className="cursor-pointer relative h-[40px] w-[40px] overflow-hidden"
-                            whileHover={{ scale: 1.08 }}
-                            whileTap={{ scale: 0.95 }}
-                            onClick={(event) => {
-                                setMeExpanded((value) => !value);
+                            whileHover={ { scale: 1.08 } }
+                            whileTap={ { scale: 0.95 } }
+                            onClick={ event =>
+                            {
+                                setMeExpanded(value => !value);
                                 event.stopPropagation();
-                            }}
-                        >
-                            <LayoutAvatarImageView headOnly={true} direction={2} figure={userFigure} className="tb-icon tb-avatar-head" />
+                            } }>
+                            <LayoutAvatarImageView headOnly={ true } direction={ 2 } figure={ userFigure } className="tb-icon tb-avatar-head" />
                         </motion.div>
-                        {getTotalUnseen > 0 && <LayoutItemCountView count={getTotalUnseen} className="pointer-events-none absolute -right-1 -top-1 z-10" />}
+                        { (getTotalUnseen > 0) &&
+                            <LayoutItemCountView count={ getTotalUnseen } className="pointer-events-none absolute -right-1 -top-1 z-10" /> }
                     </motion.div>
-                    {buildersClubEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="buildersclub" onClick={() => CreateLinkEvent('catalog/toggle/builder')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    <motion.div variants={itemVariants} className="relative">
-                        <ToolbarItemView icon="inventory" onClick={() => CreateLinkEvent('inventory/toggle')} className="tb-icon" />
-                        {getFullCount > 0 && <LayoutItemCountView count={getFullCount} className="absolute -right-1 top-0" />}
+                    { buildersClubEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="buildersclub" onClick={ () => CreateLinkEvent('catalog/toggle/builder') } className="tb-icon" />
+                        </motion.div> }
+                    <motion.div variants={ itemVariants } className="relative">
+                        <ToolbarItemView icon="inventory" onClick={ () => CreateLinkEvent('inventory/toggle') } className="tb-icon" />
+                        { (getFullCount > 0) &&
+                            <LayoutItemCountView count={ getFullCount } className="absolute -right-1 top-0" /> }
                     </motion.div>
-                    {!leftCollapsed && (
-                        <>
-                            {rareValuesEnabled && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="rare-values" onClick={() => CreateLinkEvent('rare-values/toggle')} className="tb-icon" />
-                                </motion.div>
-                            )}
-                            {fortuneWheelEnabled && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="fortune-wheel" onClick={() => CreateLinkEvent('fortune-wheel/toggle')} className="tb-icon" />
-                                </motion.div>
-                            )}
-                            {isInRoom && showToolbarButton && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="wired-tools" onClick={openMonitor} className="tb-icon" />
-                                </motion.div>
-                            )}
-                        </>
-                    )}
-                    {isInRoom && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="camera" onClick={() => CreateLinkEvent('camera/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {!leftCollapsed && (
-                        <>
-                            {isInRoom && youtubeEnabled && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="youtube" onClick={openYouTubePlayer} className="tb-icon" />
-                                </motion.div>
-                            )}
-                            {isInRoom && soundboardEnabled && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView icon="soundboard" onClick={() => CreateLinkEvent('soundboard/toggle')} className="tb-icon" />
-                                </motion.div>
-                            )}
-                        </>
-                    )}
-                    {isMod && (
-                        <motion.div variants={itemVariants} className="relative">
-                            <ToolbarItemView icon="modtools" onClick={() => CreateLinkEvent('mod-tools/toggle')} className="tb-icon" />
-                            {openTicketsCount > 0 && (
-                                <LayoutItemCountView count={openTicketsCount} className="pointer-events-none absolute -right-1 -top-1 z-10" />
-                            )}
-                        </motion.div>
-                    )}
-                    {isHk && hkEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="housekeeping" onClick={() => CreateLinkEvent('housekeeping/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {isMod && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="furnieditor" onClick={() => CreateLinkEvent('furni-editor/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
+                    { !leftCollapsed && (<>
+                    { rareValuesEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="rare-values" onClick={ () => CreateLinkEvent('rare-values/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    { fortuneWheelEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="fortune-wheel" onClick={ () => CreateLinkEvent('fortune-wheel/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    { (isInRoom && showToolbarButton) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="wired-tools" onClick={ openMonitor } className="tb-icon" />
+                        </motion.div> }
+                    </>) }
+                    { isInRoom &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="camera" onClick={ () => CreateLinkEvent('camera/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    { !leftCollapsed && (<>
+                    { (isInRoom && youtubeEnabled) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="youtube" onClick={ openYouTubePlayer } className="tb-icon" />
+                        </motion.div> }
+                    { (isInRoom && soundboardEnabled) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="soundboard" onClick={ () => CreateLinkEvent('soundboard/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    </>) }
+                    { isMod &&
+                        <motion.div variants={ itemVariants } className="relative">
+                            <ToolbarItemView icon="modtools" onClick={ () => CreateLinkEvent('mod-tools/toggle') } className="tb-icon" />
+                            { (openTicketsCount > 0) &&
+                                <LayoutItemCountView count={ openTicketsCount } className="pointer-events-none absolute -right-1 -top-1 z-10" /> }
+                        </motion.div> }
+                    { (isHk && hkEnabled) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="housekeeping" onClick={ () => CreateLinkEvent('housekeeping/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    { isMod &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="furnieditor" onClick={ () => CreateLinkEvent('furni-editor/toggle') } className="tb-icon" />
+                        </motion.div> }
                 </motion.div>
             </motion.div>
             <motion.div
                 initial="visible"
-                animate={visibilityVariant}
-                variants={rightNavVariants}
-                transition={NAV_TRANSITION}
-                className={`tb-nav-clip fixed bottom-0 z-40 h-[52px] max-w-[calc(50vw-242px)] items-center pr-3 ${desktopFlexClasses} ${isInRoom ? 'right-0' : 'right-3'}`}
-            >
+                animate={ visibilityVariant }
+                variants={ rightNavVariants }
+                transition={ NAV_TRANSITION }
+                className={ `tb-nav-clip fixed bottom-0 z-40 h-[52px] max-w-[calc(50vw-242px)] items-center pr-3 ${ desktopFlexClasses } ${ isInRoom ? 'right-0' : 'right-3' }` }>
                 <motion.div
-                    variants={containerVariants}
-                    className="tb-open-shell flex h-[52px] max-w-full items-center gap-3 overflow-visible bg-transparent px-[8px] pt-[10px] pb-[2px]"
-                >
-                    <motion.div variants={itemVariants} className="relative">
-                        <ToolbarItemView icon="friendall" onClick={() => CreateLinkEvent('friends/toggle')} className="tb-icon" />
-                        {requests.length > 0 && <LayoutItemCountView count={requests.length} className="absolute -right-2 -top-1" />}
+                    variants={ containerVariants }
+                    className="tb-open-shell flex h-[52px] max-w-full items-center gap-3 overflow-visible bg-transparent px-[8px] pt-[10px] pb-[2px]">
+                    <motion.div variants={ itemVariants } className="relative">
+                        <ToolbarItemView icon="friendall" onClick={ () => CreateLinkEvent('friends/toggle') } className="tb-icon" />
+                        { (requests.length > 0) &&
+                            <LayoutItemCountView count={ requests.length } className="absolute -right-2 -top-1" /> }
                     </motion.div>
-                    {rightCollapsed && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="friendsearch" onClick={() => SendMessageComposer(new FindNewFriendsMessageComposer())} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {!rightCollapsed && (
-                        <>
-                            {mentionsEnabled && (
-                                <motion.div variants={itemVariants} className="relative">
-                                    <ToolbarItemView icon="mentions" onClick={() => CreateLinkEvent('mentions/toggle')} className="tb-icon" />
-                                    {mentionsUnread > 0 && <LayoutItemCountView count={mentionsUnread} className="absolute -right-2 -top-1" />}
-                                </motion.div>
-                            )}
-                            {(iconState === MessengerIconState.SHOW || iconState === MessengerIconState.UNREAD) && (
-                                <motion.div variants={itemVariants}>
-                                    <ToolbarItemView
-                                        className={`tb-icon ${iconState === MessengerIconState.UNREAD ? 'is-unseen animate-pulse' : ''}`}
-                                        icon="message"
-                                        onClick={() => OpenMessengerChat()}
-                                    />
-                                </motion.div>
-                            )}
-                            <div className={`mx-1 h-5 w-[1px] bg-white/20 ${desktopBlockClasses}`} />
-                            <div className={`h-full shrink-0 ${desktopBlockClasses}`} id="toolbar-friend-bar-container-desktop" />
-                        </>
-                    )}
+                    { rightCollapsed &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="friendsearch" onClick={ () => SendMessageComposer(new FindNewFriendsMessageComposer()) } className="tb-icon" />
+                        </motion.div> }
+                    { !rightCollapsed && (<>
+                    { mentionsEnabled &&
+                        <motion.div variants={ itemVariants } className="relative">
+                            <ToolbarItemView icon="mentions" onClick={ () => CreateLinkEvent('mentions/toggle') } className="tb-icon" />
+                            { (mentionsUnread > 0) &&
+                                <LayoutItemCountView count={ mentionsUnread } className="absolute -right-2 -top-1" /> }
+                        </motion.div> }
+                    { ((iconState === MessengerIconState.SHOW) || (iconState === MessengerIconState.UNREAD)) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView className={ `tb-icon ${ iconState === MessengerIconState.UNREAD ? 'is-unseen animate-pulse' : '' }` } icon="message" onClick={ () => OpenMessengerChat() } />
+                        </motion.div> }
+                    <div className={ `mx-1 h-5 w-[1px] bg-white/20 ${ desktopBlockClasses }` } />
+                    <div className={ `h-full shrink-0 ${ desktopBlockClasses }` } id="toolbar-friend-bar-container-desktop" />
+                    </>) }
                 </motion.div>
                 <button
                     type="button"
-                    onClick={() => setRightCollapsed((value) => !value)}
-                    aria-label="Mostra/Nascondi icone"
-                    className="tb-collapse pointer-events-auto mt-[6px] ml-[3px]"
-                >
+                    onClick={ () => setRightCollapsed(value => !value) }
+                    aria-label={ localizeWithFallback('toolbar.icons.toggle', 'Show/hide icons') }
+                    className="tb-collapse pointer-events-auto mt-[6px] ml-[3px]">
                     <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d={rightCollapsed ? 'M15 19l-7-7 7-7' : 'M9 5l7 7-7 7'} />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={ 3 } d={ rightCollapsed ? 'M15 19l-7-7 7-7' : 'M9 5l7 7-7 7' } />
                     </svg>
                 </button>
             </motion.div>
             <motion.div
                 initial="visible"
-                animate={visibilityVariant}
-                variants={mobileNavVariants}
-                transition={NAV_TRANSITION}
-                className={`fixed left-1/2 bottom-0 z-40 flex w-[95vw] -translate-x-1/2 items-center overflow-visible ${mobileOnlyClasses} ${isInRoom ? 'rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[6px] py-[4px] mb-[3px] shadow-[0_-6px_18px_rgba(0,0,0,0.18)]' : ''}`}
-            >
+                animate={ visibilityVariant }
+                variants={ mobileNavVariants }
+                transition={ NAV_TRANSITION }
+                className={ `fixed left-1/2 bottom-0 z-40 flex w-[95vw] -translate-x-1/2 items-center overflow-visible ${ mobileOnlyClasses } ${ isInRoom ? 'rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[6px] py-[4px] mb-[3px] shadow-[0_-6px_18px_rgba(0,0,0,0.18)]' : '' }` }>
                 <motion.div
-                    variants={containerVariants}
-                    className="tb-bar-scroll flex h-full min-w-0 flex-1 items-center gap-2 overflow-x-auto overflow-y-visible px-1"
-                >
-                    <motion.div variants={itemVariants}>
-                        {isInRoom ? (
-                            <ToolbarItemView icon="habbo" onClick={() => VisitDesktop()} className="tb-icon" />
-                        ) : (
-                            <ToolbarItemView icon="house" onClick={() => CreateLinkEvent('navigator/goto/home')} className="tb-icon" />
-                        )}
+                    variants={ containerVariants }
+                    className="tb-bar-scroll flex h-full min-w-0 flex-1 items-center gap-2 overflow-x-auto overflow-y-visible px-1">
+                    <motion.div variants={ itemVariants }>
+                        { isInRoom
+                            ? <ToolbarItemView icon="habbo" onClick={ () => VisitDesktop() } className="tb-icon" />
+                            : <ToolbarItemView icon="house" onClick={ () => CreateLinkEvent('navigator/goto/home') } className="tb-icon" /> }
                     </motion.div>
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="rooms" onClick={() => CreateLinkEvent('navigator/toggle')} className="tb-icon" />
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="rooms" onClick={ () => CreateLinkEvent('navigator/toggle') } className="tb-icon" />
                     </motion.div>
-                    {GetConfigurationValue('game.center.enabled') && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="game" onClick={() => CreateLinkEvent('games/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="catalog" onClick={() => CreateLinkEvent('catalog/toggle/normal')} className="tb-icon" />
+                    { GetConfigurationValue('game.center.enabled') &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="game" onClick={ () => CreateLinkEvent('games/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="catalog" onClick={ () => CreateLinkEvent('catalog/toggle/normal') } className="tb-icon" />
                     </motion.div>
-                    <motion.div variants={itemVariants} className="relative shrink-0">
+                    <motion.div variants={ itemVariants } className="relative shrink-0">
                         <AnimatePresence>
-                            {isMeExpanded && (
+                            { isMeExpanded &&
                                 <motion.div
-                                    initial={{ opacity: 0, y: 6, scale: 0.97 }}
-                                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                                    exit={{ opacity: 0, y: 6, scale: 0.97 }}
-                                    transition={ME_POPOVER_TRANSITION}
-                                    className="pointer-events-auto fixed bottom-[calc(100%+10px)] left-1/2 z-[70] -translate-x-1/2"
-                                >
-                                    <ToolbarMeView setMeExpanded={setMeExpanded} unseenAchievementCount={getTotalUnseen} useGuideTool={useGuideTool} />
-                                </motion.div>
-                            )}
+                                    initial={ { opacity: 0, y: 6, scale: 0.97 } }
+                                    animate={ { opacity: 1, y: 0, scale: 1 } }
+                                    exit={ { opacity: 0, y: 6, scale: 0.97 } }
+                                    transition={ ME_POPOVER_TRANSITION }
+                                    className="pointer-events-auto fixed bottom-[calc(100%+10px)] left-1/2 z-[70] -translate-x-1/2">
+                                    <ToolbarMeView setMeExpanded={ setMeExpanded } unseenAchievementCount={ getTotalUnseen } useGuideTool={ useGuideTool } />
+                                </motion.div> }
                         </AnimatePresence>
                         <motion.div
                             className="cursor-pointer relative h-[40px] w-[40px] overflow-hidden"
-                            whileHover={{ scale: 1.08 }}
-                            whileTap={{ scale: 0.95 }}
-                            onClick={(event) => {
-                                setMeExpanded((value) => !value);
+                            whileHover={ { scale: 1.08 } }
+                            whileTap={ { scale: 0.95 } }
+                            onClick={ event =>
+                            {
+                                setMeExpanded(value => !value);
                                 event.stopPropagation();
-                            }}
-                        >
-                            <LayoutAvatarImageView headOnly={true} direction={2} figure={userFigure} className="tb-icon tb-avatar-head" />
+                            } }>
+                            <LayoutAvatarImageView headOnly={ true } direction={ 2 } figure={ userFigure } className="tb-icon tb-avatar-head" />
                         </motion.div>
-                        {getTotalUnseen > 0 && <LayoutItemCountView count={getTotalUnseen} className="pointer-events-none absolute -right-1 -top-1 z-10" />}
+                        { (getTotalUnseen > 0) &&
+                            <LayoutItemCountView count={ getTotalUnseen } className="pointer-events-none absolute -right-1 -top-1 z-10" /> }
                     </motion.div>
-                    <motion.div variants={itemVariants} className="relative">
-                        <ToolbarItemView icon="inventory" onClick={() => CreateLinkEvent('inventory/toggle')} className="tb-icon" />
-                        {getFullCount > 0 && <LayoutItemCountView count={getFullCount} className="absolute -right-1 top-0" />}
+                    <motion.div variants={ itemVariants } className="relative">
+                        <ToolbarItemView icon="inventory" onClick={ () => CreateLinkEvent('inventory/toggle') } className="tb-icon" />
+                        { (getFullCount > 0) &&
+                            <LayoutItemCountView count={ getFullCount } className="absolute -right-1 top-0" /> }
                     </motion.div>
-                    {rareValuesEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="rare-values" onClick={() => CreateLinkEvent('rare-values/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {fortuneWheelEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="fortune-wheel" onClick={() => CreateLinkEvent('fortune-wheel/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
+                    { rareValuesEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="rare-values" onClick={ () => CreateLinkEvent('rare-values/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    { fortuneWheelEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="fortune-wheel" onClick={ () => CreateLinkEvent('fortune-wheel/toggle') } className="tb-icon" />
+                        </motion.div> }
                 </motion.div>
-                <motion.div variants={containerVariants} className="tb-bar-scroll flex h-full items-center gap-2 overflow-x-auto overflow-y-visible px-1">
-                    {isInRoom && showToolbarButton && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="wired-tools" onClick={openMonitor} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {isInRoom && youtubeEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="youtube" onClick={openYouTubePlayer} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    {isInRoom && soundboardEnabled && (
-                        <motion.div variants={itemVariants}>
-                            <ToolbarItemView icon="soundboard" onClick={() => CreateLinkEvent('soundboard/toggle')} className="tb-icon" />
-                        </motion.div>
-                    )}
-                    <motion.div variants={itemVariants} className="relative">
-                        <ToolbarItemView icon="friendall" onClick={() => CreateLinkEvent('friends/toggle')} className="tb-icon" />
-                        {requests.length > 0 && <LayoutItemCountView count={requests.length} className="absolute -right-2 -top-1" />}
+                <motion.div
+                    variants={ containerVariants }
+                    className="tb-bar-scroll flex h-full items-center gap-2 overflow-x-auto overflow-y-visible px-1">
+                    { (isInRoom && showToolbarButton) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="wired-tools" onClick={ openMonitor } className="tb-icon" />
+                        </motion.div> }
+                    { (isInRoom && youtubeEnabled) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="youtube" onClick={ openYouTubePlayer } className="tb-icon" />
+                        </motion.div> }
+                    { (isInRoom && soundboardEnabled) &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="soundboard" onClick={ () => CreateLinkEvent('soundboard/toggle') } className="tb-icon" />
+                        </motion.div> }
+                    <motion.div variants={ itemVariants } className="relative">
+                        <ToolbarItemView icon="friendall" onClick={ () => CreateLinkEvent('friends/toggle') } className="tb-icon" />
+                        { (requests.length > 0) &&
+                            <LayoutItemCountView count={ requests.length } className="absolute -right-2 -top-1" /> }
                     </motion.div>
-                    {mentionsEnabled && (
-                        <motion.div variants={itemVariants} className="relative">
-                            <ToolbarItemView icon="mentions" onClick={() => CreateLinkEvent('mentions/toggle')} className="tb-icon" />
-                            {mentionsUnread > 0 && <LayoutItemCountView count={mentionsUnread} className="absolute -right-2 -top-1" />}
-                        </motion.div>
-                    )}
+                    { mentionsEnabled &&
+                        <motion.div variants={ itemVariants } className="relative">
+                            <ToolbarItemView icon="mentions" onClick={ () => CreateLinkEvent('mentions/toggle') } className="tb-icon" />
+                            { (mentionsUnread > 0) &&
+                                <LayoutItemCountView count={ mentionsUnread } className="absolute -right-2 -top-1" /> }
+                        </motion.div> }
                 </motion.div>
             </motion.div>
-            {/* Mobile side tools — moved out of the bottom bar into a
+            { /* Mobile side tools — moved out of the bottom bar into a
                  vertical pill stack on the left edge so the bottom bar has
                  room. Optional Builders Club, plus camera in-room
-                 and the staff-only tools when permitted. */}
+                 and the staff-only tools when permitted. */ }
             <motion.div
                 initial="visible"
-                animate={visibilityVariant}
-                variants={mobileNavVariants}
-                transition={NAV_TRANSITION}
-                style={staffStackBottom != null ? { top: 'auto', bottom: `${staffStackBottom}px` } : undefined}
-                className={`fixed left-1 z-40 flex flex-col items-center gap-2 rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[4px] py-[6px] shadow-[0_6px_18px_rgba(0,0,0,0.18)] ${staffStackBottom == null ? 'top-1/2 -translate-y-1/2' : ''} ${mobileOnlyClasses}`}
-            >
-                {buildersClubEnabled && (
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="buildersclub" onClick={() => CreateLinkEvent('catalog/toggle/builder')} className="tb-icon" />
-                    </motion.div>
-                )}
-                {isInRoom && (
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="camera" onClick={() => CreateLinkEvent('camera/toggle')} className="tb-icon" />
-                    </motion.div>
-                )}
-                {isMod && (
-                    <motion.div variants={itemVariants} className="relative">
-                        <ToolbarItemView icon="modtools" onClick={() => CreateLinkEvent('mod-tools/toggle')} className="tb-icon" />
-                        {openTicketsCount > 0 && <LayoutItemCountView count={openTicketsCount} className="pointer-events-none absolute -right-1 -top-1 z-10" />}
-                    </motion.div>
-                )}
-                {isHk && hkEnabled && (
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="housekeeping" onClick={() => CreateLinkEvent('housekeeping/toggle')} className="tb-icon" />
-                    </motion.div>
-                )}
-                {isMod && (
-                    <motion.div variants={itemVariants}>
-                        <ToolbarItemView icon="furnieditor" onClick={() => CreateLinkEvent('furni-editor/toggle')} className="tb-icon" />
-                    </motion.div>
-                )}
+                animate={ visibilityVariant }
+                variants={ mobileNavVariants }
+                transition={ NAV_TRANSITION }
+                style={ staffStackBottom != null ? { top: 'auto', bottom: `${ staffStackBottom }px` } : undefined }
+                className={ `fixed left-1 z-40 flex flex-col items-center gap-2 rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[4px] py-[6px] shadow-[0_6px_18px_rgba(0,0,0,0.18)] ${ staffStackBottom == null ? 'top-1/2 -translate-y-1/2' : '' } ${ mobileOnlyClasses }` }>
+                { buildersClubEnabled &&
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="buildersclub" onClick={ () => CreateLinkEvent('catalog/toggle/builder') } className="tb-icon" />
+                    </motion.div> }
+                { isInRoom &&
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="camera" onClick={ () => CreateLinkEvent('camera/toggle') } className="tb-icon" />
+                    </motion.div> }
+                { isMod &&
+                    <motion.div variants={ itemVariants } className="relative">
+                        <ToolbarItemView icon="modtools" onClick={ () => CreateLinkEvent('mod-tools/toggle') } className="tb-icon" />
+                        { (openTicketsCount > 0) &&
+                            <LayoutItemCountView count={ openTicketsCount } className="pointer-events-none absolute -right-1 -top-1 z-10" /> }
+                    </motion.div> }
+                { (isHk && hkEnabled) &&
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="housekeeping" onClick={ () => CreateLinkEvent('housekeeping/toggle') } className="tb-icon" />
+                    </motion.div> }
+                { isMod &&
+                    <motion.div variants={ itemVariants }>
+                        <ToolbarItemView icon="furnieditor" onClick={ () => CreateLinkEvent('furni-editor/toggle') } className="tb-icon" />
+                    </motion.div> }
             </motion.div>
         </>
     );

--- a/src/components/wired/views/actions/WiredActionSendSignalView.tsx
+++ b/src/components/wired/views/actions/WiredActionSendSignalView.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
-import { LocalizeText, WiredFurniType, WiredSelectionVisualizer } from '../../../../api';
+import { LocalizeText, WiredFurniType, WiredSelectionVisualizer , localizeWithFallback} from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { WiredFurniSelectionSourceRow } from '../WiredFurniSelectionSourceRow';
@@ -13,48 +13,53 @@ const FORWARD_ITEM_DELIMITER = ';';
 
 type SelectionMode = 'antenna' | 'furni';
 
-const parseForwardIds = (data: string): number[] => {
-    if (!data || !data.length) return [];
+const parseForwardIds = (data: string): number[] =>
+{
+    if(!data || !data.length) return [];
 
     const ids = new Set<number>();
 
-    for (const part of data.split(/[;,\t]/)) {
+    for(const part of data.split(/[;,\t]/))
+    {
         const trimmed = part.trim();
-        if (!trimmed.length) continue;
+        if(!trimmed.length) continue;
 
         const value = parseInt(trimmed, 10);
-        if (!isNaN(value) && value > 0) ids.add(value);
+        if(!isNaN(value) && value > 0) ids.add(value);
     }
 
     return Array.from(ids);
 };
 
-const serializeForwardIds = (ids: number[]): string => {
-    if (!ids || !ids.length) return '';
+const serializeForwardIds = (ids: number[]): string =>
+{
+    if(!ids || !ids.length) return '';
 
-    return ids.filter((id) => id > 0).join(FORWARD_ITEM_DELIMITER);
+    return ids.filter(id => (id > 0)).join(FORWARD_ITEM_DELIMITER);
 };
 
-export const WiredActionSendSignalView: FC<{}> = () => {
-    const [furniSource, setFurniSource] = useState<number>(SOURCE_TRIGGER);
-    const [userSource, setUserSource] = useState<number>(SOURCE_TRIGGER);
-    const [signalPerFurni, setSignalPerFurni] = useState(false);
-    const [signalPerUser, setSignalPerUser] = useState(false);
-    const [antennaIds, setAntennaIds] = useState<number[]>([]);
-    const [forwardFurniIds, setForwardFurniIds] = useState<number[]>([]);
-    const [selectionMode, setSelectionMode] = useState<SelectionMode>('antenna');
+export const WiredActionSendSignalView: FC<{}> = () =>
+{
+    const [ furniSource, setFurniSource ] = useState<number>(SOURCE_TRIGGER);
+    const [ userSource, setUserSource ] = useState<number>(SOURCE_TRIGGER);
+    const [ signalPerFurni, setSignalPerFurni ] = useState(false);
+    const [ signalPerUser, setSignalPerUser ] = useState(false);
+    const [ antennaIds, setAntennaIds ] = useState<number[]>([]);
+    const [ forwardFurniIds, setForwardFurniIds ] = useState<number[]>([]);
+    const [ selectionMode, setSelectionMode ] = useState<SelectionMode>('antenna');
     const highlightedIds = useRef<number[]>([]);
 
     const { trigger = null, furniIds = [], setFurniIds = null, setIntParams = null, setStringParam = null } = useWired();
 
-    useEffect(() => {
-        if (!trigger) return;
+    useEffect(() =>
+    {
+        if(!trigger) return;
 
         const p = trigger.intData;
-        if (p.length > 1) setFurniSource(p[1]);
+        if(p.length > 1) setFurniSource(p[1]);
         else setFurniSource(SOURCE_TRIGGER);
 
-        if (p.length > 2) setUserSource(p[2]);
+        if(p.length > 2) setUserSource(p[2]);
         else setUserSource(SOURCE_TRIGGER);
 
         setSignalPerFurni(p.length > 3 && p[3] === 1);
@@ -63,101 +68,105 @@ export const WiredActionSendSignalView: FC<{}> = () => {
         setAntennaIds(trigger.selectedItems ?? []);
         setForwardFurniIds(parseForwardIds(trigger.stringData));
         setSelectionMode('antenna');
-    }, [trigger]);
+    }, [ trigger ]);
 
-    useEffect(() => {
-        if (selectionMode === 'antenna') setAntennaIds(furniIds);
+    useEffect(() =>
+    {
+        if(selectionMode === 'antenna') setAntennaIds(furniIds);
         else setForwardFurniIds(furniIds);
-    }, [furniIds, selectionMode]);
+    }, [ furniIds, selectionMode ]);
 
-    const syncHighlights = useCallback((nextAntennaIds: number[], nextForwardFurniIds: number[], nextSelectionMode: SelectionMode, nextFurniSource: number) => {
-        if (highlightedIds.current.length) {
+    const syncHighlights = useCallback((nextAntennaIds: number[], nextForwardFurniIds: number[], nextSelectionMode: SelectionMode, nextFurniSource: number) =>
+    {
+        if(highlightedIds.current.length)
+        {
             WiredSelectionVisualizer.clearSelectionShaderFromFurni(highlightedIds.current);
             WiredSelectionVisualizer.clearSecondarySelectionShaderFromFurni(highlightedIds.current);
         }
 
-        const visibleForwardIds = nextFurniSource === SOURCE_SELECTED ? nextForwardFurniIds : [];
-        const activeIds = nextSelectionMode === 'antenna' ? nextAntennaIds : visibleForwardIds;
-        const passiveIds = nextSelectionMode === 'antenna' ? visibleForwardIds : nextAntennaIds;
+        const visibleForwardIds = (nextFurniSource === SOURCE_SELECTED) ? nextForwardFurniIds : [];
+        const activeIds = (nextSelectionMode === 'antenna') ? nextAntennaIds : visibleForwardIds;
+        const passiveIds = (nextSelectionMode === 'antenna') ? visibleForwardIds : nextAntennaIds;
         const activeSet = new Set(activeIds);
-        const passiveOnlyIds = passiveIds.filter((id) => !activeSet.has(id));
+        const passiveOnlyIds = passiveIds.filter(id => !activeSet.has(id));
 
-        if (activeIds.length) WiredSelectionVisualizer.applySelectionShaderToFurni(activeIds);
-        if (passiveOnlyIds.length) WiredSelectionVisualizer.applySecondarySelectionShaderToFurni(passiveOnlyIds);
+        if(activeIds.length) WiredSelectionVisualizer.applySelectionShaderToFurni(activeIds);
+        if(passiveOnlyIds.length) WiredSelectionVisualizer.applySecondarySelectionShaderToFurni(passiveOnlyIds);
 
-        highlightedIds.current = Array.from(new Set([...activeIds, ...passiveOnlyIds]));
+        highlightedIds.current = Array.from(new Set([ ...activeIds, ...passiveOnlyIds ]));
     }, []);
 
-    useEffect(() => {
+    useEffect(() =>
+    {
         syncHighlights(antennaIds, forwardFurniIds, selectionMode, furniSource);
-    }, [antennaIds, forwardFurniIds, selectionMode, furniSource, syncHighlights]);
+    }, [ antennaIds, forwardFurniIds, selectionMode, furniSource, syncHighlights ]);
 
-    const switchSelection = useCallback(
-        (mode: SelectionMode) => {
-            if (mode === selectionMode) return;
-            if (mode === 'furni' && furniSource !== SOURCE_SELECTED) return;
+    const switchSelection = useCallback((mode: SelectionMode) =>
+    {
+        if(mode === selectionMode) return;
+        if(mode === 'furni' && furniSource !== SOURCE_SELECTED) return;
 
-            const nextAntennaIds = selectionMode === 'antenna' ? [...furniIds] : [...antennaIds];
-            const nextForwardFurniIds = selectionMode === 'furni' ? [...furniIds] : [...forwardFurniIds];
-
-            setAntennaIds(nextAntennaIds);
-            setForwardFurniIds(nextForwardFurniIds);
-            setSelectionMode(mode);
-            if (setFurniIds) setFurniIds([...(mode === 'antenna' ? nextAntennaIds : nextForwardFurniIds)]);
-        },
-        [selectionMode, furniSource, furniIds, antennaIds, forwardFurniIds, setFurniIds]
-    );
-
-    const onChangeFurniSource = (next: number) => {
-        const nextAntennaIds = selectionMode === 'antenna' ? [...furniIds] : [...antennaIds];
+        const nextAntennaIds = (selectionMode === 'antenna') ? [ ...furniIds ] : [ ...antennaIds ];
+        const nextForwardFurniIds = (selectionMode === 'furni') ? [ ...furniIds ] : [ ...forwardFurniIds ];
 
         setAntennaIds(nextAntennaIds);
-        if (forwardFurniIds.length || selectionMode === 'furni') {
+        setForwardFurniIds(nextForwardFurniIds);
+        setSelectionMode(mode);
+        if(setFurniIds) setFurniIds([ ...((mode === 'antenna') ? nextAntennaIds : nextForwardFurniIds) ]);
+    }, [ selectionMode, furniSource, furniIds, antennaIds, forwardFurniIds, setFurniIds ]);
+
+    const onChangeFurniSource = (next: number) =>
+    {
+        const nextAntennaIds = (selectionMode === 'antenna') ? [ ...furniIds ] : [ ...antennaIds ];
+
+        setAntennaIds(nextAntennaIds);
+        if(forwardFurniIds.length || selectionMode === 'furni')
+        {
             setForwardFurniIds([]);
         }
 
-        if (selectionMode === 'furni') {
-            if (setFurniIds) setFurniIds([...nextAntennaIds]);
+        if(selectionMode === 'furni')
+        {
+            if(setFurniIds) setFurniIds([ ...nextAntennaIds ]);
             setSelectionMode('antenna');
         }
 
         setFurniSource(next);
     };
 
-    const save = useCallback(() => {
-        const nextAntennaIds = selectionMode === 'antenna' ? [...furniIds] : [...antennaIds];
-        const nextForwardFurniIds = selectionMode === 'furni' ? [...furniIds] : [...forwardFurniIds];
+    const save = useCallback(() =>
+    {
+        const nextAntennaIds = (selectionMode === 'antenna') ? [ ...furniIds ] : [ ...antennaIds ];
+        const nextForwardFurniIds = (selectionMode === 'furni') ? [ ...furniIds ] : [ ...forwardFurniIds ];
 
         setAntennaIds(nextAntennaIds);
         setForwardFurniIds(nextForwardFurniIds);
 
-        if (selectionMode === 'furni') {
+        if(selectionMode === 'furni')
+        {
             setSelectionMode('antenna');
-            if (setFurniIds) setFurniIds([...nextAntennaIds]);
+            if(setFurniIds) setFurniIds([ ...nextAntennaIds ]);
         }
 
-        const antennaSource = nextAntennaIds && nextAntennaIds.length ? nextAntennaIds[0] : 0;
+        const antennaSource = (nextAntennaIds && nextAntennaIds.length) ? nextAntennaIds[0] : 0;
 
-        setIntParams([antennaSource, furniSource, userSource, signalPerFurni ? 1 : 0, signalPerUser ? 1 : 0, 0]);
+        setIntParams([
+            antennaSource,
+            furniSource,
+            userSource,
+            signalPerFurni ? 1 : 0,
+            signalPerUser ? 1 : 0,
+            0,
+        ]);
 
         setStringParam(serializeForwardIds(nextForwardFurniIds));
-    }, [
-        selectionMode,
-        furniIds,
-        antennaIds,
-        furniSource,
-        userSource,
-        signalPerFurni,
-        signalPerUser,
-        forwardFurniIds,
-        setFurniIds,
-        setIntParams,
-        setStringParam
-    ]);
+    }, [ selectionMode, furniIds, antennaIds, furniSource, userSource, signalPerFurni, signalPerUser, forwardFurniIds, setFurniIds, setIntParams, setStringParam ]);
 
-    useEffect(() => {
-        return () => {
-            if (!highlightedIds.current.length) return;
+    useEffect(() =>
+    {
+        return () =>
+        {
+            if(!highlightedIds.current.length) return;
 
             WiredSelectionVisualizer.clearSelectionShaderFromFurni(highlightedIds.current);
             WiredSelectionVisualizer.clearSecondarySelectionShaderFromFurni(highlightedIds.current);
@@ -169,66 +178,63 @@ export const WiredActionSendSignalView: FC<{}> = () => {
 
     return (
         <WiredActionBaseView
-            hasSpecialInput={true}
-            requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_BY_ID}
-            cardStyle={{ width: '400px' }}
-            save={save}
+            hasSpecialInput={ true }
+            requiresFurni={ WiredFurniType.STUFF_SELECTION_OPTION_BY_ID }
+            cardStyle={ { width: '400px' } }
+            save={ save }
             selectionPreview={
                 <div className="flex flex-col gap-2">
                     <WiredFurniSelectionSourceRow
                         title="Antenne:"
-                        titleIsLiteral={true}
-                        options={[{ value: SOURCE_SELECTED, label: 'wiredfurni.params.sources.furni.100' }]}
-                        value={SOURCE_SELECTED}
+                        titleIsLiteral={ true }
+                        options={ [ { value: SOURCE_SELECTED, label: 'wiredfurni.params.sources.furni.100' } ] }
+                        value={ SOURCE_SELECTED }
                         selectionKind="primary"
-                        selectionActive={selectionMode === 'antenna'}
-                        selectionCount={antennaIds.length}
-                        selectionLimit={selectionLimit}
-                        selectionEnabledValues={[SOURCE_SELECTED]}
-                        onChange={() => {}}
-                        onSelectionActivate={() => switchSelection('antenna')}
-                    />
+                        selectionActive={ selectionMode === 'antenna' }
+                        selectionCount={ antennaIds.length }
+                        selectionLimit={ selectionLimit }
+                        selectionEnabledValues={ [ SOURCE_SELECTED ] }
+                        onChange={ () =>
+                        {} }
+                        onSelectionActivate={ () => switchSelection('antenna') } />
                     <WiredFurniSelectionSourceRow
-                        title="Furni da mandare avanti:"
-                        titleIsLiteral={true}
-                        options={FURNI_SOURCES}
-                        value={furniSource}
+                        title={ localizeWithFallback('wiredfurni.sendsignal.furni', 'Furniture to send forward:') }
+                        titleIsLiteral={ true }
+                        options={ FURNI_SOURCES }
+                        value={ furniSource }
                         selectionKind="secondary"
-                        selectionActive={selectionMode === 'furni'}
-                        selectionCount={forwardFurniIds.length}
-                        selectionLimit={selectionLimit}
-                        selectionEnabledValues={[SOURCE_SELECTED]}
-                        onChange={onChangeFurniSource}
-                        onSelectionActivate={() => switchSelection('furni')}
-                    />
+                        selectionActive={ selectionMode === 'furni' }
+                        selectionCount={ forwardFurniIds.length }
+                        selectionLimit={ selectionLimit }
+                        selectionEnabledValues={ [ SOURCE_SELECTED ] }
+                        onChange={ onChangeFurniSource }
+                        onSelectionActivate={ () => switchSelection('furni') } />
                     <WiredFurniSelectionSourceRow
-                        title="Utenti da mandare avanti:"
-                        titleIsLiteral={true}
-                        options={USER_SOURCES}
-                        value={userSource}
+                        title={ localizeWithFallback('wiredfurni.sendsignal.users', 'Users to send forward:') }
+                        titleIsLiteral={ true }
+                        options={ USER_SOURCES }
+                        value={ userSource }
                         selectionKind="secondary"
-                        selectionActive={false}
-                        selectionCount={0}
-                        selectionLimit={0}
-                        selectionEnabledValues={[]}
-                        showSelectionToggle={false}
-                        onChange={setUserSource}
-                    />
+                        selectionActive={ false }
+                        selectionCount={ 0 }
+                        selectionLimit={ 0 }
+                        selectionEnabledValues={ [] }
+                        showSelectionToggle={ false }
+                        onChange={ setUserSource } />
                 </div>
             }
         >
             <div className="flex flex-col gap-3">
-                <Text bold>{LocalizeText('wiredfurni.params.signal.options')}</Text>
+                <Text bold>{ LocalizeText('wiredfurni.params.signal.options') }</Text>
                 <div className="form-check">
                     <input
                         type="checkbox"
                         className="form-check-input"
                         id="signal-per-furni"
-                        checked={signalPerFurni}
-                        onChange={(e) => setSignalPerFurni(e.target.checked)}
-                    />
+                        checked={ signalPerFurni }
+                        onChange={ e => setSignalPerFurni(e.target.checked) } />
                     <label className="form-check-label" htmlFor="signal-per-furni">
-                        <Text small>{LocalizeText('wiredfurni.params.signal.split_furni')}</Text>
+                        <Text small>{ LocalizeText('wiredfurni.params.signal.split_furni') }</Text>
                     </label>
                 </div>
                 <div className="form-check">
@@ -236,11 +242,10 @@ export const WiredActionSendSignalView: FC<{}> = () => {
                         type="checkbox"
                         className="form-check-input"
                         id="signal-per-user"
-                        checked={signalPerUser}
-                        onChange={(e) => setSignalPerUser(e.target.checked)}
-                    />
+                        checked={ signalPerUser }
+                        onChange={ e => setSignalPerUser(e.target.checked) } />
                     <label className="form-check-label" htmlFor="signal-per-user">
-                        <Text small>{LocalizeText('wiredfurni.params.signal.split_users')}</Text>
+                        <Text small>{ LocalizeText('wiredfurni.params.signal.split_users') }</Text>
                     </label>
                 </div>
             </div>

--- a/src/components/wired/views/extras/WiredExtraUserVariableView.tsx
+++ b/src/components/wired/views/extras/WiredExtraUserVariableView.tsx
@@ -1,5 +1,5 @@
 ﻿import { FC, useEffect, useMemo, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { LocalizeText, WiredFurniType , localizeWithFallback} from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { NitroInput } from '../../../../layout';
@@ -10,12 +10,14 @@ const AVAILABILITY_PERMANENT = 10;
 const AVAILABILITY_SHARED = 11;
 const MAX_NAME_LENGTH = 40;
 
-const normalizeVariableName = (value: string) => {
+const normalizeVariableName = (value: string) =>
+{
     let normalizedValue = (value ?? '').replace(/[\t\r\n]/g, '');
 
-    if (normalizedValue.includes('=')) normalizedValue = normalizedValue.substring(0, normalizedValue.indexOf('=')).trim();
+    if(normalizedValue.includes('=')) normalizedValue = normalizedValue.substring(0, normalizedValue.indexOf('=')).trim();
 
-    while (normalizedValue.startsWith('@') || normalizedValue.startsWith('~')) {
+    while(normalizedValue.startsWith('@') || normalizedValue.startsWith('~'))
+    {
         normalizedValue = normalizedValue.substring(1);
     }
 
@@ -25,132 +27,107 @@ const normalizeVariableName = (value: string) => {
     return normalizedValue.slice(0, MAX_NAME_LENGTH);
 };
 
-const handleVariableNameKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, setValue: (value: string) => void) => {
-    if (event.key !== ' ') return;
+const handleVariableNameKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, setValue: (value: string) => void) =>
+{
+    if(event.key !== ' ') return;
 
     event.preventDefault();
 
     const input = event.currentTarget;
-    const start = input.selectionStart ?? input.value.length;
-    const end = input.selectionEnd ?? start;
-    const nextValue = `${input.value.substring(0, start)}_${input.value.substring(end)}`;
+    const start = (input.selectionStart ?? input.value.length);
+    const end = (input.selectionEnd ?? start);
+    const nextValue = `${ input.value.substring(0, start) }_${ input.value.substring(end) }`;
 
     setValue(normalizeVariableName(nextValue));
 
     window.requestAnimationFrame(() => input.setSelectionRange(Math.min(start + 1, input.value.length + 1), Math.min(start + 1, input.value.length + 1)));
 };
 
-interface WiredExtraVariableViewProps {
+interface WiredExtraVariableViewProps
+{
     availabilityRoomValue: number;
     availabilityRoomText: string;
     availabilityRadioName: string;
     showSharedAvailability?: boolean;
 }
 
-export const WiredExtraVariableView: FC<WiredExtraVariableViewProps> = (props) => {
+export const WiredExtraVariableView: FC<WiredExtraVariableViewProps> = props =>
+{
     const { trigger = null, setIntParams = null, setStringParam = null } = useWired();
-    const [variableName, setVariableName] = useState('');
-    const [hasValue, setHasValue] = useState(false);
-    const [availability, setAvailability] = useState(props.availabilityRoomValue);
-    const roomAvailabilityText = useMemo(() => {
+    const [ variableName, setVariableName ] = useState('');
+    const [ hasValue, setHasValue ] = useState(false);
+    const [ availability, setAvailability ] = useState(props.availabilityRoomValue);
+    const roomAvailabilityText = useMemo(() =>
+    {
         const localizedText = props.availabilityRoomText;
 
-        if (localizedText && localizedText !== 'wiredfurni.params.variables.availability.1') return localizedText;
+        if(localizedText && (localizedText !== 'wiredfurni.params.variables.availability.1')) return localizedText;
 
-        return 'Mentre la stanza è attiva';
-    }, [props.availabilityRoomText]);
-    const normalizeAvailability = useMemo(
-        () => (value: number) => {
-            if (props.showSharedAvailability && value === AVAILABILITY_SHARED) return AVAILABILITY_SHARED;
-            if (value === AVAILABILITY_PERMANENT) return AVAILABILITY_PERMANENT;
+        return localizeWithFallback('wiredfurni.condition.room.active', 'While the room is active');
+    }, [ props.availabilityRoomText ]);
+    const normalizeAvailability = useMemo(() => (value: number) =>
+    {
+        if(props.showSharedAvailability && (value === AVAILABILITY_SHARED)) return AVAILABILITY_SHARED;
+        if(value === AVAILABILITY_PERMANENT) return AVAILABILITY_PERMANENT;
 
-            return props.availabilityRoomValue;
-        },
-        [props.availabilityRoomValue, props.showSharedAvailability]
-    );
+        return props.availabilityRoomValue;
+    }, [ props.availabilityRoomValue, props.showSharedAvailability ]);
 
-    useEffect(() => {
-        if (!trigger) return;
+    useEffect(() =>
+    {
+        if(!trigger) return;
 
         setVariableName(normalizeVariableName(trigger.stringData));
-        setHasValue(trigger.intData.length > 0 ? trigger.intData[0] === 1 : false);
-        setAvailability(normalizeAvailability(trigger.intData.length > 1 ? trigger.intData[1] : props.availabilityRoomValue));
-    }, [normalizeAvailability, props.availabilityRoomValue, trigger]);
+        setHasValue((trigger.intData.length > 0) ? (trigger.intData[0] === 1) : false);
+        setAvailability(normalizeAvailability((trigger.intData.length > 1) ? trigger.intData[1] : props.availabilityRoomValue));
+    }, [ normalizeAvailability, props.availabilityRoomValue, trigger ]);
 
-    const save = () => {
+    const save = () =>
+    {
         setStringParam(normalizeVariableName(variableName));
-        setIntParams([hasValue ? 1 : 0, normalizeAvailability(availability)]);
+        setIntParams([ hasValue ? 1 : 0, normalizeAvailability(availability) ]);
     };
 
     return (
-        <WiredExtraBaseView hasSpecialInput={true} requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_NONE} save={save} cardStyle={{ width: 400 }}>
+        <WiredExtraBaseView hasSpecialInput={ true } requiresFurni={ WiredFurniType.STUFF_SELECTION_OPTION_NONE } save={ save } cardStyle={ { width: 400 } }>
             <div className="flex flex-col gap-2">
                 <div className="flex flex-col gap-1">
-                    <Text>{LocalizeText('wiredfurni.params.variables.variable_name')}</Text>
-                    <NitroInput
-                        maxLength={MAX_NAME_LENGTH}
-                        type="text"
-                        value={variableName}
-                        onChange={(event) => setVariableName(normalizeVariableName(event.target.value))}
-                        onKeyDown={(event) => handleVariableNameKeyDown(event, setVariableName)}
-                    />
+                    <Text>{ LocalizeText('wiredfurni.params.variables.variable_name') }</Text>
+                    <NitroInput maxLength={ MAX_NAME_LENGTH } type="text" value={ variableName } onChange={ event => setVariableName(normalizeVariableName(event.target.value)) } onKeyDown={ event => handleVariableNameKeyDown(event, setVariableName) } />
                 </div>
 
                 <div className="flex flex-col gap-1">
-                    <Text>{LocalizeText('wiredfurni.params.variables.settings')}</Text>
+                    <Text>{ LocalizeText('wiredfurni.params.variables.settings') }</Text>
                     <label className="flex items-center gap-1 cursor-pointer">
-                        <input checked={hasValue} className="form-check-input" type="checkbox" onChange={(event) => setHasValue(event.target.checked)} />
-                        <Text>{LocalizeText('wiredfurni.params.variables.settings.has_value')}</Text>
+                        <input checked={ hasValue } className="form-check-input" type="checkbox" onChange={ event => setHasValue(event.target.checked) } />
+                        <Text>{ LocalizeText('wiredfurni.params.variables.settings.has_value') }</Text>
                     </label>
                 </div>
 
                 <div className="flex flex-col gap-1">
-                    <Text>{LocalizeText('wiredfurni.params.variables.availability')}</Text>
+                    <Text>{ LocalizeText('wiredfurni.params.variables.availability') }</Text>
                     <label className="flex items-center gap-1 cursor-pointer">
-                        <input
-                            checked={availability === props.availabilityRoomValue}
-                            className="form-check-input"
-                            name={props.availabilityRadioName}
-                            type="radio"
-                            onChange={() => setAvailability(props.availabilityRoomValue)}
-                        />
-                        <Text>{roomAvailabilityText}</Text>
+                        <input checked={ (availability === props.availabilityRoomValue) } className="form-check-input" name={ props.availabilityRadioName } type="radio" onChange={ () => setAvailability(props.availabilityRoomValue) } />
+                        <Text>{ roomAvailabilityText }</Text>
                     </label>
                     <label className="flex items-center gap-1 cursor-pointer">
-                        <input
-                            checked={availability === AVAILABILITY_PERMANENT}
-                            className="form-check-input"
-                            name={props.availabilityRadioName}
-                            type="radio"
-                            onChange={() => setAvailability(AVAILABILITY_PERMANENT)}
-                        />
-                        <Text>{LocalizeText('wiredfurni.params.variables.availability.10')}</Text>
+                        <input checked={ (availability === AVAILABILITY_PERMANENT) } className="form-check-input" name={ props.availabilityRadioName } type="radio" onChange={ () => setAvailability(AVAILABILITY_PERMANENT) } />
+                        <Text>{ LocalizeText('wiredfurni.params.variables.availability.10') }</Text>
                     </label>
-                    {!!props.showSharedAvailability && (
+                    { !!props.showSharedAvailability &&
                         <label className="flex items-center gap-1 cursor-pointer">
-                            <input
-                                checked={availability === AVAILABILITY_SHARED}
-                                className="form-check-input"
-                                name={props.availabilityRadioName}
-                                type="radio"
-                                onChange={() => setAvailability(AVAILABILITY_SHARED)}
-                            />
-                            <Text>{LocalizeText('wiredfurni.params.variables.availability.11')}</Text>
-                        </label>
-                    )}
+                            <input checked={ (availability === AVAILABILITY_SHARED) } className="form-check-input" name={ props.availabilityRadioName } type="radio" onChange={ () => setAvailability(AVAILABILITY_SHARED) } />
+                            <Text>{ LocalizeText('wiredfurni.params.variables.availability.11') }</Text>
+                        </label> }
                 </div>
             </div>
         </WiredExtraBaseView>
     );
 };
 
-export const WiredExtraUserVariableView: FC<{}> = () => {
-    return (
-        <WiredExtraVariableView
-            availabilityRadioName="wiredUserVariableAvailability"
-            availabilityRoomText={LocalizeText('wiredfurni.params.variables.availability.0')}
-            availabilityRoomValue={AVAILABILITY_ROOM}
-            showSharedAvailability={true}
-        />
-    );
+export const WiredExtraUserVariableView: FC<{}> = () =>
+{
+    return <WiredExtraVariableView availabilityRadioName="wiredUserVariableAvailability" availabilityRoomText={ LocalizeText('wiredfurni.params.variables.availability.0') } availabilityRoomValue={ AVAILABILITY_ROOM } showSharedAvailability={ true } />;
 };
+
+


### PR DESCRIPTION
## What
Replaces 7 hard-coded Italian UI strings with `localizeWithFallback(key, 'English')` so they show English by default and are translatable:
- `ToolbarView` — icon show/hide `aria-label`
- `CatalogBuildersClubStatusView` — "Full Member" / "Free Trial"
- `CatalogLayoutBcInfoView` — logo hint
- `WiredActionSendSignalView` — furni / users send-forward titles
- `WiredExtraUserVariableView` — "while the room is active" condition

## Note on diff size
These views are heavily reformatted on this fork's `main` vs `Dev`; the PR brings the fork's version (formatting + the localization fixes), hence the larger diffs. The functional change is the 7 `localizeWithFallback` conversions.