### PR TITLE
🆙 Fix the user setting : skip.purchase.confirmation

### DIFF
--- a/src/components/catalog/views/page/layout/CatalogLayoutBuildersClubBuyView.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutBuildersClubBuyView.tsx
@@ -3,7 +3,7 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CatalogPurchaseState, LocalizeText, SanitizeHtml, SendMessageComposer } from '../../../../../api';
 import { Button, Column, Flex, Grid, LayoutCurrencyIcon, LayoutGridItem, LayoutLoadingSpinnerView, Text } from '../../../../../common';
 import { CatalogEvent, CatalogPurchasedEvent, CatalogPurchaseFailureEvent } from '../../../../../events';
-import { useCatalogData, useClubOffers, usePurse, useUiEvent } from '../../../../../hooks';
+import { useCatalogData, useCatalogSkipPurchaseConfirmation, useClubOffers, usePurse, useUiEvent } from '../../../../../hooks';
 import { CatalogHeaderView } from '../../catalog-header/CatalogHeaderView';
 import { CatalogLayoutProps } from './CatalogLayout.types';
 
@@ -13,6 +13,7 @@ const BUILDERS_CLUB_ADDONS_WINDOW_ID = 3;
 export const CatalogLayoutBuildersClubBuyView: FC<CatalogLayoutProps> = () => {
     const [pendingOffer, setPendingOffer] = useState<ClubOfferData>(null);
     const [purchaseState, setPurchaseState] = useState(CatalogPurchaseState.NONE);
+    const [catalogSkipPurchaseConfirmation] = useCatalogSkipPurchaseConfirmation();
     const { currentPage = null } = useCatalogData();
     const { getCurrencyAmount = null } = usePurse();
     const isPurchasingRef = useRef(false);
@@ -121,12 +122,12 @@ export const CatalogLayoutBuildersClubBuyView: FC<CatalogLayoutProps> = () => {
             case CatalogPurchaseState.NONE:
             default:
                 return (
-                    <Button fullWidth variant="success" onClick={() => setPurchaseState(CatalogPurchaseState.CONFIRM)}>
+                    <Button fullWidth variant="success" onClick={() => (catalogSkipPurchaseConfirmation ? purchaseOffer() : setPurchaseState(CatalogPurchaseState.CONFIRM))}>
                         {LocalizeText('buy')}
                     </Button>
                 );
         }
-    }, [getCurrencyAmount, pendingOffer, purchaseOffer, purchaseState]);
+    }, [getCurrencyAmount, pendingOffer, purchaseOffer, purchaseState, catalogSkipPurchaseConfirmation]);
 
     const pageDescription = useMemo(() => {
         if (!currentPage) return '';

--- a/src/components/catalog/views/page/layout/CatalogLayoutVipBuyView.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutVipBuyView.tsx
@@ -3,7 +3,7 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CatalogPurchaseState, LocalizeText, SanitizeHtml, SendMessageComposer } from '../../../../../api';
 import { AutoGrid, Button, Column, Flex, Grid, LayoutCurrencyIcon, LayoutLoadingSpinnerView, Text } from '../../../../../common';
 import { CatalogEvent, CatalogPurchasedEvent, CatalogPurchaseFailureEvent } from '../../../../../events';
-import { useCatalogData, useClubOffers, useMessageEvent, usePurse, useUiEvent, useUserDataSnapshot } from '../../../../../hooks';
+import { useCatalogData, useCatalogSkipPurchaseConfirmation, useClubOffers, useMessageEvent, usePurse, useUiEvent, useUserDataSnapshot } from '../../../../../hooks';
 import { CatalogLayoutProps } from './CatalogLayout.types';
 
 const VIP_WINDOW_ID = 1;
@@ -11,6 +11,7 @@ const VIP_WINDOW_ID = 1;
 export const CatalogLayoutVipBuyView: FC<CatalogLayoutProps> = (props) => {
     const [pendingOffer, setPendingOffer] = useState<ClubOfferData>(null);
     const [purchaseState, setPurchaseState] = useState(CatalogPurchaseState.NONE);
+    const [catalogSkipPurchaseConfirmation] = useCatalogSkipPurchaseConfirmation();
     const [giftMode, setGiftMode] = useState(false);
     const [giftRecipient, setGiftRecipient] = useState('');
     const [giftError, setGiftError] = useState<string | null>(null);
@@ -188,12 +189,12 @@ export const CatalogLayoutVipBuyView: FC<CatalogLayoutProps> = (props) => {
             case CatalogPurchaseState.NONE:
             default:
                 return (
-                    <Button disabled={giftBlocked} fullWidth variant="success" onClick={() => setPurchaseState(CatalogPurchaseState.CONFIRM)}>
+                    <Button disabled={giftBlocked} fullWidth variant="success" onClick={() => (catalogSkipPurchaseConfirmation ? purchaseSubscription() : setPurchaseState(CatalogPurchaseState.CONFIRM))}>
                         {buyLabel}
                     </Button>
                 );
         }
-    }, [pendingOffer, purchaseState, purchaseSubscription, getCurrencyAmount, giftMode, giftRecipient, isSelfGift]);
+    }, [pendingOffer, purchaseState, purchaseSubscription, getCurrencyAmount, giftMode, giftRecipient, isSelfGift, catalogSkipPurchaseConfirmation]);
 
     return (
         <Grid>

--- a/src/components/catalog/views/page/widgets/CatalogPurchaseWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogPurchaseWidgetView.tsx
@@ -1,28 +1,9 @@
 import { CreateLinkEvent, PurchaseFromCatalogComposer } from '@nitrots/nitro-renderer';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import {
-    BuilderFurniPlaceableStatus,
-    CatalogPurchaseState,
-    CatalogType,
-    DispatchUiEvent,
-    GetClubMemberLevel,
-    LocalizeText,
-    LocalStorageKeys,
-    NotificationBubbleType,
-    Offer,
-    ProductTypeEnum,
-    SendMessageComposer
-} from '../../../../../api';
+import { BuilderFurniPlaceableStatus, CatalogPurchaseState, CatalogType, DispatchUiEvent, GetClubMemberLevel, LocalizeText, NotificationBubbleType, Offer, ProductTypeEnum, SendMessageComposer } from '../../../../../api';
 import { Button, LayoutLoadingSpinnerView, Text } from '../../../../../common';
-import {
-    CatalogEvent,
-    CatalogInitGiftEvent,
-    CatalogPurchasedEvent,
-    CatalogPurchaseFailureEvent,
-    CatalogPurchaseNotAllowedEvent,
-    CatalogPurchaseSoldOutEvent
-} from '../../../../../events';
-import { useCatalogActions, useCatalogData, useCatalogUiState, useLocalStorage, useNotification, usePurse, useUiEvent } from '../../../../../hooks';
+import { CatalogEvent, CatalogInitGiftEvent, CatalogPurchasedEvent, CatalogPurchaseFailureEvent, CatalogPurchaseNotAllowedEvent, CatalogPurchaseSoldOutEvent } from '../../../../../events';
+import { useCatalogActions, useCatalogData, useCatalogSkipPurchaseConfirmation, useCatalogUiState, useNotification, usePurse, useUiEvent } from '../../../../../hooks';
 
 interface CatalogPurchaseWidgetViewProps {
     noGiftOption?: boolean;
@@ -36,7 +17,7 @@ export const CatalogPurchaseWidgetView: FC<CatalogPurchaseWidgetViewProps> = (pr
     const [builderPlaceableRefreshTick, setBuilderPlaceableRefreshTick] = useState(0);
     const [purchaseWillBeGift, setPurchaseWillBeGift] = useState(false);
     const [purchaseState, setPurchaseState] = useState(CatalogPurchaseState.NONE);
-    const [catalogSkipPurchaseConfirmation, setCatalogSkipPurchaseConfirmation] = useLocalStorage(LocalStorageKeys.CATALOG_SKIP_PURCHASE_CONFIRMATION, false);
+    const [catalogSkipPurchaseConfirmation] = useCatalogSkipPurchaseConfirmation();
     const { currentOffer = null, currentPage = null } = useCatalogData();
     const { currentType = CatalogType.NORMAL, purchaseOptions = null, setPurchaseOptions = null, setCatalogPlaceMultipleObjects = null } = useCatalogUiState();
     const { requestOfferToMover = null, getBuilderFurniPlaceableStatus = null, getNodesByOfferId = null } = useCatalogActions();
@@ -139,17 +120,8 @@ export const CatalogPurchaseWidgetView: FC<CatalogPurchaseWidgetViewProps> = (pr
         };
     }, [purchaseState]);
 
-    // Builders-club state — derived + hooks MUST run unconditionally on
-    // every render so the hook order stays stable even when currentOffer
-    // is null (the `if(!currentOffer) return null` below would otherwise
-    // hide the useMemo/useEffect block from the first render and React
-    // would flag "Rendered more hooks than during the previous render").
     const isBuildersClubOffer = currentType === CatalogType.BUILDER;
-    const isBuildersClubPlaceable =
-        isBuildersClubOffer &&
-        !!currentOffer &&
-        !!currentOffer.product &&
-        (currentOffer.product.productType === ProductTypeEnum.FLOOR || currentOffer.product.productType === ProductTypeEnum.WALL);
+    const isBuildersClubPlaceable = isBuildersClubOffer && !!currentOffer && !!currentOffer.product && (currentOffer.product.productType === ProductTypeEnum.FLOOR || currentOffer.product.productType === ProductTypeEnum.WALL);
     const builderPlaceableStatus = useMemo(() => {
         if (!isBuildersClubPlaceable || !getBuilderFurniPlaceableStatus || !currentOffer) return BuilderFurniPlaceableStatus.OKAY;
 
@@ -173,6 +145,8 @@ export const CatalogPurchaseWidgetView: FC<CatalogPurchaseWidgetViewProps> = (pr
     }, [isBuildersClubPlaceable]);
 
     if (!currentOffer) return null;
+
+    const isLimitedEditionOffer = !!(currentOffer.product && currentOffer.product.isUniqueLimitedItem);
 
     const PurchaseButton = () => {
         const swfButtonClassNames = ['nitro-catalog-swf-button'];
@@ -291,7 +265,7 @@ export const CatalogPurchaseWidgetView: FC<CatalogPurchaseWidgetViewProps> = (pr
                         classNames={[...swfButtonClassNames, 'nitro-catalog-swf-buy-button']}
                         variant="success"
                         disabled={purchaseOptions.extraParamRequired && (!purchaseOptions.extraData || !purchaseOptions.extraData.length)}
-                        onClick={(event) => setPurchaseState(CatalogPurchaseState.CONFIRM)}
+                        onClick={(event) => (catalogSkipPurchaseConfirmation && !isLimitedEditionOffer ? purchase() : setPurchaseState(CatalogPurchaseState.CONFIRM))}
                     >
                         {LocalizeText('catalog.purchase_confirmation.' + (currentOffer.isRentOffer ? 'rent' : 'buy'))}
                     </Button>


### PR DESCRIPTION
The catalog buy button — if the offer's product is a unique limited item (isUniqueLimitedItem, the same field the sold-out check already uses), the click goes to the confirm state regardless of the setting. The item-mover path (dragging an item from the catalog into the room) — same guard; an LTD placement falls back to the confirm flow instead of buying instantly.