### PR TITLE
fix: clamp navigator popup windows

### DIFF
--- a/src/components/navigator/views/NavigatorDoorStateView.tsx
+++ b/src/components/navigator/views/NavigatorDoorStateView.tsx
@@ -45,7 +45,7 @@ export const NavigatorDoorStateView: FC<{}> = (props) => {
     const isDoorbell = DOORBELL_STATES.indexOf(snapshot.state) >= 0;
 
     return (
-        <NitroCardView className="nitro-navigator-doorbell" theme="primary-slim">
+        <NitroCardView className="nitro-navigator-doorbell min-w-0 w-[min(320px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText(isDoorbell ? 'navigator.doorbell.title' : 'navigator.password.title')} onCloseClick={onClose} />
             <NitroCardContentView>
                 <div className="flex flex-col gap-1">

--- a/src/components/navigator/views/NavigatorRoomInfoView.tsx
+++ b/src/components/navigator/views/NavigatorRoomInfoView.tsx
@@ -138,10 +138,10 @@ export const NavigatorRoomInfoView: FC<NavigatorRoomInfoViewProps> = (props) => 
     if (!navigatorData?.enteredGuestRoom) return null;
 
     return (
-        <NitroCardView className="nitro-room-info" theme="primary-slim">
+        <NitroCardView className="nitro-room-info min-w-0 w-[min(380px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText('navigator.roomsettings.roominfo')} onCloseClick={() => processAction('close')} />
-            <NitroCardContentView className="text-black">
-                <Flex gap={2} overflow="hidden">
+            <NitroCardContentView className="text-black max-h-[calc(100vh-72px)]" overflow="auto">
+                <Flex gap={2} overflow="hidden" className="flex-col sm:flex-row">
                     <LayoutRoomThumbnailView customUrl={navigatorData.enteredGuestRoom.officialRoomPicRef} roomId={navigatorData.enteredGuestRoom.roomId}>
                         {hasPermission('settings') && (
                             <i

--- a/src/components/navigator/views/NavigatorRoomLinkView.tsx
+++ b/src/components/navigator/views/NavigatorRoomLinkView.tsx
@@ -14,19 +14,19 @@ export const NavigatorRoomLinkView: FC<NavigatorRoomLinkViewProps> = (props) => 
     if (!navigatorData.enteredGuestRoom) return null;
 
     return (
-        <NitroCardView className="nitro-room-link" theme="primary-slim">
+        <NitroCardView className="nitro-room-link min-w-0 w-[min(430px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText('navigator.embed.title')} onCloseClick={onCloseClick} />
-            <NitroCardContentView className="text-black flex items-center">
-                <div className="flex gap-2">
+            <NitroCardContentView className="text-black flex items-center max-h-[calc(100vh-72px)]" overflow="auto">
+                <div className="flex flex-col sm:flex-row gap-2 min-w-0">
                     <LayoutRoomThumbnailView customUrl={navigatorData.enteredGuestRoom.officialRoomPicRef} roomId={navigatorData.enteredGuestRoom.roomId} />
-                    <div className="flex flex-col">
+                    <div className="flex flex-col min-w-0">
                         <Text bold fontSize={5}>
                             {LocalizeText('navigator.embed.headline')}
                         </Text>
                         <Text>{LocalizeText('navigator.embed.info')}</Text>
                         <input
                             readOnly
-                            className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem]  rounded-[.2rem] form-control-sm"
+                            className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem] rounded-[.2rem] form-control-sm w-full min-w-0"
                             type="text"
                             value={LocalizeText('navigator.embed.src', ['roomId'], [navigatorData.enteredGuestRoom.roomId.toString()]).replace(
                                 '${url.prefix}',


### PR DESCRIPTION
## Summary
- Adds viewport clamps to navigator doorbell/password, room info, and room link popups.
- Lets room info and room link stack their thumbnail/content on small screens.
- Keeps long room link inputs constrained to the popup width.

## Checks
- `yarn.cmd lint`
- `git diff --check`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.