### PR TITLE
fix: clamp room widget windows

### DIFF
--- a/src/components/room/widgets/furniture/FurnitureAreaHideView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureAreaHideView.tsx
@@ -21,7 +21,10 @@ export const FurnitureAreaHideView: FC<{}> = (props) => {
     if (objectId === -1) return null;
 
     return (
-        <NitroCardView theme="primary-slim" className="nitro-room-widget-area-hide" style={{ maxWidth: '400px' }}>
+        <NitroCardView
+            theme="primary-slim"
+            className="nitro-room-widget-area-hide min-w-0 w-[min(400px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
+        >
             <NitroCardHeaderView headerText={LocalizeText('widget.areahide.title')} onCloseClick={onClose} />
             <NitroCardContentView overflow="hidden" justifyContent="between">
                 <Column gap={2}>

--- a/src/components/room/widgets/furniture/playlist-editor/FurniturePlaylistEditorWidgetView.tsx
+++ b/src/components/room/widgets/furniture/playlist-editor/FurniturePlaylistEditorWidgetView.tsx
@@ -23,11 +23,11 @@ export const FurniturePlaylistEditorWidgetView: FC<{}> = (props) => {
         <NitroCardView className="nitro-playlist-editor-widget" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText('playlist.editor.title')} onCloseClick={onClose} />
             <NitroCardContentView>
-                <div className="flex flex-row gap-1 h-full">
-                    <div className="w-50 relative overflow-hidden h-full rounded flex flex-col">
+                <div className="playlist-editor-layout flex flex-row gap-1 h-full min-h-0">
+                    <div className="playlist-editor-pane relative overflow-hidden h-full rounded flex flex-col min-w-0">
                         <DiskInventoryView addToPlaylist={addToPlaylist} diskInventory={diskInventory} />
                     </div>
-                    <div className="w-50 relative overflow-hidden h-full rounded flex flex-col">
+                    <div className="playlist-editor-pane relative overflow-hidden h-full rounded flex flex-col min-w-0">
                         <SongPlaylistView
                             currentPlayingIndex={currentPlayingIndex}
                             furniId={objectId}

--- a/src/components/room/widgets/pet-package/PetPackageWidgetView.tsx
+++ b/src/components/room/widgets/pet-package/PetPackageWidgetView.tsx
@@ -17,7 +17,11 @@ export const PetPackageWidgetView: FC<{}> = (props) => {
     return (
         <>
             {isVisible && (
-                <NitroCardView className="nitro-pet-package no-resize" theme="primary-slim">
+                <NitroCardView
+                    isResizable={false}
+                    className="nitro-pet-package min-w-0 w-[min(340px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
+                    theme="primary-slim"
+                >
                     <NitroCardHeaderView
                         center
                         headerText={objectType === 'gnome_box' ? LocalizeText('widgets.gnomepackage.name.title') : LocalizeText('furni.petpackage.open')}
@@ -36,7 +40,7 @@ export const PetPackageWidgetView: FC<{}> = (props) => {
                             <div className="flex flex-col gap-1">
                                 <div className="flex items-center bg-white rounded py-1 px-2 input-pet-package-container">
                                     <input
-                                        className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem]  rounded-[.2rem] form-control-sm input-pet-package"
+                                        className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem] rounded-[.2rem] form-control-sm input-pet-package w-full min-w-0"
                                         maxLength={GetConfigurationValue('pet.package.name.max.length')}
                                         placeholder={
                                             objectType === 'gnome_box'

--- a/src/components/room/widgets/room-filter-words/RoomFilterWordsWidgetView.tsx
+++ b/src/components/room/widgets/room-filter-words/RoomFilterWordsWidgetView.tsx
@@ -44,7 +44,11 @@ export const RoomFilterWordsWidgetView: FC<{}> = (props) => {
     if (!isVisible) return null;
 
     return (
-        <NitroCardView className="nitro-guide-tool no-resize" theme="primary-slim">
+        <NitroCardView
+            isResizable={false}
+            className="nitro-guide-tool nitro-room-filter-words min-w-0 w-[min(340px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
+            theme="primary-slim"
+        >
             <NitroCardHeaderView headerText={LocalizeText('navigator.roomsettings.roomfilter')} onCloseClick={() => onClose()} />
             <NitroCardContentView className="text-black">
                 <Grid className="flex items-center gap-2 justify-end">
@@ -52,7 +56,7 @@ export const RoomFilterWordsWidgetView: FC<{}> = (props) => {
                     <Button onClick={() => processAction(true)}>{LocalizeText('navigator.roomsettings.roomfilter.addword')}</Button>
                 </Grid>
                 <Column
-                    className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem]  rounded-[.2rem] form-control-sm"
+                    className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem] rounded-[.2rem] form-control-sm"
                     gap={0}
                     overflow="auto"
                     style={{ height: '100px' }}

--- a/src/components/room/widgets/room-promotes/views/RoomPromoteEditWidgetView.tsx
+++ b/src/components/room/widgets/room-promotes/views/RoomPromoteEditWidgetView.tsx
@@ -22,7 +22,7 @@ export const RoomPromoteEditWidgetView: FC<RoomPromoteEditWidgetViewProps> = (pr
     };
 
     return (
-        <NitroCardView className="nitro-guide-tool" theme="primary-slim">
+        <NitroCardView className="nitro-guide-tool nitro-room-promote-edit min-w-0 w-[min(340px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText('navigator.eventsettings.editcaption')} onCloseClick={() => setIsEditingPromote(false)} />
             <NitroCardContentView className="text-black">
                 <div className="flex flex-col">
@@ -38,7 +38,7 @@ export const RoomPromoteEditWidgetView: FC<RoomPromoteEditWidgetViewProps> = (pr
                 <div className="flex flex-col">
                     <Text bold>{LocalizeText('navigator.eventsettings.desc')}</Text>
                     <textarea
-                        className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem]  rounded-[.2rem] form-control-sm"
+                        className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem] rounded-[.2rem] form-control-sm"
                         maxLength={64}
                         placeholder={LocalizeText('navigator.eventsettings.desc')}
                         value={newEventDescription}

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -509,8 +509,20 @@
 }
 
 .nitro-playlist-editor-widget {
-    width: 625px;
-    height: 440px;
+    width: min(625px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    height: min(440px, calc(100vh - 16px));
+    min-height: 0;
+    max-height: calc(100vh - 16px);
+
+    .playlist-editor-layout {
+        min-height: 0;
+    }
+
+    .playlist-editor-pane {
+        flex: 1 1 0;
+    }
 
     img.my-music {
         position: absolute;
@@ -607,6 +619,19 @@
             mask-image: url('@/assets/images/room-widgets/playlist-editor/disk_image.png');
             height: 76px;
             width: 76px;
+        }
+    }
+}
+
+@media (max-width: 640px), (max-height: 520px) {
+    .nitro-playlist-editor-widget {
+        .playlist-editor-layout {
+            flex-direction: column;
+        }
+
+        .playlist-editor-pane {
+            width: 100%;
+            min-height: 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds viewport-safe clamps to room filter, room promote edit, pet package, area hide, and playlist editor windows.
- Removes the old inline maxWidth from area hide and avoids the global `.no-resize` fixed 340x430 rule for room filter/pet package.
- Lets the playlist editor stack its two panes on narrow or short viewports.

## Checks
- `yarn.cmd lint`
- `git diff --check`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.