### PR TITLE
fix: keep mod tools tables responsive

### DIFF
--- a/src/components/mod-tools/views/chatlog/ChatlogView.tsx
+++ b/src/components/mod-tools/views/chatlog/ChatlogView.tsx
@@ -66,40 +66,44 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
 
     return (
         <Column fit gap={0} overflow="hidden">
-            {/* Column headers */}
-            <div className="grid grid-cols-[60px_120px_1fr] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
-                <div>{LocalizeText('modtools.chatlog.column.time')}</div>
-                <div>{LocalizeText('modtools.chatlog.column.user')}</div>
-                <div>{LocalizeText('modtools.chatlog.column.message')}</div>
-            </div>
-            {isEmpty ? (
-                <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
-                    <FaCommentDots size={22} />
-                    <span>{LocalizeText('modtools.chatlog.empty')}</span>
-                </div>
-            ) : (
-                <InfiniteScroll
-                    rowRender={(row: ChatlogRecord) => {
-                        if (row.isRoomInfo) return <RoomInfo roomId={row.roomId} roomName={row.roomName} />;
+            <div className="min-w-0 overflow-x-auto">
+                <div className="min-w-[360px]">
+                    {/* Column headers */}
+                    <div className="grid grid-cols-[60px_120px_1fr] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                        <div>{LocalizeText('modtools.chatlog.column.time')}</div>
+                        <div>{LocalizeText('modtools.chatlog.column.user')}</div>
+                        <div>{LocalizeText('modtools.chatlog.column.message')}</div>
+                    </div>
+                    {isEmpty ? (
+                        <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
+                            <FaCommentDots size={22} />
+                            <span>{LocalizeText('modtools.chatlog.empty')}</span>
+                        </div>
+                    ) : (
+                        <InfiniteScroll
+                            rowRender={(row: ChatlogRecord) => {
+                                if (row.isRoomInfo) return <RoomInfo roomId={row.roomId} roomName={row.roomName} />;
 
-                        return (
-                            <div
-                                className={`grid grid-cols-[60px_120px_1fr] gap-2 items-start px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors ${row.hasHighlighting ? 'bg-amber-50/60' : ''}`}
-                            >
-                                <span className="font-mono text-[.7rem] opacity-70 tabular-nums whitespace-nowrap">{row.timestamp}</span>
-                                <button
-                                    className="text-left font-semibold text-sky-700 hover:text-sky-900 hover:underline truncate"
-                                    onClick={() => CreateLinkEvent(`mod-tools/open-user-info/${row.habboId}`)}
-                                >
-                                    {row.username}
-                                </button>
-                                <span className="break-words">{row.message}</span>
-                            </div>
-                        );
-                    }}
-                    rows={allRecords}
-                />
-            )}
+                                return (
+                                    <div
+                                        className={`grid grid-cols-[60px_120px_1fr] gap-2 items-start px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors ${row.hasHighlighting ? 'bg-amber-50/60' : ''}`}
+                                    >
+                                        <span className="font-mono text-[.7rem] opacity-70 tabular-nums whitespace-nowrap">{row.timestamp}</span>
+                                        <button
+                                            className="text-left font-semibold text-sky-700 hover:text-sky-900 hover:underline truncate"
+                                            onClick={() => CreateLinkEvent(`mod-tools/open-user-info/${row.habboId}`)}
+                                        >
+                                            {row.username}
+                                        </button>
+                                        <span className="break-words">{row.message}</span>
+                                    </div>
+                                );
+                            }}
+                            rows={allRecords}
+                        />
+                    )}
+                </div>
+            </div>
         </Column>
     );
 };

--- a/src/components/mod-tools/views/tickets/ModToolsMyIssuesTabView.tsx
+++ b/src/components/mod-tools/views/tickets/ModToolsMyIssuesTabView.tsx
@@ -25,52 +25,56 @@ export const ModToolsMyIssuesTabView: FC<ModToolsMyIssuesTabViewProps> = (props)
 
     return (
         <div className="flex flex-col gap-1 overflow-hidden">
-            <div className="grid grid-cols-[100px_1fr_100px_90px_90px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
-                <div>{LocalizeText('modtools.tickets.column.type')}</div>
-                <div className="flex items-center gap-1">
-                    <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
-                </div>
-                <div className="flex items-center gap-1">
-                    <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
-                </div>
-                <div></div>
-                <div></div>
-            </div>
-            {isEmpty ? (
-                <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
-                    <FaInbox size={22} />
-                    <span>{LocalizeText('modtools.tickets.empty.mine')}</span>
-                </div>
-            ) : (
-                <div className="flex flex-col overflow-auto">
-                    {myIssues.map((issue) => (
-                        <div
-                            key={issue.issueId}
-                            className="grid grid-cols-[100px_1fr_100px_90px_90px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors"
-                        >
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-sky-50 text-sky-800 border-sky-200 w-fit">
-                                {GetIssueCategoryName(issue.categoryId)}
-                            </span>
-                            <span className="font-medium truncate">{issue.reportedUserName}</span>
-                            <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
-                                {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
-                            </span>
-                            <button
-                                className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-sky-600 text-white hover:bg-sky-700 transition-colors"
-                                onClick={() => handleIssue(issue.issueId)}
-                            >
-                                <FaTools size={10} /> {LocalizeText('modtools.tickets.action.handle')}
-                            </button>
-                            <button
-                                className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-rose-600 text-white hover:bg-rose-700 transition-colors"
-                                onClick={() => releaseIssue(issue.issueId)}
-                            >
-                                <FaSignOutAlt size={10} /> {LocalizeText('modtools.tickets.action.release')}
-                            </button>
+            <div className="min-w-0 overflow-x-auto">
+                <div className="min-w-[500px]">
+                    <div className="grid grid-cols-[100px_1fr_100px_90px_90px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                        <div>{LocalizeText('modtools.tickets.column.type')}</div>
+                        <div className="flex items-center gap-1">
+                            <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
                         </div>
-                    ))}
+                        <div className="flex items-center gap-1">
+                            <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
+                        </div>
+                        <div></div>
+                        <div></div>
+                    </div>
+                    {isEmpty ? (
+                        <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
+                            <FaInbox size={22} />
+                            <span>{LocalizeText('modtools.tickets.empty.mine')}</span>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col overflow-auto">
+                            {myIssues.map((issue) => (
+                                <div
+                                    key={issue.issueId}
+                                    className="grid grid-cols-[100px_1fr_100px_90px_90px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors"
+                                >
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-sky-50 text-sky-800 border-sky-200 w-fit">
+                                        {GetIssueCategoryName(issue.categoryId)}
+                                    </span>
+                                    <span className="font-medium truncate">{issue.reportedUserName}</span>
+                                    <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
+                                        {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
+                                    </span>
+                                    <button
+                                        className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-sky-600 text-white hover:bg-sky-700 transition-colors"
+                                        onClick={() => handleIssue(issue.issueId)}
+                                    >
+                                        <FaTools size={10} /> {LocalizeText('modtools.tickets.action.handle')}
+                                    </button>
+                                    <button
+                                        className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-rose-600 text-white hover:bg-rose-700 transition-colors"
+                                        onClick={() => releaseIssue(issue.issueId)}
+                                    >
+                                        <FaSignOutAlt size={10} /> {LocalizeText('modtools.tickets.action.release')}
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
-            )}
+            </div>
         </div>
     );
 };

--- a/src/components/mod-tools/views/tickets/ModToolsOpenIssuesTabView.tsx
+++ b/src/components/mod-tools/views/tickets/ModToolsOpenIssuesTabView.tsx
@@ -24,45 +24,49 @@ export const ModToolsOpenIssuesTabView: FC<ModToolsOpenIssuesTabViewProps> = (pr
 
     return (
         <div className="flex flex-col gap-1 overflow-hidden">
-            <div className="grid grid-cols-[100px_1fr_100px_100px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
-                <div>{LocalizeText('modtools.tickets.column.type')}</div>
-                <div className="flex items-center gap-1">
-                    <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
-                </div>
-                <div className="flex items-center gap-1">
-                    <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
-                </div>
-                <div></div>
-            </div>
-            {isEmpty ? (
-                <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
-                    <FaInbox size={22} />
-                    <span>{LocalizeText('modtools.tickets.empty.open')}</span>
-                </div>
-            ) : (
-                <div className="flex flex-col overflow-auto">
-                    {openIssues.map((issue) => (
-                        <div
-                            key={issue.issueId}
-                            className="grid grid-cols-[100px_1fr_100px_100px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-amber-50/50 transition-colors"
-                        >
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-amber-50 text-amber-800 border-amber-200 w-fit">
-                                {GetIssueCategoryName(issue.categoryId)}
-                            </span>
-                            <span className="font-medium truncate">{issue.reportedUserName}</span>
-                            <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
-                                {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
-                            </span>
-                            <button
-                                className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
-                                onClick={() => pickIssue(issue.issueId)}
-                            >
-                                <FaHandPointer size={10} /> {LocalizeText('modtools.tickets.action.pick')}
-                            </button>
+            <div className="min-w-0 overflow-x-auto">
+                <div className="min-w-[420px]">
+                    <div className="grid grid-cols-[100px_1fr_100px_100px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                        <div>{LocalizeText('modtools.tickets.column.type')}</div>
+                        <div className="flex items-center gap-1">
+                            <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
                         </div>
-                    ))}
+                        <div className="flex items-center gap-1">
+                            <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
+                        </div>
+                        <div></div>
+                    </div>
+                    {isEmpty ? (
+                        <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
+                            <FaInbox size={22} />
+                            <span>{LocalizeText('modtools.tickets.empty.open')}</span>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col overflow-auto">
+                            {openIssues.map((issue) => (
+                                <div
+                                    key={issue.issueId}
+                                    className="grid grid-cols-[100px_1fr_100px_100px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-amber-50/50 transition-colors"
+                                >
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-amber-50 text-amber-800 border-amber-200 w-fit">
+                                        {GetIssueCategoryName(issue.categoryId)}
+                                    </span>
+                                    <span className="font-medium truncate">{issue.reportedUserName}</span>
+                                    <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
+                                        {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
+                                    </span>
+                                    <button
+                                        className="inline-flex items-center justify-center gap-1 px-2 py-1 rounded text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
+                                        onClick={() => pickIssue(issue.issueId)}
+                                    >
+                                        <FaHandPointer size={10} /> {LocalizeText('modtools.tickets.action.pick')}
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
-            )}
+            </div>
         </div>
     );
 };

--- a/src/components/mod-tools/views/tickets/ModToolsPickedIssuesTabView.tsx
+++ b/src/components/mod-tools/views/tickets/ModToolsPickedIssuesTabView.tsx
@@ -13,42 +13,46 @@ export const ModToolsPickedIssuesTabView: FC<ModToolsPickedIssuesTabViewProps> =
 
     return (
         <div className="flex flex-col gap-1 overflow-hidden">
-            <div className="grid grid-cols-[100px_1fr_100px_120px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
-                <div>{LocalizeText('modtools.tickets.column.type')}</div>
-                <div className="flex items-center gap-1">
-                    <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
-                </div>
-                <div className="flex items-center gap-1">
-                    <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
-                </div>
-                <div className="flex items-center gap-1">
-                    <FaUserShield size={10} /> {LocalizeText('modtools.tickets.column.picker')}
+            <div className="min-w-0 overflow-x-auto">
+                <div className="min-w-[460px]">
+                    <div className="grid grid-cols-[100px_1fr_100px_120px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                        <div>{LocalizeText('modtools.tickets.column.type')}</div>
+                        <div className="flex items-center gap-1">
+                            <FaUser size={10} /> {LocalizeText('modtools.tickets.column.reported')}
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <FaClock size={10} /> {LocalizeText('modtools.tickets.column.opened')}
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <FaUserShield size={10} /> {LocalizeText('modtools.tickets.column.picker')}
+                        </div>
+                    </div>
+                    {isEmpty ? (
+                        <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
+                            <FaInbox size={22} />
+                            <span>{LocalizeText('modtools.tickets.empty.picked')}</span>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col overflow-auto">
+                            {pickedIssues.map((issue) => (
+                                <div
+                                    key={issue.issueId}
+                                    className="grid grid-cols-[100px_1fr_100px_120px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02]"
+                                >
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-zinc-50 text-zinc-700 border-zinc-200 w-fit">
+                                        {GetIssueCategoryName(issue.categoryId)}
+                                    </span>
+                                    <span className="font-medium truncate">{issue.reportedUserName}</span>
+                                    <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
+                                        {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
+                                    </span>
+                                    <span className="truncate font-medium opacity-80">{issue.pickerUserName}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
-            {isEmpty ? (
-                <div className="flex flex-col items-center justify-center gap-1 py-8 opacity-50 text-sm">
-                    <FaInbox size={22} />
-                    <span>{LocalizeText('modtools.tickets.empty.picked')}</span>
-                </div>
-            ) : (
-                <div className="flex flex-col overflow-auto">
-                    {pickedIssues.map((issue) => (
-                        <div
-                            key={issue.issueId}
-                            className="grid grid-cols-[100px_1fr_100px_120px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02]"
-                        >
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-zinc-50 text-zinc-700 border-zinc-200 w-fit">
-                                {GetIssueCategoryName(issue.categoryId)}
-                            </span>
-                            <span className="font-medium truncate">{issue.reportedUserName}</span>
-                            <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
-                                {new Date(Date.now() - issue.issueAgeInMilliseconds).toLocaleTimeString()}
-                            </span>
-                            <span className="truncate font-medium opacity-80">{issue.pickerUserName}</span>
-                        </div>
-                    ))}
-                </div>
-            )}
         </div>
     );
 };

--- a/src/components/mod-tools/views/user/ModToolsUserRoomVisitsView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserRoomVisitsView.tsx
@@ -51,43 +51,47 @@ export const ModToolsUserRoomVisitsView: FC<ModToolsUserRoomVisitsViewProps> = (
                     <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-white border-zinc-200">{countLabel}</span>
                 </div>
 
-                {/* Table head */}
-                <div className="grid grid-cols-[60px_1fr_80px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
-                    <div className="flex items-center gap-1">
-                        <FaClock size={10} /> {LocalizeText('modtools.user.visits.time')}
-                    </div>
-                    <div>{LocalizeText('modtools.user.visits.room')}</div>
-                    <div className="text-right">{LocalizeText('modtools.user.visits.action')}</div>
-                </div>
+                <div className="min-w-0 overflow-x-auto">
+                    <div className="min-w-[280px]">
+                        {/* Table head */}
+                        <div className="grid grid-cols-[60px_1fr_80px] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                            <div className="flex items-center gap-1">
+                                <FaClock size={10} /> {LocalizeText('modtools.user.visits.time')}
+                            </div>
+                            <div>{LocalizeText('modtools.user.visits.room')}</div>
+                            <div className="text-right">{LocalizeText('modtools.user.visits.action')}</div>
+                        </div>
 
-                {/* Rows */}
-                {isEmpty ? (
-                    <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
-                        <FaDoorOpen size={22} />
-                        <span>{LocalizeText('modtools.user.visits.empty')}</span>
+                        {/* Rows */}
+                        {isEmpty ? (
+                            <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
+                                <FaDoorOpen size={22} />
+                                <span>{LocalizeText('modtools.user.visits.empty')}</span>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col grow min-h-0 overflow-hidden">
+                                <InfiniteScroll
+                                    rowRender={(row) => (
+                                        <div className="grid grid-cols-[60px_1fr_80px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50 transition-colors">
+                                            <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
+                                                {row.enterHour.toString().padStart(2, '0')}:{row.enterMinute.toString().padStart(2, '0')}
+                                            </span>
+                                            <span className="truncate font-medium">{row.roomName}</span>
+                                            <button
+                                                className="inline-flex items-center justify-end gap-1 text-sky-700 hover:text-sky-900 hover:underline text-xs"
+                                                onClick={() => TryVisitRoom(row.roomId)}
+                                                title={LocalizeText('modtools.user.visits.visit.title')}
+                                            >
+                                                <FaSignInAlt size={10} /> {LocalizeText('modtools.user.visits.visit')}
+                                            </button>
+                                        </div>
+                                    )}
+                                    rows={rows}
+                                />
+                            </div>
+                        )}
                     </div>
-                ) : (
-                    <div className="flex flex-col grow min-h-0 overflow-hidden">
-                        <InfiniteScroll
-                            rowRender={(row) => (
-                                <div className="grid grid-cols-[60px_1fr_80px] gap-2 items-center px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50 transition-colors">
-                                    <span className="font-mono text-[.75rem] opacity-70 tabular-nums">
-                                        {row.enterHour.toString().padStart(2, '0')}:{row.enterMinute.toString().padStart(2, '0')}
-                                    </span>
-                                    <span className="truncate font-medium">{row.roomName}</span>
-                                    <button
-                                        className="inline-flex items-center justify-end gap-1 text-sky-700 hover:text-sky-900 hover:underline text-xs"
-                                        onClick={() => TryVisitRoom(row.roomId)}
-                                        title={LocalizeText('modtools.user.visits.visit.title')}
-                                    >
-                                        <FaSignInAlt size={10} /> {LocalizeText('modtools.user.visits.visit')}
-                                    </button>
-                                </div>
-                            )}
-                            rows={rows}
-                        />
-                    </div>
-                )}
+                </div>
             </NitroCardContentView>
         </NitroCardView>
     );


### PR DESCRIPTION
## Summary
- Adds horizontal overflow guards around Mod Tools chatlog and ticket tables.
- Keeps the fixed table columns readable on narrow viewports instead of letting them spill out of the Nitro card.
- Applies the same responsive handling to user room visits.

## Checks
- `yarn.cmd lint`
- `git diff --check`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is already isolated in PR #279.