### PR TITLE
fix: restore wired close icon

### DIFF
--- a/src/css/WiredView.css
+++ b/src/css/WiredView.css
@@ -52,12 +52,24 @@
 
         .nitro-card-close-button::before,
         .nitro-card-close-button::after {
+            content: '';
+            position: absolute;
             left: 50%;
             top: 50%;
             width: 10px;
             height: 2px;
+            border-radius: 2px;
             background: #6a6a6a;
             margin: 0;
+            transform-origin: center;
+        }
+
+        .nitro-card-close-button::before {
+            transform: translate(-50%, -50%) rotate(45deg);
+        }
+
+        .nitro-card-close-button::after {
+            transform: translate(-50%, -50%) rotate(-45deg);
         }
     }
 


### PR DESCRIPTION
## Summary
- Restores the Wired close button icon by defining the missing pseudo-element content, positioning, and rotations.
- Keeps the existing Wired-specific button styling intact.

## Checks
- `yarn.cmd lint`
- `git diff --check`
- `yarn.cmd test src/css/ui-css-ownership.test.ts`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.