### PR TITLE
fix: clamp furniture dialog windows

### DIFF
--- a/src/components/room/widgets/furniture/FurnitureCraftingView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureCraftingView.tsx
@@ -66,8 +66,8 @@ export const FurnitureCraftingView: FC<{}> = (props) => {
         <NitroCardView className="nitro-widget-crafting" theme="primary-slim">
             <NitroCardHeaderView headerText={LocalizeText('crafting.title')} onCloseClick={onClose} />
             <NitroCardContentView>
-                <div className="flex grow! gap-2 overflow-hidden">
-                    <div className="flex flex-col w-full gap-2">
+                <div className="crafting-widget-layout flex grow! gap-2 overflow-hidden">
+                    <div className="crafting-widget-pane flex flex-col w-full gap-2 min-w-0">
                         <Column fullHeight overflow="hidden">
                             <div className="bg-muted rounded py-1 text-center">{LocalizeText('crafting.title.products')}</div>
                             <AutoGrid columnCount={5}>
@@ -98,7 +98,7 @@ export const FurnitureCraftingView: FC<{}> = (props) => {
                             </AutoGrid>
                         </Column>
                     </div>
-                    <div className="flex flex-col w-full gap-2">
+                    <div className="crafting-widget-pane flex flex-col w-full gap-2 min-w-0">
                         {!selectedRecipe && (
                             <Column center fullHeight className="text-black text-center">
                                 {LocalizeText('crafting.info.start')}

--- a/src/components/room/widgets/furniture/FurnitureExternalImageView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureExternalImageView.tsx
@@ -19,7 +19,12 @@ export const FurnitureExternalImageView: FC<{}> = (props) => {
     };
 
     return (
-        <NitroCardView className="nitro-external-image-widget no-resize" uniqueKey="photo-viewer" theme="primary-slim">
+        <NitroCardView
+            isResizable={false}
+            className="nitro-external-image-widget min-w-0 max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
+            uniqueKey="photo-viewer"
+            theme="primary-slim"
+        >
             <NitroCardHeaderView
                 headerText={LocalizeText('camera.interface.title')}
                 isGalleryPhoto={true}

--- a/src/components/room/widgets/furniture/FurnitureMysteryTrophyOpenDialogView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureMysteryTrophyOpenDialogView.tsx
@@ -20,7 +20,11 @@ export const FurnitureMysteryTrophyOpenDialogView: FC<FurnitureMysteryTrophyOpen
     if (objectId === -1) return null;
 
     return (
-        <NitroCardView className="nitro-mysterytrophy-dialog no-resize" theme="primary-slim">
+        <NitroCardView
+            isResizable={false}
+            className="nitro-mysterytrophy-dialog min-w-0 w-[min(400px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]"
+            theme="primary-slim"
+        >
             <NitroCardHeaderView center headerText={LocalizeText('mysterytrophy.header.title')} onCloseClick={onClose} />
             <NitroCardContentView>
                 <div className="flex mysterytrophy-dialog-top p-3">
@@ -35,7 +39,7 @@ export const FurnitureMysteryTrophyOpenDialogView: FC<FurnitureMysteryTrophyOpen
                     <div className="flex flex-col gap-1">
                         <div className="flex items-center bg-white rounded py-1 px-2 input-mysterytrophy-dialog">
                             <textarea
-                                className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem]  rounded-[.2rem] form-control-sm input-mysterytrophy"
+                                className="min-h-[calc(1.5em+ .5rem+2px)] px-[.5rem] py-[.25rem] rounded-[.2rem] form-control-sm input-mysterytrophy"
                                 value={description}
                                 onChange={(event) => setDescription(event.target.value)}
                             />

--- a/src/css/room/InfoStand.css
+++ b/src/css/room/InfoStand.css
@@ -1,5 +1,13 @@
 .nitro-use-product-confirmation {
-  width: 350px;
+  width: min(350px, calc(100vw - 16px));
+  min-width: 0;
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+
+  .nitro-card-content-shell {
+    max-height: calc(100vh - 72px);
+    overflow: auto;
+  }
 
   .product-preview {
     display: flex;
@@ -19,6 +27,12 @@
       height: 80px;
       background: url('@/assets/images/room-widgets/furni-context-menu/monsterplant-preview.png') no-repeat center;
     }
+  }
+}
+
+@media (max-width: 420px) {
+  .nitro-use-product-confirmation .nitro-card-content-shell > .flex {
+    flex-direction: column;
   }
 }
 

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -151,7 +151,10 @@
 }
 
 .nitro-room-widget-dimmer {
-    width: 275px;
+    width: min(275px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
 
     .dimmer-banner {
         width: 56px;
@@ -172,13 +175,29 @@
 }
 
 .nitro-widget-crafting {
-    width: 500px;
-    height: 300px;
+    width: min(500px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    height: min(300px, calc(100vh - 16px));
+    min-height: 0;
+    max-height: calc(100vh - 16px);
+
+    .crafting-widget-layout {
+        min-height: 0;
+    }
+
+    .crafting-widget-pane {
+        flex: 1 1 0;
+    }
 }
 
 .nitro-widget-exchange-credit {
-    width: 375px;
-    height: 150px;
+    width: min(375px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    height: min(150px, calc(100vh - 16px));
+    min-height: 0;
+    max-height: calc(100vh - 16px);
 
     .exchange-image {
         background-image: url('@/assets/images/room-widgets/exchange-credit/exchange-credit-image.png');
@@ -188,9 +207,15 @@
 }
 
 .nitro-external-image-widget {
+    width: min(340px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+
     .picture-preview {
-        width: 320px;
-        height: 320px;
+        width: min(320px, calc(100vw - 36px));
+        height: auto;
+        aspect-ratio: 1;
     }
     
     .picture-preview-buttons {
@@ -209,7 +234,10 @@
 }
 
 .nitro-gift-opening {
-    width: 340px;
+    width: min(340px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
     resize: none;
 }
 
@@ -612,8 +640,12 @@
 }
 
 .nitro-mysterybox-dialog {
-    width: 375px;
-    height: 210px;
+    width: min(375px, calc(100vw - 16px));
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+    height: min(210px, calc(100vh - 16px));
+    min-height: 0;
+    max-height: calc(100vh - 16px);
 
     .prize-container {
         height: 80px;
@@ -624,17 +656,14 @@
     }
 }
 
-.nitro-mysterytrophy-dialog
-{
-    .mysterytrophy-dialog-top
-    {
-        width: 400px;
-        height: 120px;
+.nitro-mysterytrophy-dialog {
+    .mysterytrophy-dialog-top {
+        width: 100%;
+        min-height: 120px;
         border-radius: 2px;
         background-color: #0E3F52;
 
-        .mysterytrophy-image
-        {
+        .mysterytrophy-image {
             width: 80px;
             height: 84px;
             position: relative;
@@ -642,35 +671,32 @@
             background-repeat: no-repeat;
         }
 
-        .mysterytrophy-text-big
-        {
+        .mysterytrophy-text-big {
             font-size: 16px;
         }
     }
 
-    .mysterytrophy-dialog-bottom
-    {
+    .mysterytrophy-dialog-bottom {
         display: flex;
         justify-content: center;
-        width: 400px;
-        height: 120px;
+        width: 100%;
+        min-height: 120px;
         border-radius: 2px;
         background-color: #E9E9E1;
 
-        .input-mysterytrophy-dialog
-        {
-            width: 380px;
+        .input-mysterytrophy-dialog {
+            width: min(380px, 100%);
+            min-width: 0;
             border: 1px solid black;
 
-            .input-mysterytrophy
-            {
-                width: 350px;
+            .input-mysterytrophy {
+                width: 100%;
+                min-width: 0;
                 border: 0;
                 outline: 0;
             }
 
-            .mysterytrophy-pencil-image
-            {
+            .mysterytrophy-pencil-image {
                 width: 16px;
                 height: 16px;
                 position: relative;
@@ -679,9 +705,26 @@
             }
         }
 
-        .text-decoration
-        {
+        .text-decoration {
             text-decoration: underline;
         }
+    }
+}
+
+@media (max-width: 560px), (max-height: 460px) {
+    .nitro-widget-crafting {
+        .crafting-widget-layout {
+            flex-direction: column;
+            overflow: auto;
+        }
+
+        .crafting-widget-pane {
+            width: 100%;
+            min-height: 0;
+        }
+    }
+
+    .nitro-widget-exchange-credit {
+        height: auto;
     }
 }


### PR DESCRIPTION
## Summary
- Adds viewport-safe sizing for crafting, dimmer, exchange credit, external image, gift opening, mystery box, and mystery trophy dialogs.
- Replaces fixed image/trophy dialog dimensions with responsive caps while preserving desktop sizing.
- Makes use-product confirmations scroll/stack on small screens.

## Checks
- `yarn.cmd lint`
- `git diff --check`
- `yarn.cmd test src/css/ui-css-ownership.test.ts`

## Note
- Local `yarn.cmd typecheck` still fails on the current Dev baseline with `src/pixiPatch.ts(1,23): Cannot find module 'pixi.js'`; that alias fix is isolated in PR #279.