### PR TITLE
perf(catalog): faster open — virtual grid, session index cache, lazy icons

### DIFF
--- a/scripts/catalog-stats.mjs
+++ b/scripts/catalog-stats.mjs
@@ -1,0 +1,52 @@
+import mysql from 'mysql2/promise';
+
+const c = await mysql.createConnection({
+    host: 'localhost',
+    user: 'habbo',
+    password: 'habbo',
+    database: 'next'
+});
+
+const [[{ pages }]] = await c.query('SELECT COUNT(*) AS pages FROM catalog_pages');
+const [[{ items }]] = await c.query('SELECT COUNT(*) AS items FROM catalog_items');
+const [[{ visible }]] = await c.query("SELECT COUNT(*) AS visible FROM catalog_pages WHERE visible = '1'");
+const [topPages] = await c.query(
+    'SELECT page_id, COUNT(*) AS offers FROM catalog_items GROUP BY page_id ORDER BY offers DESC LIMIT 10'
+);
+const [topParents] = await c.query(
+    'SELECT parent_id, COUNT(*) AS children FROM catalog_pages GROUP BY parent_id ORDER BY children DESC LIMIT 5'
+);
+
+// Estimate index packet: each node ~ (visible, icon, id, parent, name, caption, offerCount + offerIds + childCount)
+let offerIdTotal = 0;
+const [offerCounts] = await c.query(`
+    SELECT cp.id, COUNT(ci.id) AS offer_count
+    FROM catalog_pages cp
+    LEFT JOIN catalog_items ci ON ci.page_id = cp.id
+    WHERE cp.visible = '1'
+    GROUP BY cp.id
+`);
+for (const row of offerCounts) offerIdTotal += Number(row.offer_count);
+
+const [layouts] = await c.query(
+    "SELECT page_layout, COUNT(*) AS cnt FROM catalog_pages WHERE visible = '1' GROUP BY page_layout ORDER BY cnt DESC LIMIT 12"
+);
+const [[avgRow]] = await c.query(
+    'SELECT AVG(oc) AS avg_offers, MAX(oc) AS max_offers FROM (SELECT COUNT(*) AS oc FROM catalog_items GROUP BY page_id) t'
+);
+const [[over100]] = await c.query(
+    'SELECT COUNT(*) AS c FROM (SELECT page_id FROM catalog_items GROUP BY page_id HAVING COUNT(*) > 100) x'
+);
+const [[over500]] = await c.query(
+    'SELECT COUNT(*) AS c FROM (SELECT page_id FROM catalog_items GROUP BY page_id HAVING COUNT(*) > 500) x'
+);
+const estIndexKB = Math.round((Number(pages) * 80 + offerIdTotal * 4) / 1024);
+
+console.log(
+    JSON.stringify(
+        { pages, items, visible, offerIdTotal, estIndexKB, topPages, topParents, layouts, avgRow, over100, over500 },
+        null,
+        2
+    )
+);
+await c.end();

--- a/src/components/catalog/views/page/common/CatalogGridOfferView.tsx
+++ b/src/components/catalog/views/page/common/CatalogGridOfferView.tsx
@@ -1,5 +1,5 @@
 import { MouseEventType } from '@nitrots/nitro-renderer';
-import { FC, MouseEvent, useMemo, useState } from 'react';
+import { FC, MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { FaHeart } from 'react-icons/fa';
 import { CatalogType, GetConfigurationValue, IPurchasableOffer, Offer, ProductTypeEnum } from '../../../../../api';
 import { LayoutAvatarImageView, LayoutGridItem, LayoutGridItemProps } from '../../../../../common';
@@ -19,8 +19,36 @@ export const CatalogGridOfferView: FC<CatalogGridOfferViewProps> = (props) => {
     const { isVisible = false } = useInventoryFurni();
     const { isFavoriteOffer, toggleFavoriteOffer } = useCatalogFavorites();
     const isFav = offer ? isFavoriteOffer(offer.offerId) : false;
+    const tileRef = useRef<HTMLDivElement>(null);
+    const [iconVisible, setIconVisible] = useState(false);
 
-    const iconUrl = useMemo(() => {
+    useEffect(() => {
+        const el = tileRef.current;
+
+        if (!el) return;
+
+        if (typeof IntersectionObserver === 'undefined') {
+            setIconVisible(true);
+
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    setIconVisible(true);
+                    observer.disconnect();
+                }
+            },
+            { root: el.closest('.nitro-catalog-default-layout, .nitro-catalog-window') ?? null, rootMargin: '120px' }
+        );
+
+        observer.observe(el);
+
+        return () => observer.disconnect();
+    }, [offer?.offerId]);
+
+    const resolvedIconUrl = useMemo(() => {
         if (!offer) return null;
 
         if (offer.pricingModel === Offer.PRICING_MODEL_BUNDLE) {
@@ -53,6 +81,8 @@ export const CatalogGridOfferView: FC<CatalogGridOfferViewProps> = (props) => {
 
         return product.getIconUrl(offer) ?? null;
     }, [offer]);
+
+    const iconUrl = iconVisible ? resolvedIconUrl : null;
 
     const prices = useMemo(() => {
         if (!offer) return [];
@@ -97,6 +127,7 @@ export const CatalogGridOfferView: FC<CatalogGridOfferViewProps> = (props) => {
     if (!product) return null;
 
     return (
+        <div ref={tileRef}>
         <LayoutGridItem
             className={`group/tile relative ${itemActive ? 'is-active' : ''}`}
             gap={1}
@@ -140,12 +171,13 @@ export const CatalogGridOfferView: FC<CatalogGridOfferViewProps> = (props) => {
                 onClick={(e) => {
                     e.stopPropagation();
                     e.preventDefault();
-                    toggleFavoriteOffer(offer.offerId, offer.localizationName, iconUrl);
+                    toggleFavoriteOffer(offer.offerId, offer.localizationName, resolvedIconUrl);
                 }}
                 onMouseDown={(e) => e.stopPropagation()}
             >
                 <FaHeart className={`text-[10px] drop-shadow transition-colors duration-100 ${isFav ? 'text-danger' : 'text-muted hover:text-danger'}`} />
             </div>
         </LayoutGridItem>
+        </div>
     );
 };

--- a/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.tsx
@@ -1,3 +1,4 @@
+import { InfiniteGrid } from '@layout/InfiniteGrid';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { IPurchasableOffer } from '../../../../../api';
 import { AutoGrid, AutoGridProps } from '../../../../../common';
@@ -5,12 +6,15 @@ import { useCatalogActions, useCatalogData } from '../../../../../hooks';
 import { useCatalogAdmin } from '../../../CatalogAdminContext';
 import { CatalogGridOfferView } from '../common/CatalogGridOfferView';
 
+/** Pages above this count use @tanstack/react-virtual via InfiniteGrid. */
+const VIRTUALIZE_OFFER_THRESHOLD = 500;
+
 interface CatalogItemGridWidgetViewProps extends AutoGridProps {
     tintColor?: string;
 }
 
 export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (props) => {
-    const { columnCount = 5, tintColor = null, children = null, ...rest } = props;
+    const { columnCount = 5, columnMinHeight = 80, tintColor = null, children = null, className = '', ...rest } = props;
     const { currentOffer = null, currentPage = null } = useCatalogData();
     const { selectCatalogOffer = null } = useCatalogActions();
     const catalogAdmin = useCatalogAdmin();
@@ -19,8 +23,11 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
     const [dragIndex, setDragIndex] = useState<number | null>(null);
     const [dropIndex, setDropIndex] = useState<number | null>(null);
 
+    const offers = currentPage?.offers ?? [];
+    const useVirtualGrid = !adminMode && offers.length > VIRTUALIZE_OFFER_THRESHOLD;
+
     useEffect(() => {
-        if (elementRef && elementRef.current) elementRef.current.scrollTop = 0;
+        if (elementRef.current) elementRef.current.scrollTop = 0;
     }, [currentPage]);
 
     const handleDragStart = useCallback((index: number) => {
@@ -35,12 +42,12 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
     const handleDrop = useCallback(
         (index: number) => {
             if (dragIndex !== null && dragIndex !== index && currentPage?.offers) {
-                const offers = [...currentPage.offers];
-                const [moved] = offers.splice(dragIndex, 1);
+                const reordered = [...currentPage.offers];
+                const [moved] = reordered.splice(dragIndex, 1);
 
-                offers.splice(index, 0, moved);
+                reordered.splice(index, 0, moved);
 
-                const orders = offers.map((o, i) => ({ id: o.offerId, orderNumber: i }));
+                const orders = reordered.map((o, i) => ({ id: o.offerId, orderNumber: i }));
 
                 catalogAdmin?.reorderOffers(orders);
             }
@@ -62,33 +69,48 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
         selectCatalogOffer(offer);
     };
 
-    return (
-        <AutoGrid columnCount={columnCount} innerRef={elementRef} {...rest}>
-            {currentPage.offers &&
-                currentPage.offers.length > 0 &&
-                currentPage.offers.map((offer, index) => {
-                    const isDragging = dragIndex === index;
-                    const isDropTarget = dropIndex === index && dragIndex !== index;
+    const renderOfferTile = (offer: IPurchasableOffer, index: number) => {
+        const isDragging = dragIndex === index;
+        const isDropTarget = dropIndex === index && dragIndex !== index;
 
-                    return (
-                        <div
-                            key={index}
-                            className={`${isDragging ? 'opacity-40' : ''} ${isDropTarget ? 'ring-2 ring-primary ring-offset-1 rounded' : ''}`}
-                            draggable={adminMode}
-                            onDragEnd={adminMode ? handleDragEnd : undefined}
-                            onDragOver={adminMode ? (e) => handleDragOver(e, index) : undefined}
-                            onDragStart={adminMode ? () => handleDragStart(index) : undefined}
-                            onDrop={adminMode ? () => handleDrop(index) : undefined}
-                        >
-                            <CatalogGridOfferView
-                                itemActive={currentOffer && currentOffer.offerId === offer.offerId}
-                                offer={offer}
-                                selectOffer={selectOffer}
-                                tintColor={tintColor}
-                            />
-                        </div>
-                    );
-                })}
+        return (
+            <div
+                key={offer.offerId}
+                className={`${isDragging ? 'opacity-40' : ''} ${isDropTarget ? 'ring-2 ring-primary ring-offset-1 rounded' : ''}`}
+                draggable={adminMode}
+                onDragEnd={adminMode ? handleDragEnd : undefined}
+                onDragOver={adminMode ? (e) => handleDragOver(e, index) : undefined}
+                onDragStart={adminMode ? () => handleDragStart(index) : undefined}
+                onDrop={adminMode ? () => handleDrop(index) : undefined}
+            >
+                <CatalogGridOfferView
+                    itemActive={currentOffer && currentOffer.offerId === offer.offerId}
+                    offer={offer}
+                    selectOffer={selectOffer}
+                    tintColor={tintColor}
+                />
+            </div>
+        );
+    };
+
+    if (useVirtualGrid) {
+        return (
+            <div className={`nitro-catalog-grid-virtual h-full min-h-0 ${className}`.trim()}>
+                <InfiniteGrid
+                    columnCount={columnCount}
+                    estimateSize={columnMinHeight}
+                    items={offers}
+                    overscan={4}
+                    itemRender={(offer, index) => (offer ? renderOfferTile(offer, index) : <></>)}
+                />
+                {children}
+            </div>
+        );
+    }
+
+    return (
+        <AutoGrid className={className} columnCount={columnCount} columnMinHeight={columnMinHeight} innerRef={elementRef} {...rest}>
+            {offers.length > 0 && offers.map((offer, index) => renderOfferTile(offer, index))}
             {children}
         </AutoGrid>
     );

--- a/src/hooks/catalog/useCatalog.ts
+++ b/src/hooks/catalog/useCatalog.ts
@@ -85,6 +85,12 @@ import {
 } from './useCatalog.helpers';
 import { useCatalogPlaceMultipleItems } from './useCatalogPlaceMultipleItems';
 import { useCatalogSkipPurchaseConfirmation } from './useCatalogSkipPurchaseConfirmation';
+import {
+    catalogIndexRootFromSnapshot,
+    clearCatalogIndexCache,
+    readCatalogIndexCache,
+    writeCatalogIndexCache
+} from './useCatalogIndexCache';
 
 const DUMMY_PAGE_ID_FOR_OFFER_SEARCH = -12345678;
 const DRAG_AND_DROP_ENABLED = true;
@@ -168,9 +174,13 @@ const useCatalogStore = () => {
         setCurrentType(normalizeCatalogType(type));
     }, []);
 
-    // Real-time furni importati: ri-mergia il chunk custom/imported.json5 nelle Map
-    // furnidata + RoomContentLoader all'apertura del catalogo, SENZA reload del client.
-    const refreshImportedFurnidata = useCallback(() => {
+    // Real-time furni importati: merge custom/imported.json5 once per session (or after publish).
+    // Fetching on every catalog open was adding avoidable latency; the file is usually absent.
+    const importedFurnidataMerged = useRef(false);
+
+    const refreshImportedFurnidata = useCallback((force: boolean = false) => {
+        if (!force && importedFurnidataMerged.current) return;
+
         try {
             const base = GetConfiguration().getValue<string>('furnidata.url');
 
@@ -181,6 +191,8 @@ const useCatalogStore = () => {
             GetSessionDataManager()
                 .mergeFurnitureDataFromUrl(importedUrl)
                 .then((added) => {
+                    importedFurnidataMerged.current = true;
+
                     if (added && added.length) GetRoomContentLoader().processFurnitureData(added);
                 })
                 .catch(() => {});
@@ -615,6 +627,7 @@ const useCatalogStore = () => {
 
         const { rootNode: builtRoot, offersToNodes: builtOffers } = buildCatalogNodeTree(parser.root);
 
+        writeCatalogIndexCache(parserCatalogType, parser.root);
         setRootNode(builtRoot);
         setOffersToNodes(builtOffers);
     });
@@ -816,6 +829,8 @@ const useCatalogStore = () => {
     useMessageEvent<CatalogPublishedMessageEvent>(CatalogPublishedMessageEvent, (event) => {
         const wasVisible = isVisible;
 
+        importedFurnidataMerged.current = false;
+        clearCatalogIndexCache();
         resetState();
 
         if (wasVisible)
@@ -1114,6 +1129,19 @@ const useCatalogStore = () => {
 
     useEffect(() => {
         if (!isVisible || rootNode) return;
+
+        const cachedRoot = readCatalogIndexCache(currentType);
+
+        if (cachedRoot) {
+            const { rootNode: builtRoot, offersToNodes: builtOffers } = buildCatalogNodeTree(catalogIndexRootFromSnapshot(cachedRoot));
+
+            setRootNode(builtRoot);
+            setOffersToNodes(builtOffers);
+
+            SendMessageComposer(new BuildersClubQueryFurniCountMessageComposer());
+
+            return;
+        }
 
         SendMessageComposer(new GetCatalogIndexComposer(currentType));
         SendMessageComposer(new BuildersClubQueryFurniCountMessageComposer());

--- a/src/hooks/catalog/useCatalogIndexCache.ts
+++ b/src/hooks/catalog/useCatalogIndexCache.ts
@@ -1,0 +1,103 @@
+import { NodeData } from '@nitrots/nitro-renderer';
+import { normalizeCatalogType } from './useCatalog.helpers';
+
+const CACHE_VERSION = 1;
+const CACHE_KEY_PREFIX = 'nitro-catalog-index';
+
+export type CatalogIndexNodeSnapshot = {
+    visible: boolean;
+    icon: number;
+    pageId: number;
+    parentId: number;
+    pageName: string;
+    localization: string;
+    offerIds: number[];
+    children: CatalogIndexNodeSnapshot[];
+};
+
+type CatalogIndexCachePayload = {
+    version: number;
+    catalogType: string;
+    savedAt: number;
+    root: CatalogIndexNodeSnapshot;
+};
+
+const cacheKey = (catalogType: string) => `${CACHE_KEY_PREFIX}:v${CACHE_VERSION}:${normalizeCatalogType(catalogType)}`;
+
+export const snapshotCatalogIndexNode = (node: NodeData): CatalogIndexNodeSnapshot => ({
+    visible: node.visible,
+    icon: node.icon,
+    pageId: node.pageId,
+    parentId: node.parentId,
+    pageName: node.pageName,
+    localization: node.localization,
+    offerIds: [...node.offerIds],
+    children: node.children.map(snapshotCatalogIndexNode)
+});
+
+/** Plain tree shape consumed by `buildCatalogNodeTree` / `CatalogNode`. */
+export const catalogIndexRootFromSnapshot = (root: CatalogIndexNodeSnapshot): NodeData => root as unknown as NodeData;
+
+const isValidSnapshot = (value: unknown): value is CatalogIndexNodeSnapshot => {
+    if (!value || typeof value !== 'object') return false;
+
+    const node = value as CatalogIndexNodeSnapshot;
+
+    return (
+        typeof node.pageName === 'string' &&
+        typeof node.localization === 'string' &&
+        Array.isArray(node.children) &&
+        Array.isArray(node.offerIds)
+    );
+};
+
+export const readCatalogIndexCache = (catalogType: string): CatalogIndexNodeSnapshot | null => {
+    if (typeof sessionStorage === 'undefined') return null;
+
+    try {
+        const raw = sessionStorage.getItem(cacheKey(catalogType));
+
+        if (!raw) return null;
+
+        const payload = JSON.parse(raw) as CatalogIndexCachePayload;
+
+        if (payload.version !== CACHE_VERSION) return null;
+        if (normalizeCatalogType(payload.catalogType) !== normalizeCatalogType(catalogType)) return null;
+        if (!isValidSnapshot(payload.root)) return null;
+
+        return payload.root;
+    } catch {
+        return null;
+    }
+};
+
+export const writeCatalogIndexCache = (catalogType: string, root: NodeData): void => {
+    if (typeof sessionStorage === 'undefined' || !root) return;
+
+    try {
+        const payload: CatalogIndexCachePayload = {
+            version: CACHE_VERSION,
+            catalogType: normalizeCatalogType(catalogType),
+            savedAt: Date.now(),
+            root: snapshotCatalogIndexNode(root)
+        };
+
+        sessionStorage.setItem(cacheKey(catalogType), JSON.stringify(payload));
+    } catch {
+        // QuotaExceededError on very large trees — ignore, network path still works.
+    }
+};
+
+export const clearCatalogIndexCache = (): void => {
+    if (typeof sessionStorage === 'undefined') return;
+
+    const keysToRemove: string[] = [];
+
+    for (let i = 0; i < sessionStorage.length; i++) {
+        const key = sessionStorage.key(i);
+
+        if (key?.startsWith(CACHE_KEY_PREFIX)) keysToRemove.push(key);
+    }
+
+    for (const key of keysToRemove) sessionStorage.removeItem(key);
+};


### PR DESCRIPTION
## Summary

Speeds up catalog open and navigation on large catalogs (~80k items, 2.1k pages) with three complementary client optimizations:

1. **Session index cache** — `CatalogPagesList` tree is snapshotted to `sessionStorage` after the first fetch; subsequent opens in the same session skip `GetCatalogIndexComposer`. Cache is cleared on `CatalogPublishedMessageEvent`.
2. **Virtualized offer grid** — pages with **>500 offers** (26 pages on our DB) render via existing `InfiniteGrid` (`@tanstack/react-virtual`) instead of mounting every tile in the DOM. Admin drag-and-drop reorder keeps the full `AutoGrid` path.
3. **Lazy grid icons** — `CatalogGridOfferView` loads furni icon URLs only when the tile is near the viewport (`IntersectionObserver`, 120px margin).

Also skips re-fetching `custom/imported.json5` on every catalog open (once per session; reset on publish).

Includes `scripts/catalog-stats.mjs` — optional MySQL diagnostic for page/offer counts and heavy-page detection.

**Pairs with** server PR: shallow `CatalogPagesList` index (no embedded offer IDs per node).

## Measured context (DB `next`)

| Metric | Value |
|--------|-------|
| Catalog pages | 2,171 (2,162 visible) |
| Catalog items | 79,611 |
| Pages with >500 offers | 26 |
| Largest page | 1,605 offers |

## Tradeoffs

- `offersToNodes` map is empty when index is restored from cache or received from shallow server index — deep-link `catalog/open/offerId/...` no longer resolves via index (search still uses furnidata).
- `sessionStorage` cache may fail silently on quota exceeded; network fallback still works.

## Test plan

- [ ] Open catalog twice in same session — second open should not request catalog index (network tab).
- [ ] Publish a catalog page — reopen catalog; index should be re-fetched and cache rebuilt.
- [ ] Open a page with >500 offers (e.g. page_id 3017) — smooth scroll, only visible icons load.
- [ ] Admin catalog mode — drag-and-drop reorder still works on large pages.
- [ ] Favorites heart icon uses resolved URL even before lazy icon paint.
