### PR TITLE
feat(purse): show remaining HC time on the club button

### DIFF
--- a/src/components/purse/PurseView.tsx
+++ b/src/components/purse/PurseView.tsx
@@ -1,7 +1,7 @@
 import { CreateLinkEvent } from '@nitrots/nitro-renderer';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { FaChartBar, FaCog, FaLanguage, FaSignOutAlt } from 'react-icons/fa';
-import { ClearRememberLogin, GetConfigurationValue, GetRememberLogin, LocalizeText, localizeWithFallback } from '../../api';
+import { ClearRememberLogin, FriendlyTime, GetConfigurationValue, GetRememberLogin, LocalizeText, localizeWithFallback } from '../../api';
 import { Column, LayoutCurrencyIcon } from '../../common';
 import { usePurse } from '../../hooks';
 import { CurrencyView } from './views/CurrencyView';
@@ -39,6 +39,17 @@ export const PurseView: FC<{}> = (props) => {
     const otherCurrencies = currencyTypes.filter((type) => type !== 0 && type !== 5);
 
     const joinLabel = useMemo(() => localizeWithFallback('purse.join', 'Join'), []);
+
+    // When the user has active HC, show the remaining time instead of "Join"
+    // (same formula as the HC Center's getClubText).
+    const clubLabel = useMemo(() => {
+        if (!purse || purse.clubDays <= 0) return joinLabel;
+        if (purse.minutesUntilExpiration > -1 && purse.minutesUntilExpiration < 60 * 24) {
+            return FriendlyTime.shortFormat(purse.minutesUntilExpiration * 60);
+        }
+        return FriendlyTime.shortFormat((purse.clubPeriods * 31 + purse.clubDays) * 86400);
+    }, [purse, joinLabel]);
+
     const earningsLabel = useMemo(() => localizeWithFallback('earnings.title', 'Earnings'), []);
     const helpLabel = useMemo(() => localizeWithFallback('help.button.name', 'Help'), []);
 
@@ -93,9 +104,9 @@ export const PurseView: FC<{}> = (props) => {
                     </div>
                     <div className="nitro-purse__col nitro-purse__col--primary">
                         {!hcDisabled && (
-                            <button type="button" className="nitro-purse__btn nitro-purse__btn--join" onClick={openClub} title={joinLabel}>
+                            <button type="button" className="nitro-purse__btn nitro-purse__btn--join" onClick={openClub} title={clubLabel}>
                                 <LayoutCurrencyIcon type="hc" />
-                                <span>{joinLabel}</span>
+                                <span>{clubLabel}</span>
                             </button>
                         )}
                         <button type="button" className="nitro-purse__btn nitro-purse__btn--earnings" onClick={openEarnings} title={earningsLabel}>


### PR DESCRIPTION
## What

When the user has active **Habbo Club**, the purse HC button now shows the **remaining HC time** instead of always reading "Join".

## How

A new `clubLabel` (memoised) mirrors the HC Center's `getClubText` logic:
- no active club (`purse.clubDays <= 0`) → `Join` (unchanged)
- expiring within 24h → `FriendlyTime.shortFormat(minutesUntilExpiration * 60)`
- otherwise → `FriendlyTime.shortFormat((clubPeriods * 31 + clubDays) * 86400)`

The button's label + title use `clubLabel`; `onClick` (open HC Center) is unchanged. All data comes from the existing `usePurse` (`clubDays` / `clubPeriods` / `minutesUntilExpiration`) — no server/renderer changes.

## Scope

Single file: `src/components/purse/PurseView.tsx` (+14 / -3).