### PR TITLE
style(ui): restore official Habbo Ubuntu colors and button chrome

### DIFF
--- a/src/api/ui-settings/IUiSettings.ts
+++ b/src/api/ui-settings/IUiSettings.ts
@@ -7,7 +7,7 @@ export interface IUiSettings {
 
 export const DEFAULT_UI_SETTINGS: IUiSettings = {
     colorMode: 'default',
-    headerColor: '#1E7295',
+    headerColor: '#418db0',
     headerImageUrl: '',
     headerAlpha: 100
 };
@@ -38,8 +38,8 @@ export const PRESET_COLORS: string[] = [
     '#CC33FF',
     '#FF66CC',
     '#FF99CC',
-    '#1E7295',
-    '#185D79',
+    '#418db0',
+    '#376275',
     '#2DABC2',
     '#2B91A7',
     '#283F5D'
@@ -52,7 +52,7 @@ export interface IThemePreset {
 }
 
 export const THEME_PRESETS: IThemePreset[] = [
-    { name: 'default', color: '#1E7295', alpha: 100 },
+    { name: 'default', color: '#418db0', alpha: 100 },
     { name: 'ocean', color: '#0077B6', alpha: 100 },
     { name: 'forest', color: '#2D6A4F', alpha: 100 },
     { name: 'sunset', color: '#E76F51', alpha: 100 },

--- a/src/common/Button.tsx
+++ b/src/common/Button.tsx
@@ -22,7 +22,7 @@ export const Button: FC<ButtonProps> = (props) => {
         if (variant) {
             if (variant == 'primary')
                 newClassNames.push(
-                    'text-white bg-[#1e7295] border-[#1e7295] [box-shadow:inset_0_2px_#ffffff26,inset_0_-2px_#0000001a,0_1px_#0000001a] hover:text-white hover:bg-[#1a617f] hover:border-[#185b77]'
+                    'text-white bg-[#418db0] border-[#2e6f8a] [box-shadow:inset_0_2px_#ffffff26,inset_0_-2px_#0000001a,0_1px_#0000001a] hover:text-white hover:bg-[#3789a8] hover:border-[#2e6f8a]'
                 );
 
             if (variant == 'success')
@@ -47,7 +47,7 @@ export const Button: FC<ButtonProps> = (props) => {
 
             if (variant == 'secondary')
                 newClassNames.push(
-                    'text-white  bg-[#185d79] border-[#185d79] [box-shadow:inset_0_2px_#ffffff26,inset_0_-2px_#0000001a,0_1px_#0000001a]  hover:text-white hover:bg-[#144f67] hover:border-[#134a61]'
+                    'text-[#151515] bg-[#d4e6ef] border-[#376275] [box-shadow:inset_0_2px_#ffffff80,inset_0_-2px_#00000014,0_1px_#00000014] hover:text-[#151515] hover:bg-[#e0eff6] hover:border-[#376275]'
                 );
 
             if (variant == 'dark')
@@ -57,7 +57,7 @@ export const Button: FC<ButtonProps> = (props) => {
 
             if (variant == 'gray')
                 newClassNames.push(
-                    'text-white bg-[#1e7295] border-[#1e7295] [box-shadow:inset_0_2px_#ffffff26,inset_0_-2px_#0000001a,0_1px_#0000001a] hover:text-white hover:bg-[#1a617f] hover:border-[#185b77]'
+                    'text-white bg-[#418db0] border-[#2e6f8a] [box-shadow:inset_0_2px_#ffffff26,inset_0_-2px_#0000001a,0_1px_#0000001a] hover:text-white hover:bg-[#3789a8] hover:border-[#2e6f8a]'
                 );
         }
 

--- a/src/common/Text.tsx
+++ b/src/common/Text.tsx
@@ -44,8 +44,8 @@ export const Text: FC<TextProps> = (props) => {
         const newClassNames: string[] = [truncate ? 'block' : 'inline'];
 
         if (variant) {
-            if (variant === 'primary') newClassNames.push('text-[#1e7295]');
-            if (variant == 'secondary') newClassNames.push('text-[#185d79]');
+            if (variant === 'primary') newClassNames.push('text-[#418db0]');
+            if (variant == 'secondary') newClassNames.push('text-[#376275]');
             if (variant === 'black') newClassNames.push('text-[#000000]');
             if (variant == 'dark') newClassNames.push('text-[#18181b]');
             if (variant === 'gray') newClassNames.push('text-[#6b7280]');

--- a/src/common/layout/LayoutProgressBar.tsx
+++ b/src/common/layout/LayoutProgressBar.tsx
@@ -12,7 +12,7 @@ export const LayoutProgressBar: FC<LayoutProgressBarProps> = (props) => {
 
     const getClassNames = useMemo(() => {
         const newClassNames: string[] = [
-            'border border-[solid] border-[#fff] p-[2px] h-[20px] rounded-[.25rem] overflow-hidden bg-[#1E7295]        ',
+            'border border-[solid] border-[#fff] p-[2px] h-[20px] rounded-[.25rem] overflow-hidden bg-[#418db0]        ',
             'text-white'
         ];
 

--- a/src/components/customize/CustomizeNickIconView.tsx
+++ b/src/components/customize/CustomizeNickIconView.tsx
@@ -370,10 +370,10 @@ export const CustomizeNickIconView: FC<{}> = () => {
                                 return (
                                     <div
                                         key={item.iconKey}
-                                        className={`relative flex min-h-[126px] flex-col items-center justify-between gap-2 rounded border p-3 transition-colors ${item.active ? 'border-[#1e7295] bg-[#dff3fb]' : 'border-black/10 bg-black/5'}`}
+                                        className={`relative flex min-h-[126px] flex-col items-center justify-between gap-2 rounded border p-3 transition-colors ${item.active ? 'border-[#418db0] bg-[#dff3fb]' : 'border-black/10 bg-black/5'}`}
                                     >
                                         {item.active && (
-                                            <span className="absolute right-1 top-1 rounded bg-[#1e7295] px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
+                                            <span className="absolute right-1 top-1 rounded bg-[#418db0] px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
                                                 Active
                                             </span>
                                         )}
@@ -403,14 +403,14 @@ export const CustomizeNickIconView: FC<{}> = () => {
                         <div className="rounded border border-black/10 bg-black/5 p-1">
                             <div className="flex items-center gap-2">
                                 <button
-                                    className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activePrefixSubTab === 'library' ? 'bg-[#1e7295] text-white' : 'bg-white text-black'}`}
+                                    className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activePrefixSubTab === 'library' ? 'bg-[#418db0] text-white' : 'bg-white text-black'}`}
                                     type="button"
                                     onClick={() => setActivePrefixSubTab('library')}
                                 >
                                     Library
                                 </button>
                                 <button
-                                    className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activePrefixSubTab === 'custom' ? 'bg-[#1e7295] text-white' : 'bg-white text-black'}`}
+                                    className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activePrefixSubTab === 'custom' ? 'bg-[#418db0] text-white' : 'bg-white text-black'}`}
                                     type="button"
                                     onClick={() => setActivePrefixSubTab('custom')}
                                 >
@@ -428,10 +428,10 @@ export const CustomizeNickIconView: FC<{}> = () => {
                                     {combinedPrefixes.map((item) => (
                                         <div
                                             key={`${item.catalogPrefixId || 'custom'}-${item.ownedPrefixId || item.id}`}
-                                            className={`relative flex min-h-[96px] flex-col gap-2 rounded border p-2.5 ${item.active ? 'border-[#1e7295] bg-[#dff3fb]' : 'border-black/10 bg-black/5'}`}
+                                            className={`relative flex min-h-[96px] flex-col gap-2 rounded border p-2.5 ${item.active ? 'border-[#418db0] bg-[#dff3fb]' : 'border-black/10 bg-black/5'}`}
                                         >
                                             {item.active && (
-                                                <span className="absolute right-1 top-1 rounded bg-[#1e7295] px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
+                                                <span className="absolute right-1 top-1 rounded bg-[#418db0] px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
                                                     Active
                                                 </span>
                                             )}
@@ -507,7 +507,7 @@ export const CustomizeNickIconView: FC<{}> = () => {
                                             {PRESET_COLORS.map((color) => (
                                                 <button
                                                     key={color}
-                                                    className={`flex h-[28px] items-center justify-center rounded border text-[10px] font-bold uppercase ${customPrefixColor === color ? 'border-[#1e7295] ring-1 ring-[#1e7295]' : 'border-black/10'}`}
+                                                    className={`flex h-[28px] items-center justify-center rounded border text-[10px] font-bold uppercase ${customPrefixColor === color ? 'border-[#418db0] ring-1 ring-[#418db0]' : 'border-black/10'}`}
                                                     style={{ backgroundColor: color }}
                                                     type="button"
                                                     onClick={() => setCustomPrefixColor(color)}

--- a/src/components/furni-editor/views/FurniEditorEditView.tsx
+++ b/src/components/furni-editor/views/FurniEditorEditView.tsx
@@ -75,7 +75,7 @@ const Tip: FC<{ field: string }> = ({ field }) => {
             ref={ref}
             onMouseEnter={show}
             onMouseLeave={hide}
-            className="ml-0.5 inline-flex w-3 h-3 rounded-full bg-[#1e7295] text-white text-[8px] items-center justify-center cursor-help font-bold align-middle"
+            className="ml-0.5 inline-flex w-3 h-3 rounded-full bg-[#418db0] text-white text-[8px] items-center justify-center cursor-help font-bold align-middle"
         >
             ?
             {pos &&
@@ -603,7 +603,7 @@ export const FurniEditorEditView: FC<FurniEditorEditViewProps> = (props) => {
                                             onClick={() => setField(key, !on)}
                                             aria-pressed={on}
                                             title={on ? 'Enabled — click to disable' : 'Disabled — click to enable'}
-                                            className={`inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg border font-medium transition ${on ? 'bg-[#1E7295] border-[#1E7295] text-[#ffffff] shadow-sm' : 'bg-slate-100 border-slate-200 text-slate-400 hover:bg-slate-200 hover:text-slate-600'}`}
+                                            className={`inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg border font-medium transition ${on ? 'bg-[#418db0] border-[#418db0] text-[#ffffff] shadow-sm' : 'bg-slate-100 border-slate-200 text-slate-400 hover:bg-slate-200 hover:text-slate-600'}`}
                                         >
                                             <span
                                                 className={`inline-block w-2 h-2 rounded-full ring-1 ${on ? 'bg-[#22c55e] ring-[#ffffff]/70' : 'bg-[#ef4444] ring-[#00000014]'}`}

--- a/src/components/furni-editor/views/FurniEditorSearchView.tsx
+++ b/src/components/furni-editor/views/FurniEditorSearchView.tsx
@@ -163,7 +163,7 @@ export const FurniEditorSearchView: FC<FurniEditorSearchViewProps> = (props) => 
                                 key={t || 'all'}
                                 type="button"
                                 onClick={() => applyType(t)}
-                                className={`px-3 py-1.5 text-[12px] font-medium rounded-lg border transition ${on ? 'bg-[#1E7295] border-[#1E7295] text-[#ffffff] shadow-sm' : 'bg-slate-100 border-slate-200 text-slate-500 hover:bg-slate-200 hover:text-slate-600'}`}
+                                className={`px-3 py-1.5 text-[12px] font-medium rounded-lg border transition ${on ? 'bg-[#418db0] border-[#418db0] text-[#ffffff] shadow-sm' : 'bg-slate-100 border-slate-200 text-slate-500 hover:bg-slate-200 hover:text-slate-600'}`}
                             >
                                 {t === '' ? 'All' : t === 's' ? 'Floor' : 'Wall'}
                             </button>
@@ -220,7 +220,7 @@ export const FurniEditorSearchView: FC<FurniEditorSearchViewProps> = (props) => 
                                 </td>
                                 <td className="px-2 py-1.5 text-center">
                                     <span
-                                        className={`inline-block px-2 py-0.5 rounded-md text-[#ffffff] text-[10px] font-semibold ${item.type === 's' ? 'bg-[#1E7295]' : 'bg-[#64748b]'}`}
+                                        className={`inline-block px-2 py-0.5 rounded-md text-[#ffffff] text-[10px] font-semibold ${item.type === 's' ? 'bg-[#418db0]' : 'bg-[#64748b]'}`}
                                     >
                                         {item.type === 's' ? 'Floor' : 'Wall'}
                                     </span>

--- a/src/components/interface-settings/InterfaceColorTabView.tsx
+++ b/src/components/interface-settings/InterfaceColorTabView.tsx
@@ -75,12 +75,12 @@ export const InterfaceColorTabView: FC<{}> = () => {
 
     const onReset = useCallback(() => {
         resetSettings();
-        setColor(hexToRgba('#1E7295', 1));
+        setColor(hexToRgba('#418db0', 1));
     }, [resetSettings]);
 
     const onDelete = useCallback(() => {
         updateSettings({ colorMode: 'default' });
-        setColor(hexToRgba('#1E7295', 1));
+        setColor(hexToRgba('#418db0', 1));
     }, [updateSettings]);
 
     const onExport = useCallback(() => {

--- a/src/components/inventory/views/prefix/InventoryPrefixView.tsx
+++ b/src/components/inventory/views/prefix/InventoryPrefixView.tsx
@@ -145,14 +145,14 @@ export const InventoryPrefixView: FC<{}> = () => {
             <div className="shrink-0 rounded border border-black/10 bg-[#C9C9C9] p-1">
                 <div className="flex items-center gap-2">
                     <button
-                        className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activeTab === 'prefixes' ? 'bg-[#1e7295] text-white' : 'bg-white text-black'}`}
+                        className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activeTab === 'prefixes' ? 'bg-[#418db0] text-white' : 'bg-white text-black'}`}
                         type="button"
                         onClick={() => setActiveTab('prefixes')}
                     >
                         Prefixes
                     </button>
                     <button
-                        className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activeTab === 'icons' ? 'bg-[#1e7295] text-white' : 'bg-white text-black'}`}
+                        className={`rounded px-3 py-1.5 text-[11px] font-bold transition-colors ${activeTab === 'icons' ? 'bg-[#418db0] text-white' : 'bg-white text-black'}`}
                         type="button"
                         onClick={() => setActiveTab('icons')}
                     >

--- a/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetFurniView.tsx
+++ b/src/components/room/widgets/avatar-info/infostand/InfoStandWidgetFurniView.tsx
@@ -713,7 +713,7 @@ export const InfoStandWidgetFurniView: FC<InfoStandWidgetFurniViewProps> = (prop
                                 )}
                                 {isModerator && (
                                     <button
-                                        className="w-full text-white text-xs bg-[#1e7295] hover:bg-[#1a617f] border border-[#ffffff33] rounded px-2 py-1 cursor-pointer transition-colors"
+                                        className="w-full text-white text-xs bg-[#418db0] hover:bg-[#3789a8] border border-[#ffffff33] rounded px-2 py-1 cursor-pointer transition-colors"
                                         onClick={() => {
                                             const roomObject = GetRoomEngine().getRoomObject(
                                                 roomSession.roomId,

--- a/src/components/toolbar/ToolbarMeView.tsx
+++ b/src/components/toolbar/ToolbarMeView.tsx
@@ -40,7 +40,7 @@ export const ToolbarMeView: FC<
     return (
         <Flex
             alignItems="center"
-            className="bg-[rgba(20,20,20,.95)] border border-[solid] border-[#101010] [box-shadow:inset_2px_2px_rgba(255,255,255,.1),inset_-2px_-2px_rgba(255,255,255,.1)] rounded-[$border-radius] p-2"
+            className="bg-[rgba(85,85,85,0.95)] border border-[solid] border-[#3d3d3d] [box-shadow:inset_2px_2px_rgba(255,255,255,.1),inset_-2px_-2px_rgba(0,0,0,.15)] rounded-[6px] p-2"
             gap={2}
             innerRef={elementRef}
         >

--- a/src/components/toolbar/ToolbarView.tsx
+++ b/src/components/toolbar/ToolbarView.tsx
@@ -192,7 +192,7 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
                 animate={ visibilityVariant }
                 variants={ shellVariants }
                 transition={ SHELL_TRANSITION }
-                className={ `pointer-events-none fixed bottom-0 left-0 right-0 z-[39] h-[52px] rounded-t-[12px] border border-b-0 border-white/8 bg-[rgba(62,64,72,0.55)] shadow-[0_-6px_18px_rgba(0,0,0,0.18)] ${ desktopBlockClasses }` } />
+                className={ `pointer-events-none fixed bottom-0 left-0 right-0 z-[39] h-[52px] rounded-t-[12px] border border-b-0 border-[#3d3d3d]/80 bg-[rgba(85,85,85,0.92)] shadow-[0_-6px_18px_rgba(0,0,0,0.18)] ${ desktopBlockClasses }` } />
 
             <motion.div
                 initial="visible"
@@ -356,7 +356,7 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
                 animate={ visibilityVariant }
                 variants={ mobileNavVariants }
                 transition={ NAV_TRANSITION }
-                className={ `fixed left-1/2 bottom-0 z-40 flex w-[95vw] -translate-x-1/2 items-center overflow-visible ${ mobileOnlyClasses } ${ isInRoom ? 'rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[6px] py-[4px] mb-[3px] shadow-[0_-6px_18px_rgba(0,0,0,0.18)]' : '' }` }>
+                className={ `fixed left-1/2 bottom-0 z-40 flex w-[95vw] -translate-x-1/2 items-center overflow-visible ${ mobileOnlyClasses } ${ isInRoom ? 'rounded-[12px] border border-[#3d3d3d]/80 bg-[rgba(85,85,85,0.92)] px-[6px] py-[4px] mb-[3px] shadow-[0_-6px_18px_rgba(0,0,0,0.18)]' : '' }` }>
                 <motion.div
                     variants={ containerVariants }
                     className="tb-bar-scroll flex h-full min-w-0 flex-1 items-center gap-2 overflow-x-auto overflow-y-visible px-1">
@@ -453,7 +453,7 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
                 variants={ mobileNavVariants }
                 transition={ NAV_TRANSITION }
                 style={ staffStackBottom != null ? { top: 'auto', bottom: `${ staffStackBottom }px` } : undefined }
-                className={ `fixed left-1 z-40 flex flex-col items-center gap-2 rounded-[12px] border border-white/8 bg-[rgba(62,64,72,0.55)] px-[4px] py-[6px] shadow-[0_6px_18px_rgba(0,0,0,0.18)] ${ staffStackBottom == null ? 'top-1/2 -translate-y-1/2' : '' } ${ mobileOnlyClasses }` }>
+                className={ `fixed left-1 z-40 flex flex-col items-center gap-2 rounded-[12px] border border-[#3d3d3d]/80 bg-[rgba(85,85,85,0.92)] px-[4px] py-[6px] shadow-[0_6px_18px_rgba(0,0,0,0.18)] ${ staffStackBottom == null ? 'top-1/2 -translate-y-1/2' : '' } ${ mobileOnlyClasses }` }>
                 { buildersClubEnabled &&
                     <motion.div variants={ itemVariants }>
                         <ToolbarItemView icon="buildersclub" onClick={ () => CreateLinkEvent('catalog/toggle/builder') } className="tb-icon" />

--- a/src/components/user-settings/UserAccountSettingsView.tsx
+++ b/src/components/user-settings/UserAccountSettingsView.tsx
@@ -30,7 +30,7 @@ const passwordStrength = (value: string): { score: number; labelKey: string; col
 
     if(score <= 1) return { score: 1, labelKey: 'usersettings.strength.weak', color: 'bg-[#a81a12]' };
     if(score === 2) return { score: 2, labelKey: 'usersettings.strength.fair', color: 'bg-[#ffc107]' };
-    if(score === 3) return { score: 3, labelKey: 'usersettings.strength.good', color: 'bg-[#1e7295]' };
+    if(score === 3) return { score: 3, labelKey: 'usersettings.strength.good', color: 'bg-[#418db0]' };
     return { score: 4, labelKey: 'usersettings.strength.strong', color: 'bg-[#00800b]' };
 };
 
@@ -396,7 +396,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
         <NitroCardView className="user-account-settings-window min-w-0 w-[min(360px,calc(100vw-16px))] max-w-[calc(100vw-16px)] max-h-[calc(100vh-16px)]" theme="primary-slim" uniqueKey="user-account-settings">
             <NitroCardHeaderView headerText={ localizeWithFallback('usersettings.title', "User Settings") } onCloseClick={ close } />
 
-            <div className="relative flex items-center gap-3 px-3 py-2 bg-[linear-gradient(180deg,#2e8fb8_0%,#1e7295_100%)] text-white">
+            <div className="relative flex items-center gap-3 px-3 py-2 bg-[linear-gradient(180deg,#5ba4c4_0%,#418db0_100%)] text-white">
                 <div className="absolute inset-0 opacity-20 pointer-events-none [background-image:radial-gradient(rgba(255,255,255,0.5)_1px,transparent_1px)] [background-size:6px_6px]" />
                 { session.figure && (
                     <div className="relative w-[60px] h-[60px] shrink-0 rounded-full bg-white/20 border-2 border-white/40 overflow-hidden">
@@ -422,30 +422,30 @@ export const UserAccountSettingsView: FC<{}> = () =>
                         <Text small className="text-black/60 uppercase tracking-wider px-1">{ localizeWithFallback('usersettings.menu.section', "Account") }</Text>
                         <button
                             type="button"
-                            className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left"
+                            className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#418db0] transition-colors cursor-pointer text-left"
                             onClick={ () => { resetForm(); setSection('password'); } }>
-                            <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#1e7295] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
+                            <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#418db0] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
                                 <FaKey />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
                                 <Text bold>{ localizeWithFallback('usersettings.menu.password.title', "Reset password") }</Text>
                                 <Text small className="text-black/60">{ localizeWithFallback('usersettings.menu.password.desc', "Change the password you use to log in.") }</Text>
                             </div>
-                            <FaChevronRight className="text-black/40 group-hover:text-[#1e7295]" />
+                            <FaChevronRight className="text-black/40 group-hover:text-[#418db0]" />
                         </button>
 
                         <button
                             type="button"
-                            className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left"
+                            className="group flex items-center gap-3 rounded-md border border-black/10 bg-white px-3 py-2 hover:bg-[#f5fbfd] hover:border-[#418db0] transition-colors cursor-pointer text-left"
                             onClick={ () => { resetForm(); setSection('email'); } }>
-                            <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#185d79] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
+                            <div className="flex items-center justify-center w-9 h-9 rounded-full bg-[#376275] text-white shrink-0 shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
                                 <FaEnvelope />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
                                 <Text bold>{ localizeWithFallback('usersettings.menu.email.title', "Change email") }</Text>
                                 <Text small className="text-black/60">{ localizeWithFallback('usersettings.menu.email.desc', "Update your account's email address.") }</Text>
                             </div>
-                            <FaChevronRight className="text-black/40 group-hover:text-[#1e7295]" />
+                            <FaChevronRight className="text-black/40 group-hover:text-[#418db0]" />
                         </button>
 
                         <button
@@ -484,12 +484,12 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50">
                                 <FaArrowLeft size={ 11 } />
                             </button>
-                            <FaUserCog className="text-[#1e7295]" />
+                            <FaUserCog className="text-[#418db0]" />
                             <Text bold>{ localizeWithFallback('usersettings.menu.password.title', "Reset password") }</Text>
                         </div>
 
-                        <div className="flex items-start gap-2 rounded-md border border-[#1e7295]/30 bg-[#1e7295]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
-                            <FaInfoCircle className="mt-[2px] shrink-0 text-[#1e7295]" />
+                        <div className="flex items-start gap-2 rounded-md border border-[#418db0]/30 bg-[#418db0]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
+                            <FaInfoCircle className="mt-[2px] shrink-0 text-[#418db0]" />
                             <span>{ LocalizeText('usersettings.password.hint', [ 'count' ], [ MIN_PASSWORD_LENGTH.toString() ]) }</span>
                         </div>
 
@@ -499,7 +499,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type={ showCurrent ? 'text' : 'password' }
-                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
+                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#418db0] focus:outline-none"
                                     autoComplete="current-password"
                                     maxLength={ MAX_PASSWORD_LENGTH }
                                     value={ currentPassword }
@@ -522,7 +522,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type={ showNew ? 'text' : 'password' }
-                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
+                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#418db0] focus:outline-none"
                                     autoComplete="new-password"
                                     maxLength={ MAX_PASSWORD_LENGTH }
                                     value={ newPassword }
@@ -553,7 +553,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type={ showNew ? 'text' : 'password' }
-                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ confirmPassword.length > 0 && confirmPassword !== newPassword ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ confirmPassword.length > 0 && confirmPassword !== newPassword ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#418db0]' }` }
                                     autoComplete="new-password"
                                     maxLength={ MAX_PASSWORD_LENGTH }
                                     value={ confirmPassword }
@@ -596,12 +596,12 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 className="flex items-center justify-center w-7 h-7 rounded-full bg-black/5 hover:bg-black/10 text-black/70 disabled:opacity-50">
                                 <FaArrowLeft size={ 11 } />
                             </button>
-                            <FaEnvelope className="text-[#185d79]" />
+                            <FaEnvelope className="text-[#376275]" />
                             <Text bold>{ localizeWithFallback('usersettings.menu.email.title', "Change email") }</Text>
                         </div>
 
-                        <div className="flex items-start gap-2 rounded-md border border-[#1e7295]/30 bg-[#1e7295]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
-                            <FaInfoCircle className="mt-[2px] shrink-0 text-[#1e7295]" />
+                        <div className="flex items-start gap-2 rounded-md border border-[#418db0]/30 bg-[#418db0]/10 px-2 py-2 text-[11px] leading-4 text-[#0d3d52]">
+                            <FaInfoCircle className="mt-[2px] shrink-0 text-[#418db0]" />
                             <span>{ localizeWithFallback('usersettings.email.hint', "For your security, please confirm your current password before changing your account email.") }</span>
                         </div>
 
@@ -611,7 +611,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type={ showEmailPassword ? 'text' : 'password' }
-                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
+                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#418db0] focus:outline-none"
                                     autoComplete="current-password"
                                     maxLength={ MAX_PASSWORD_LENGTH }
                                     value={ emailCurrentPassword }
@@ -634,7 +634,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaEnvelope className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type="email"
-                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newEmail.length > 0 && !EMAIL_RE.test(newEmail) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newEmail.length > 0 && !EMAIL_RE.test(newEmail) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#418db0]' }` }
                                     autoComplete="email"
                                     inputMode="email"
                                     maxLength={ MAX_EMAIL_LENGTH }
@@ -694,7 +694,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaKey className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type={ showUsernamePassword ? 'text' : 'password' }
-                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#1e7295] focus:outline-none"
+                                    className="w-full rounded border border-black/20 bg-white pl-7 pr-8 py-1 focus:border-[#418db0] focus:outline-none"
                                     autoComplete="current-password"
                                     maxLength={ MAX_PASSWORD_LENGTH }
                                     value={ usernameCurrentPassword }
@@ -717,7 +717,7 @@ export const UserAccountSettingsView: FC<{}> = () =>
                                 <FaIdBadge className="absolute left-2 text-black/40" size={ 12 } />
                                 <input
                                     type="text"
-                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newUsername.length > 0 && (!USERNAME_RE.test(newUsername) || newUsername === session.username) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#1e7295]' }` }
+                                    className={ `w-full rounded border bg-white pl-7 pr-8 py-1 focus:outline-none ${ newUsername.length > 0 && (!USERNAME_RE.test(newUsername) || newUsername === session.username) ? 'border-[#a81a12] focus:border-[#a81a12]' : 'border-black/20 focus:border-[#418db0]' }` }
                                     autoComplete="off"
                                     spellCheck={ false }
                                     maxLength={ MAX_USERNAME_LENGTH }

--- a/src/components/user-settings/UserSettingsView.tsx
+++ b/src/components/user-settings/UserSettingsView.tsx
@@ -223,15 +223,15 @@ export const UserSettingsView: FC<{}> = props =>
                         <button
                             type="button"
                             onClick={ () => CreateLinkEvent('user-account-settings/show') }
-                            className="group flex items-center gap-2 rounded-md border border-black/10 bg-white px-2 py-1.5 hover:bg-[#f5fbfd] hover:border-[#1e7295] transition-colors cursor-pointer text-left">
-                            <div className="flex items-center justify-center w-7 h-7 rounded-full bg-[#1e7295] text-white shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
+                            className="group flex items-center gap-2 rounded-md border border-black/10 bg-white px-2 py-1.5 hover:bg-[#f5fbfd] hover:border-[#418db0] transition-colors cursor-pointer text-left">
+                            <div className="flex items-center justify-center w-7 h-7 rounded-full bg-[#418db0] text-white shadow-[inset_0_2px_#ffffff26,inset_0_-2px_#0000001a]">
                                 <FaUserCog size={ 12 } />
                             </div>
                             <div className="flex flex-col flex-1 leading-tight">
                                 <Text bold>{ localizeWithFallback('usersettings.open.title', "User Settings") }</Text>
                                 <Text small className="text-black/60">{ localizeWithFallback('usersettings.open.subtitle', "Password and account") }</Text>
                             </div>
-                            <span className="text-black/30 group-hover:text-[#1e7295] text-[10px]">›</span>
+                            <span className="text-black/30 group-hover:text-[#418db0] text-[10px]">›</span>
                         </button>
                     </div> }
                 { (section !== null) &&

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -6,8 +6,9 @@
     --catalog-swf-border-dark: #6f6f6a;
     --catalog-swf-text: #222222;
     --catalog-swf-muted: #666666;
-    --catalog-swf-blue: #2f8097;
-    --catalog-swf-blue-dark: #1c596c;
+    --catalog-swf-blue: #418db0;
+    --catalog-swf-blue-dark: #0e3f52;
+    --catalog-swf-blue-border: #376275;
     --catalog-swf-select: #63c5e9;
     --catalog-swf-select-outer: #82d1ed;
     --catalog-swf-bc: #ff8d00;
@@ -139,33 +140,31 @@
     height: 22px !important;
     min-height: 22px !important;
     padding: 0 10px !important;
-    border: 1px solid #6f8db5 !important;
+    border: 2px solid var(--catalog-swf-blue-border) !important;
     border-image: none !important;
-    border-image-source: none !important;
     border-radius: 4px !important;
-    background: linear-gradient(180deg, #ffffff 0%, #e7eef8 100%) !important;
-    background-image: linear-gradient(180deg, #ffffff 0%, #e7eef8 100%) !important;
-    color: #1a3a6b !important;
+    background: linear-gradient(180deg, #f2f8fb 0%, #d4e6ef 44%, #a8c9d8 45%, #d9e9f0 100%) !important;
+    color: var(--catalog-swf-text) !important;
     font-size: 10px !important;
-    font-weight: 600 !important;
+    font-weight: 700 !important;
     line-height: 1 !important;
-    text-shadow: none !important;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75) !important;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 1px 0 rgba(0, 0, 0, 0.12) !important;
     cursor: pointer !important;
     white-space: nowrap !important;
 }
 
 .nitro-catalog-window .nitro-catalog-default-admin button:hover {
-    background: linear-gradient(180deg, #ffffff 0%, #d6e2f3 100%) !important;
-    background-image: linear-gradient(180deg, #ffffff 0%, #d6e2f3 100%) !important;
-    color: #0b2347 !important;
-    border-color: #4a72b8 !important;
+    filter: brightness(1.04);
+    background: linear-gradient(180deg, #ffffff 0%, #e0eff6 44%, #b8d5e4 45%, #e8f3f8 100%) !important;
+    color: var(--catalog-swf-text) !important;
+    border-color: var(--catalog-swf-blue) !important;
 }
 
 .nitro-catalog-window .nitro-catalog-default-admin button:active {
-    background: linear-gradient(180deg, #d6e2f3 0%, #ffffff 100%) !important;
-    background-image: linear-gradient(180deg, #d6e2f3 0%, #ffffff 100%) !important;
-    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.08), 0 0 0 rgba(0, 0, 0, 0) !important;
+    filter: brightness(0.96);
+    background: linear-gradient(180deg, #a8c9d8 0%, #d4e6ef 55%, #f2f8fb 100%) !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12) !important;
 }
 
 .nitro-catalog-window .nitro-catalog-default-admin button.text-success,
@@ -215,8 +214,8 @@
     --catalog-admin-border-dark: #5f5f59;
     --catalog-admin-text: #20201d;
     --catalog-admin-muted: #60605a;
-    --catalog-admin-blue: #2f8097;
-    --catalog-admin-blue-dark: #1c596c;
+    --catalog-admin-blue: #418db0;
+    --catalog-admin-blue-dark: #0e3f52;
     --catalog-admin-gold: #ffc828;
     --catalog-admin-gold-dark: #8a5b00;
     --catalog-admin-danger: #b83b32;
@@ -1325,48 +1324,45 @@
     justify-content: center !important;
     min-height: 22px;
     padding: 2px 12px !important;
-    border: 3px solid transparent !important;
-    border-radius: 0 !important;
-    border-image-source: var(--habbo-slice-button-default) !important;
-    border-image-slice: 3 3 3 3 fill !important;
-    border-image-width: 3px !important;
-    border-image-repeat: stretch !important;
-    background: transparent !important;
-    background-color: transparent !important;
-    background-image: none !important;
-    color: #222 !important;
+    border: 2px solid var(--catalog-swf-blue-border) !important;
+    border-radius: 4px !important;
+    border-image: none !important;
+    background: linear-gradient(180deg, #f2f8fb 0%, #d4e6ef 44%, #a8c9d8 45%, #d9e9f0 100%) !important;
+    color: var(--catalog-swf-text) !important;
     font-size: 11px !important;
     font-weight: 700 !important;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.7);
-    box-shadow: none !important;
-    transition: none !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 1px 0 rgba(0, 0, 0, 0.1) !important;
+    transition: filter 0.1s ease !important;
 }
 
 .nitro-catalog-window button.nitro-catalog-preview-btn,
 .nitro-catalog-window button.nitro-catalog-preview-btn *,
 .nitro-catalog-window button.nitro-catalog-preview-btn svg {
-    border-radius: 0 !important;
-    box-shadow: none !important;
+    border-radius: 4px !important;
 }
 
 .nitro-catalog-window .nitro-catalog-swf-button:hover,
 .nitro-catalog-window button.nitro-catalog-swf-spinner-button:hover,
 .nitro-catalog-window button.nitro-catalog-preview-btn:hover {
-    border-image-source: var(--habbo-slice-button-hover) !important;
+    filter: brightness(1.04);
+    background: linear-gradient(180deg, #ffffff 0%, #e0eff6 44%, #b8d5e4 45%, #e8f3f8 100%) !important;
 }
 
 .nitro-catalog-window .nitro-catalog-swf-button:active,
 .nitro-catalog-window button.nitro-catalog-swf-spinner-button:active,
 .nitro-catalog-window button.nitro-catalog-preview-btn:active {
-    border-image-source: var(--habbo-slice-button-pressed) !important;
+    filter: brightness(0.96);
+    background: linear-gradient(180deg, #a8c9d8 0%, #d4e6ef 55%, #f2f8fb 100%) !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.15) !important;
 }
 
 .nitro-catalog-window .nitro-catalog-swf-button.pointer-events-none,
 .nitro-catalog-window button.nitro-catalog-swf-spinner-button:disabled,
 .nitro-catalog-window button.nitro-catalog-preview-btn:disabled {
-    border-image-source: var(--habbo-slice-button-disabled) !important;
+    opacity: 0.55 !important;
     color: #888 !important;
-    opacity: 1 !important;
+    cursor: not-allowed !important;
 }
 
 .nitro-catalog-window .nitro-catalog-swf-buy-button {

--- a/src/css/common/Buttons.css
+++ b/src/css/common/Buttons.css
@@ -24,59 +24,71 @@ input[type=number] {
 
 .btn-primary {
   color: #fff;
-  background-color: #3c6d82;
-  border: 2px solid #1a617f;
+  background: linear-gradient(180deg, #5ba4c4 0%, #418db0 44%, #2e6f8a 100%);
+  border: 2px solid #0e3f52;
   padding: 0.25rem 0.5rem;
   font-size: .7875rem;
-  border-radius: 0.5rem;
-  box-shadow: none!important;
+  border-radius: 4px;
+  font-weight: 700;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 1px 0 rgba(0, 0, 0, 0.15) !important;
 }
 
 .btn-primary:hover {
-  border: 2px solid #1a617f;
-  box-shadow: none!important;
+  background: linear-gradient(180deg, #6eb8d4 0%, #4a9bc0 44%, #3580a0 100%);
+  border-color: #0e3f52;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 1px 0 rgba(0, 0, 0, 0.15) !important;
 }
 
 .btn-success{
   color: #fff;
-  background-color: #3c8243;
+  background: linear-gradient(180deg, #b6e86b 0%, #7fc828 45%, #4f9a18 100%);
   border: 2px solid #006d09;
   padding: 0.25rem 0.5rem;
   font-size: .7875rem;
-  border-radius: 0.5rem;
-  box-shadow: none!important;
+  border-radius: 4px;
+  font-weight: 700;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35) !important;
 }
 
 .btn-success:hover{
-  box-shadow: none!important;
+  filter: brightness(1.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35) !important;
 }
 
 .btn-danger{
   color: #fff;
-  background-color: #a81a12;
-  border: 2px solid #b9322a;
+  background: linear-gradient(180deg, #e4665c 0%, #a81a12 100%);
+  border: 2px solid #86150e;
   padding: 0.25rem 0.5rem;
   font-size: .7875rem;
-  border-radius: 0.5rem;
-  box-shadow: none!important;
+  border-radius: 4px;
+  font-weight: 700;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .btn-danger:hover{
-  box-shadow: none!important;
+  filter: brightness(1.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .btn-warning{
-  color: #222;
-  background-color: #ffc107;
-  border: 2px solid #f3c12a;
+  color: #4a2b00;
+  background: linear-gradient(180deg, #ffe66b 0%, #ffc828 45%, #f0a318 100%);
+  border: 2px solid #8a5b00;
   padding: 0.25rem 0.5rem;
   font-size: .7875rem;
-  border-radius: 0.5rem;
-  box-shadow: none!important;
+  border-radius: 4px;
+  font-weight: 700;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65) !important;
 }
 
 .btn-warning:hover{
-  box-shadow: none!important;
+  filter: brightness(1.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65) !important;
 }
 
 .btn-dark {

--- a/src/css/habbo/HabboTheme.css
+++ b/src/css/habbo/HabboTheme.css
@@ -1,0 +1,143 @@
+/**
+ * Official Habbo Ubuntu palette (Habbo Air deobfuscated).
+ * Frame #418DB0, catalog header #0E3F52 / #376275, content #DFDFDF / #ECECE4.
+ */
+:root {
+    --habbo-blue: #418db0;
+    --habbo-blue-light: #67a3bf;
+    --habbo-blue-highlight: #5ba4c4;
+    --habbo-blue-dark: #2e6f8a;
+    --habbo-blue-header: #0e3f52;
+    --habbo-blue-header-border: #376275;
+    --habbo-frame-border: #283f5d;
+    --habbo-surface: #dfdfdf;
+    --habbo-surface-warm: #ecece4;
+    --habbo-panel: #f7f7f2;
+    --habbo-tab: #b6bec5;
+    --habbo-tab-active: #dfdfdf;
+    --habbo-grid: #cdd3d9;
+    --habbo-grid-active: #ececec;
+    --habbo-select: #63c5e9;
+    --habbo-select-outer: #82d1ed;
+    --habbo-close: #921911;
+    --habbo-close-hover: #b9322a;
+    --habbo-toolbar: #555555;
+    --habbo-nav-border: #eceae0;
+    --habbo-text: #151515;
+    --habbo-text-muted: #666666;
+    --habbo-bc: #ff8d00;
+    --habbo-bc-outer: #ffb53c;
+    --habbo-success: #00800b;
+    --habbo-danger: #a81a12;
+    --habbo-buy-top: #ffe66b;
+    --habbo-buy-mid: #ffc828;
+    --habbo-buy-bottom: #f0a318;
+    --habbo-buy-text: #4a2b00;
+}
+
+/* Ubuntu shiny secondary (catalog secondary / preview / spinner) */
+.habbo-btn-secondary,
+.habbo-btn-slice {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 22px;
+    padding: 2px 12px;
+    border: 2px solid var(--habbo-blue-header-border) !important;
+    border-radius: 4px !important;
+    background: linear-gradient(180deg, #f2f8fb 0%, #d4e6ef 44%, #a8c9d8 45%, #d9e9f0 100%) !important;
+    color: var(--habbo-text) !important;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.1;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 1px 0 rgba(0, 0, 0, 0.12);
+    cursor: pointer;
+    transition: filter 0.1s ease;
+}
+
+.habbo-btn-secondary:hover,
+.habbo-btn-slice:hover {
+    filter: brightness(1.04);
+    background: linear-gradient(180deg, #ffffff 0%, #e0eff6 44%, #b8d5e4 45%, #e8f3f8 100%) !important;
+}
+
+.habbo-btn-secondary:active,
+.habbo-btn-slice:active {
+    filter: brightness(0.96);
+    background: linear-gradient(180deg, #a8c9d8 0%, #d4e6ef 55%, #f2f8fb 100%) !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+.habbo-btn-secondary:disabled,
+.habbo-btn-slice:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    filter: grayscale(0.15);
+}
+
+/* Ubuntu shiny primary blue */
+.habbo-btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 22px;
+    padding: 2px 12px;
+    border: 2px solid var(--habbo-blue-header) !important;
+    border-radius: 4px !important;
+    background: linear-gradient(180deg, var(--habbo-blue-highlight) 0%, var(--habbo-blue) 44%, var(--habbo-blue-dark) 100%) !important;
+    color: #fff !important;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.1;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.45);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 1px 0 rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+}
+
+.habbo-btn-primary:hover {
+    background: linear-gradient(180deg, #6eb8d4 0%, #4a9bc0 44%, #3580a0 100%) !important;
+}
+
+.habbo-btn-primary:active {
+    background: linear-gradient(180deg, var(--habbo-blue-dark) 0%, var(--habbo-blue) 100%) !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.28);
+}
+
+/* Gold buy / confirm */
+.habbo-btn-buy {
+    border: 2px solid #8a5b00 !important;
+    border-radius: 4px !important;
+    background: linear-gradient(180deg, var(--habbo-buy-top) 0%, var(--habbo-buy-mid) 45%, var(--habbo-buy-bottom) 100%) !important;
+    color: var(--habbo-buy-text) !important;
+    font-weight: 700;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.55);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), inset 0 -2px 0 rgba(140, 75, 0, 0.35);
+}
+
+.habbo-btn-buy:hover {
+    background: linear-gradient(180deg, #fff080 0%, #ffd54d 45%, #f5ab1c 100%) !important;
+}
+
+.habbo-btn-buy:active {
+    background: linear-gradient(180deg, #f0a318 0%, #d98c0a 100%) !important;
+    box-shadow: inset 0 2px 0 rgba(140, 75, 0, 0.45);
+}
+
+.habbo-btn-success {
+    border: 2px solid #006d09 !important;
+    border-radius: 4px !important;
+    background: linear-gradient(180deg, #b6e86b 0%, #7fc828 45%, #4f9a18 100%) !important;
+    color: #fff !important;
+    font-weight: 700;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+}
+
+.habbo-btn-danger {
+    border: 2px solid #86150e !important;
+    border-radius: 4px !important;
+    background: linear-gradient(180deg, #e4665c 0%, var(--habbo-danger) 100%) !important;
+    color: #fff !important;
+    font-weight: 700;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -738,7 +738,7 @@ body {
     --mod-tools-panel-alt: #e5e5dc;
     --mod-tools-line: #9d9d96;
     --mod-tools-line-dark: #6f6f6a;
-    --mod-tools-accent: #2f8097;
+    --mod-tools-accent: #418db0;
     --mod-tools-text: #20201d;
     --mod-tools-muted: #60605a;
 
@@ -1088,11 +1088,13 @@ body {
         align-items: center !important;
         justify-content: center !important;
         min-height: 22px !important;
-        border: 1px solid #8e8e8e !important;
-        border-radius: 6px !important;
-        background: linear-gradient(180deg, #fcfcfc 0%, #e8e8e8 46%, #d5d5d5 47%, #efefef 100%) !important;
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.92) !important;
-        color: #000 !important;
+        border: 2px solid var(--habbo-blue-header-border, #376275) !important;
+        border-radius: 4px !important;
+        background: linear-gradient(180deg, #f2f8fb 0%, #d4e6ef 44%, #a8c9d8 45%, #d9e9f0 100%) !important;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 1px 0 rgba(0, 0, 0, 0.1) !important;
+        color: var(--habbo-text, #151515) !important;
+        font-weight: 700;
+        text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75);
         padding-top: 0 !important;
         padding-bottom: 0 !important;
     }
@@ -1100,12 +1102,14 @@ body {
     .nitro-wired__button:hover,
     .nitro-wired__picker-button:hover,
     .nitro-slider-button:hover {
-        filter: brightness(0.98);
+        filter: brightness(1.04);
     }
 
-    .nitro-wired__button--primary,
-    .nitro-wired__button--secondary {
-        font-weight: 700;
+    .nitro-wired__button--primary {
+        border-color: var(--habbo-blue-header, #0e3f52) !important;
+        background: linear-gradient(180deg, #5ba4c4 0%, #418db0 44%, #2e6f8a 100%) !important;
+        color: #fff !important;
+        text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
     }
 
     &.nitro-card-shell {

--- a/src/css/inventory/InventoryView.css
+++ b/src/css/inventory/InventoryView.css
@@ -1,9 +1,9 @@
 .nitro-inventory-window {
-    --inv-blue: #4a7d8c;
-    --inv-beige: #e2e0d6;
-    --inv-tab: #c7c5ba;
-    --inv-line: #919088;
-    --inv-accent: #4a7d8c;
+    --inv-blue: #418db0;
+    --inv-beige: #dfdfdf;
+    --inv-tab: #b6bec5;
+    --inv-line: #b6bec5;
+    --inv-accent: #418db0;
     --inv-place: #5ca843;
     --inv-place-dark: #397025;
     --inv-place-light: #8ee374;

--- a/src/css/mentions/MentionToasts.css
+++ b/src/css/mentions/MentionToasts.css
@@ -37,7 +37,7 @@
     color: #fff;
 }
 
-.mention-toast-chip.is-direct { background: #1e7295; }
+.mention-toast-chip.is-direct { background: #418db0; }
 .mention-toast-chip.is-room { background: #d08a1e; }
 
 .mention-toast-spacer {
@@ -112,7 +112,7 @@
 }
 
 .mention-toast-btn:hover {
-    background: #1e7295;
+    background: #418db0;
     border-color: #2a90bd;
     color: #fff;
 }
@@ -143,7 +143,7 @@
     width: 28px;
     height: 28px;
     font-weight: 700;
-    color: #1e7295;
+    color: #418db0;
     background: rgba(30, 114, 149, 0.12);
     border-radius: 4px;
 }

--- a/src/css/mentions/MentionsPanel.css
+++ b/src/css/mentions/MentionsPanel.css
@@ -53,7 +53,7 @@
     width: 5px;
     height: 5px;
     border-radius: 50%;
-    background: #1e7295;
+    background: #418db0;
 }
 
 .mention-row:hover {
@@ -115,7 +115,7 @@
     color: #fff;
 }
 
-.mention-row-type.is-direct { background: #1e7295; }
+.mention-row-type.is-direct { background: #418db0; }
 .mention-row-type.is-room { background: #d08a1e; }
 
 .mention-row-body {
@@ -203,7 +203,7 @@
     transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 
-.mention-row-action:hover { background: #1e7295; color: #fff; border-color: #185b76; }
+.mention-row-action:hover { background: #418db0; color: #fff; border-color: #376275; }
 .mention-row-action.is-remove:hover { background: #d64545; color: #fff; border-color: #b53636; }
 
 .mentions-empty {
@@ -224,7 +224,7 @@
     justify-content: center;
     border-radius: 50%;
     background: rgba(30, 114, 149, 0.10);
-    color: #1e7295;
+    color: #418db0;
     font-size: 22px;
     font-weight: 700;
 }
@@ -267,8 +267,8 @@
 }
 
 .mentions-filter.is-active {
-    background: #1e7295;
-    border-color: #185b76;
+    background: #418db0;
+    border-color: #376275;
     color: #fff;
 }
 
@@ -290,7 +290,7 @@
 
 .mentions-refresh:hover {
     background: #e9e6dc;
-    color: #1e7295;
+    color: #418db0;
 }
 
 .mentions-refresh:active {

--- a/src/css/nitrocard/NitroCardView.css
+++ b/src/css/nitrocard/NitroCardView.css
@@ -1,16 +1,16 @@
 :root {
-    --nitro-card-border: #111111;
-    --nitro-card-frame: #d8ddd4;
-    --nitro-card-surface: #f4f2e8;
-    --nitro-card-surface-raised: #ffffff;
-    --nitro-card-header: #2f7894;
-    --nitro-card-header-highlight: #58a8c5;
-    --nitro-card-header-shadow: #1a5368;
-    --nitro-card-text: #151515;
-    --nitro-card-muted: #4f5b60;
+    --nitro-card-border: var(--habbo-frame-border, #283f5d);
+    --nitro-card-frame: #376275;
+    --nitro-card-surface: var(--habbo-surface, #dfdfdf);
+    --nitro-card-surface-raised: var(--habbo-grid-active, #ececec);
+    --nitro-card-header: var(--habbo-blue, #418db0);
+    --nitro-card-header-highlight: var(--habbo-blue-highlight, #5ba4c4);
+    --nitro-card-header-shadow: var(--habbo-blue-dark, #2e6f8a);
+    --nitro-card-text: var(--habbo-text, #151515);
+    --nitro-card-muted: var(--habbo-text-muted, #666666);
     --nitro-card-focus: #ffd95a;
-    --nitro-card-radius: 8px;
-    --nitro-card-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+    --nitro-card-radius: 6px;
+    --nitro-card-shadow: 0 4px 4px rgba(0, 0, 0, 0.35);
 }
 
 .nitro-card,
@@ -26,8 +26,8 @@
     .nitro-card-header,
     .nitro-card-header-shell {
         position: relative;
-        min-height: 34px;
-        max-height: 34px;
+        min-height: 33px;
+        max-height: 33px;
         width: 100%;
         margin: 0;
         padding: 4px 38px;
@@ -66,13 +66,13 @@
             height: 22px;
             padding: 0;
             line-height: 1;
-            border-radius: 5px;
+            border-radius: 4px;
             border: 2px solid var(--nitro-card-border);
             box-shadow: inset 0 1px rgba(255, 255, 255, 0.34);
-            background: #c63b32;
+            background: var(--habbo-close, #921911);
 
             &:hover {
-                background: #d64a40;
+                background: var(--habbo-close-hover, #b9322a);
                 border-color: #fff;
             }
 
@@ -118,12 +118,12 @@
     .nitro-card-tabs-shell {
         display: flex;
         flex-wrap: nowrap;
-        gap: 4px;
+        gap: 2px;
         min-height: auto;
         max-height: none;
-        padding: 5px 8px 0;
+        padding: 4px 6px 0;
         background: var(--nitro-card-frame);
-        border-bottom: 2px solid #b8c2b4;
+        border-bottom: 2px solid var(--nitro-card-border);
 
         .nav-item,
         .nitro-card-tab-item {
@@ -131,10 +131,10 @@
             padding: 0.35rem 0.75rem;
             margin-bottom: -2px;
             color: var(--nitro-card-text);
-            background: #cbd3c8;
+            background: var(--habbo-tab, #b6bec5);
             border: 2px solid var(--nitro-card-border);
             border-bottom: 0;
-            border-radius: 7px 7px 0 0;
+            border-radius: 6px 6px 0 0;
             box-shadow: inset 0 1px rgba(255, 255, 255, 0.72);
             line-height: 1.1;
 
@@ -143,7 +143,7 @@
             }
 
             &:hover {
-                background: #dde4da;
+                background: #c8d0d6;
             }
 
             &:focus-visible {
@@ -153,7 +153,7 @@
 
             &.active,
             &.nitro-card-tab-item-active {
-                background: var(--nitro-card-surface);
+                background: var(--habbo-tab-active, #dfdfdf);
                 border-color: var(--nitro-card-border) !important;
                 border-bottom: 0;
             }
@@ -186,37 +186,37 @@
 }
 
 .nitro-card-panel {
-    background: rgba(0, 0, 0, 0.045) !important;
-    border: 1px solid #c4cabf !important;
-    border-radius: 6px !important;
+    background: rgba(0, 0, 0, 0.04) !important;
+    border: 1px solid var(--habbo-tab, #b6bec5) !important;
+    border-radius: 4px !important;
     box-shadow: none !important;
 }
 
 .nitro-card-row {
     background: rgba(0, 0, 0, 0.035) !important;
-    border: 1px solid #c4cabf !important;
-    border-radius: 6px !important;
+    border: 1px solid var(--habbo-tab, #b6bec5) !important;
+    border-radius: 4px !important;
     box-shadow: none !important;
     transition: background-color .15s ease, border-color .15s ease;
 }
 
 .nitro-card-row:hover {
     background: rgba(0, 0, 0, 0.07) !important;
-    border-color: #aeb7aa !important;
+    border-color: #9aa3ab !important;
 }
 
 .nitro-card-divider {
-    border-color: #c4cabf !important;
+    border-color: var(--habbo-tab, #b6bec5) !important;
     box-shadow: none !important;
 }
 
 .nitro-card-shell :where(.bg-muted, .bg-light, .bg-light-dark, .bg-white, .bg-white\/50, .bg-white\/80) {
-    background: rgba(0, 0, 0, 0.045) !important;
+    background: rgba(0, 0, 0, 0.04) !important;
     box-shadow: none !important;
 }
 
 .nitro-card-shell :where(.border, .border-muted, .border-card-grid-item-border, .border-card-grid-item-border-active, .border-white, .border-white\/10, .border-white\/20, .border-white\/30) {
-    border-color: #c4cabf !important;
+    border-color: var(--habbo-tab, #b6bec5) !important;
     box-shadow: none !important;
 }
 

--- a/src/css/purse/PurseView.css
+++ b/src/css/purse/PurseView.css
@@ -132,7 +132,7 @@
 
 .nitro-purse__btn--help {
     border-color: #14526b;
-    background: linear-gradient(180deg, #2790b6 0%, #1e7295 100%);
+    background: linear-gradient(180deg, #5ba4c4 0%, #418db0 44%, #2e6f8a 100%);
 }
 
 .nitro-purse__btn--logout {

--- a/src/css/room/NavigatorRoomSettings.css
+++ b/src/css/room/NavigatorRoomSettings.css
@@ -3,7 +3,7 @@
     --room-settings-panel: #f7f7f2;
     --room-settings-line: #9d9d96;
     --room-settings-line-dark: #6f6f6a;
-    --room-settings-accent: #2f8097;
+    --room-settings-accent: #418db0;
     --room-settings-text: #20201d;
     --room-settings-muted: #60605a;
 

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -10,7 +10,7 @@
         overflow: hidden;
 
         &.track-0 {
-            background-color: #1e7295;
+            background-color: #418db0;
         }
 
         &.track-1 {

--- a/src/css/toolbar/ToolBar.css
+++ b/src/css/toolbar/ToolBar.css
@@ -35,8 +35,8 @@
     justify-content: center;
     cursor: pointer;
     border-radius: 6px;
-    background: rgba(62, 64, 72, 0.55);
-    border: 1px solid rgba(255, 255, 255, 0.10);
+    background: rgba(85, 85, 85, 0.92);
+    border: 1px solid rgba(61, 61, 61, 0.85);
     color: rgba(255, 255, 255, 0.70);
     transition: color 0.15s, background 0.15s;
 
@@ -94,15 +94,13 @@
 }
 
 .tbme-panel {
-    background: rgba(18, 16, 14, 0.88);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 14px;
+    background: rgba(85, 85, 85, 0.95);
+    border: 1px solid #3d3d3d;
+    border-radius: 8px;
     padding: 10px 12px;
     box-shadow:
-        0 10px 36px rgba(0, 0, 0, 0.65),
-        0 1px 0 rgba(255, 255, 255, 0.05) inset;
+        0 6px 18px rgba(0, 0, 0, 0.35),
+        inset 1px 1px rgba(255, 255, 255, 0.08);
 }
 
 .tbme-icon {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
     }
 });
 
+import './css/habbo/HabboTheme.css';
 import './css/index.css';
 
 import './css/backgrounds/BackgroundsView.css';

--- a/src/layout/NitroButton.tsx
+++ b/src/layout/NitroButton.tsx
@@ -2,24 +2,24 @@ import { ButtonHTMLAttributes, DetailedHTMLProps, PropsWithChildren, Ref } from 
 import { classNames } from './classNames';
 
 const classes = {
-    base: 'inline-flex justify-center items-center gap-2 transition-[background-color] duration-300 transform tracking-wide rounded-md',
-    disabled: '',
+    base: 'inline-flex justify-center items-center gap-2 rounded-[4px] font-bold text-[11px] leading-tight cursor-pointer select-none transition-[filter] duration-100',
+    disabled: 'opacity-55 pointer-events-none',
     size: {
-        default: 'px-2 py-0.5  font-medium',
-        lg: 'px-5 py-3 text-base font-medium',
-        xl: 'px-6 py-3.5 text-base font-medium'
+        default: 'px-3 py-0.5 min-h-[22px]',
+        lg: 'px-5 py-1 min-h-[28px] text-sm',
+        xl: 'px-6 py-1.5 min-h-[32px] text-sm'
     },
-    outline: {
-        default:
-            'text-blue-700 hover:text-white border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:border-blue-500 dark:text-blue-500 dark:hover:text-white dark:hover:bg-blue-600 dark:focus:ring-blue-800'
-    },
-    color: {
-        default: 'bg-button-gradient-gray border border-gray-500'
+    variant: {
+        default: 'habbo-btn-secondary',
+        primary: 'habbo-btn-primary',
+        buy: 'habbo-btn-buy',
+        success: 'habbo-btn-success',
+        danger: 'habbo-btn-danger'
     }
 };
 
 type NitroButtonProps = PropsWithChildren<{
-    color?: 'default' | 'dark' | 'ghost';
+    color?: 'default' | 'primary' | 'buy' | 'success' | 'danger' | 'dark' | 'ghost';
     size?: 'default' | 'lg' | 'xl';
     outline?: boolean;
     ref?: Ref<HTMLButtonElement>;
@@ -36,13 +36,19 @@ export const NitroButton = ({
     className = null,
     ...rest
 }: NitroButtonProps) => {
+    const variantClass = color === 'dark'
+        ? 'btn-dark'
+        : color === 'ghost'
+          ? 'habbo-btn-secondary !bg-transparent'
+          : classes.variant[color in classes.variant ? color : 'default'];
+
     return (
         <button
             ref={ref}
             className={classNames(
                 classes.base,
                 classes.size[size],
-                outline ? classes.outline[color] : classes.color[color],
+                outline ? 'habbo-btn-secondary !bg-transparent' : variantClass,
                 disabled && classes.disabled,
                 className
             )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ const {
 
 const colors = {
     'toolbar': '#555555',
-    'card-header': '#1E7295',
+    'card-header': '#418DB0',
     'card-close': '#921911',
     'card-tabs': '#185D79',
     'card-border': '#283F5D',
@@ -39,8 +39,8 @@ const colors = {
     'gray-700': '#495057',
     'gray-800': '#343a40',
     'gray-900': '#212529',
-    'primary': '#1E7295',
-    'secondary': '#185D79',
+    'primary': '#418DB0',
+    'secondary': '#376275',
     'success': '#00800b',
     'info': '#0dcaf0',
     'warning': '#ffc107',
@@ -79,7 +79,8 @@ module.exports = {
             colors: generateShades(colors),
             boxShadow,
             backgroundImage: {
-                'button-gradient-gray': 'linear-gradient(to bottom, #e2e2e2 50%, #c8c8c8 50%)',
+                'button-gradient-gray': 'linear-gradient(to bottom, #f2f8fb 50%, #c5d5de 50%)',
+                'button-gradient-habbo': 'linear-gradient(180deg, #5ba4c4 0%, #418db0 44%, #2e6f8a 100%)',
             },
             spacing: {
                 'card-header': '33px',


### PR DESCRIPTION
## Summary

Restores **official Habbo Air Ubuntu** palette (`#418DB0` frame, `#DFDFDF` content, `#376275` / `#0E3F52` accents) from `HabboAir_extracted` deobfuscated client, replacing the custom cream/green window chrome and inconsistent button styles.

## Changes

- **`HabboTheme.css`** — global CSS tokens + `.habbo-btn-primary/secondary/buy/success/danger`
- **`NitroCardView.css`** — window headers/tabs/content aligned to Air frame blue
- **`tailwind.config.js`** — `primary`, `card-header`, etc. synced to `#418DB0`
- **`Button.tsx`**, **`Buttons.css`**, **`NitroButton.tsx`** — unified Habbo shiny button gradients
- **`CatalogView.css`** — catalog blues + secondary/admin/preview buttons (gradient fallback; slice PNGs not in repo)
- **Toolbar** — classic `#555555` bar instead of glassmorphism
- **Inventory**, **navigator room settings**, **wired**, **purse**, **mentions** — accent colors updated
- Inline `#1E7295` → `#418DB0` across settings/editor components

## Reference (Air deobfuscated)

| Token | Hex | Source |
|-------|-----|--------|
| Frame blue | `#418DB0` | `catalog_ubuntu_xml.xml`, `navigator_frame_2_xml.xml` |
| Header body | `#0E3F52` | catalog header background |
| Header border | `#376275` | catalog header border |
| Content | `#DFDFDF` | classic Nitro / Ubuntu panels |
| Toolbar | `#555555` | `tailwind` / bottom bar |

## Test plan

- [ ] Open catalog, navigator, friends, inventory — blue header `#418DB0`, grey content
- [ ] Catalog secondary/preview/buy buttons — Habbo shiny style
- [ ] Wired panel buttons — secondary grey-blue + primary blue
- [ ] Toolbar — solid grey bar, me-menu popover
- [ ] User settings / account panels — accent blue updated
