### PR TITLE
fix: stack room settings panels on small viewports

### DIFF
--- a/src/css/room/NavigatorRoomSettings.css
+++ b/src/css/room/NavigatorRoomSettings.css
@@ -21,10 +21,15 @@
         }
     }
 
-    .nitro-card-tabs {
+    .nitro-card-tabs-shell {
         flex-wrap: nowrap;
         overflow-x: auto;
         overflow-y: hidden;
+    }
+
+    .nitro-card-tab-item {
+        flex: 0 0 auto;
+        white-space: nowrap;
     }
 
     .nitro-card-content-shell {
@@ -67,5 +72,24 @@
         min-height: 0;
         accent-color: var(--room-settings-accent);
         box-shadow: none !important;
+    }
+}
+
+@media (max-width: 520px), (max-height: 520px) {
+    .nitro-room-settings {
+        width: calc(100vw - 16px);
+        max-height: calc(100vh - 16px);
+
+        .nitro-card-content-shell {
+            max-height: calc(100vh - 84px);
+        }
+
+        .col-span-6 {
+            grid-column: span 12 / span 12;
+        }
+
+        .h-full {
+            height: auto;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Keeps room settings tabs scrollable without wrapping into the content area.
- Stacks 6-column room settings panels into a single column on narrow or short viewports.
- Caps the room settings content height so the window remains usable on small screens.

## Checks
- `yarn.cmd lint`
- `git diff --check`
- `yarn.cmd test src/css/ui-css-ownership.test.ts`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.