### PR TITLE
fix: keep wired window within viewport

### DIFF
--- a/src/components/wired/views/triggers/WiredTriggerVariableChangedView.tsx
+++ b/src/components/wired/views/triggers/WiredTriggerVariableChangedView.tsx
@@ -135,7 +135,7 @@ export const WiredTriggerVariableChangedView: FC<{}> = () => {
 
     return (
         <WiredTriggerBaseView hasSpecialInput={true} requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_NONE} save={save}>
-            <div className="nitro-wired__give-var" style={{ width: 244 }}>
+            <div className="nitro-wired__give-var nitro-wired__give-var--trigger-variable">
                 <div className="nitro-wired__give-var-heading">
                     <Text>{LocalizeText('wiredfurni.params.variables.variable_selection')}</Text>
                     <div className="nitro-wired__give-var-targets">

--- a/src/css/WiredView.css
+++ b/src/css/WiredView.css
@@ -1,4 +1,7 @@
 .nitro-wired {
+    width: min(300px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
     background: #efefef;
     border: 1px solid #8d8d8d !important;
     border-radius: 6px !important;
@@ -408,6 +411,10 @@
         display: flex;
         flex-direction: column;
         gap: 4px;
+    }
+
+    .nitro-wired__give-var--trigger-variable {
+        width: min(244px, 100%);
     }
 
     .nitro-wired__give-var-heading {


### PR DESCRIPTION
## Summary
- Adds viewport-safe width limits to the Wired card shell.
- Moves the variable-changed trigger width out of inline style and into WiredView.css.
- Keeps the variable picker block capped without overflowing the card on narrow screens.

## Checks
- `yarn.cmd lint`
- `git diff --check`
- `yarn.cmd test src/css/ui-css-ownership.test.ts`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.