### PR TITLE
fix(lovelock): align engraving certificate to Air layout

### DIFF
--- a/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
@@ -54,14 +54,13 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
                 <div className={`nitro-engraving-lock-view ${engravingTypeClass}`.trim()}>
                     <button type="button" className="engraving-lock-close" onClick={onClose} aria-label="Close" />
                     <div className="engraving-lock-avatar engraving-lock-avatar--left">
-                        <LayoutAvatarImageView direction={2} figure={figures[0]} fit scale={0.85} />
+                        <LayoutAvatarImageView direction={2} figure={figures[0]} />
                     </div>
                     <div className="engraving-lock-avatar engraving-lock-avatar--right">
-                        <LayoutAvatarImageView direction={4} figure={figures[1]} fit scale={0.85} />
+                        <LayoutAvatarImageView direction={4} figure={figures[1]} />
                     </div>
                     <p className="engraving-lock-header">{getEngravingCaption(type)}</p>
                     <p className="engraving-lock-date">{date}</p>
-                    <div className="engraving-lock-separator" aria-hidden="true" />
                     <span className="engraving-lock-name engraving-lock-name--left">{usernames[0]}</span>
                     <span className="engraving-lock-name engraving-lock-name--right">{usernames[1]}</span>
                 </div>

--- a/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
@@ -3,6 +3,18 @@ import { LocalizeText } from '../../../../api';
 import { Button, DraggableWindow, LayoutAvatarImageView, NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
 import { useFurnitureFriendFurniWidget } from '../../../../hooks';
 
+const formatEngravingDate = (value: string) => {
+    if (!value) return value;
+
+    const parts = value.split(/[-/.]/).map((part) => parseInt(part, 10));
+
+    if (parts.length !== 3 || parts.some(Number.isNaN)) return value;
+
+    const [day, month, year] = parts;
+
+    return `${String(day).padStart(2, '0')}/${String(month).padStart(2, '0')}/${year}`;
+};
+
 const getEngravingCaption = (type: number) => {
     switch (type) {
         case 3:
@@ -59,10 +71,10 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
                     <div className="engraving-lock-avatar engraving-lock-avatar--right">
                         <LayoutAvatarImageView direction={4} figure={figures[1]} />
                     </div>
-                    <p className="engraving-lock-header">{getEngravingCaption(type)}</p>
-                    <p className="engraving-lock-date">{date}</p>
-                    <span className="engraving-lock-name engraving-lock-name--left">{usernames[0]}</span>
-                    <span className="engraving-lock-name engraving-lock-name--right">{usernames[1]}</span>
+                    <div className="engraving-lock-header">{getEngravingCaption(type)}</div>
+                    <div className="engraving-lock-date">{formatEngravingDate(date)}</div>
+                    <div className="engraving-lock-name engraving-lock-name--left">{usernames[0]}</div>
+                    <div className="engraving-lock-name engraving-lock-name--right">{usernames[1]}</div>
                 </div>
             </DraggableWindow>
         );

--- a/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
@@ -3,6 +3,17 @@ import { LocalizeText } from '../../../../api';
 import { Button, DraggableWindow, LayoutAvatarImageView, NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
 import { useFurnitureFriendFurniWidget } from '../../../../hooks';
 
+const getEngravingCaption = (type: number) => {
+    switch (type) {
+        case 3:
+            return LocalizeText('wildwest.engraving.caption');
+        case 4:
+            return LocalizeText('habboween.engraving.caption');
+        default:
+            return LocalizeText('lovelock.engraving.caption');
+    }
+};
+
 export const FurnitureFriendFurniView: FC<{}> = (props) => {
     const { objectId = -1, type = 0, stage = 0, partnerConfirmed = false, usernames = [], figures = [], date = null, onClose = null, cancelLock = null, respond = null } = useFurnitureFriendFurniWidget();
 
@@ -15,9 +26,9 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
             <NitroCardView className="nitro-engraving-lock" theme="primary-slim">
                 <NitroCardHeaderView headerText={LocalizeText('friend.furniture.confirm.lock.caption')} onCloseClick={cancelLock ?? onClose} />
                 <NitroCardContentView>
-                    <h5 className="text-black text-center font-bold	 mt-2 mb-2">{LocalizeText('friend.furniture.confirm.lock.subtitle')}</h5>
+                    <h5 className="text-black text-center font-bold mt-2 mb-2">{LocalizeText('friend.furniture.confirm.lock.subtitle')}</h5>
                     <div className="flex justify-center mb-2">
-                        <div className={`engraving-lock-stage-${lockStage}`}></div>
+                        <div className={`engraving-lock-stage-${lockStage}`} />
                     </div>
                     {(stage === 2 || partnerConfirmed) && (
                         <div className="text-small text-black text-center mb-2">{LocalizeText('friend.furniture.confirm.lock.other.locked')}</div>
@@ -36,33 +47,27 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
     }
 
     if (usernames.length > 0) {
+        const engravingTypeClass = type === 3 || type === 4 ? `engraving-lock-${type}` : '';
+
         return (
             <DraggableWindow handleSelector=".nitro-engraving-lock-view">
-                <div className={`nitro-engraving-lock-view engraving-lock-${type}`}>
-                    <div className="engraving-lock-close" onClick={onClose} />
-                    <div className="flex justify-center">
-                        <div className="engraving-lock-avatar">
-                            <LayoutAvatarImageView direction={2} figure={figures[0]} />
-                        </div>
-                        <div className="engraving-lock-avatar">
-                            <LayoutAvatarImageView direction={4} figure={figures[1]} />
-                        </div>
+                <div className={`nitro-engraving-lock-view ${engravingTypeClass}`.trim()}>
+                    <button type="button" className="engraving-lock-close" onClick={onClose} aria-label="Close" />
+                    <div className="engraving-lock-avatar engraving-lock-avatar--left">
+                        <LayoutAvatarImageView direction={2} figure={figures[0]} fit scale={0.85} />
                     </div>
-                    <div className="flex flex-col mt-1 justify-between">
-                        <div className="flex flex-col items-center gap-1 justify-center">
-                            <div>
-                                {type === 0 && LocalizeText('lovelock.engraving.caption')}
-                                {type === 3 && LocalizeText('wildwest.engraving.caption')}
-                            </div>
-                            <div>{date}</div>
-                        </div>
-                        <div className="flex gap-4 justify-center">
-                            <div>{usernames[0]}</div>
-                            <div>{usernames[1]}</div>
-                        </div>
+                    <div className="engraving-lock-avatar engraving-lock-avatar--right">
+                        <LayoutAvatarImageView direction={4} figure={figures[1]} fit scale={0.85} />
                     </div>
+                    <p className="engraving-lock-header">{getEngravingCaption(type)}</p>
+                    <p className="engraving-lock-date">{date}</p>
+                    <div className="engraving-lock-separator" aria-hidden="true" />
+                    <span className="engraving-lock-name engraving-lock-name--left">{usernames[0]}</span>
+                    <span className="engraving-lock-name engraving-lock-name--right">{usernames[1]}</span>
                 </div>
             </DraggableWindow>
         );
     }
+
+    return null;
 };

--- a/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
@@ -66,10 +66,10 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
                 <div className={`nitro-engraving-lock-view ${engravingTypeClass}`.trim()}>
                     <button type="button" className="engraving-lock-close" onClick={onClose} aria-label="Close" />
                     <div className="engraving-lock-avatar engraving-lock-avatar--left">
-                        <LayoutAvatarImageView direction={2} figure={figures[0]} fit />
+                        <LayoutAvatarImageView direction={2} figure={figures[0]} />
                     </div>
                     <div className="engraving-lock-avatar engraving-lock-avatar--right">
-                        <LayoutAvatarImageView direction={4} figure={figures[1]} fit />
+                        <LayoutAvatarImageView direction={4} figure={figures[1]} />
                     </div>
                     <div className="engraving-lock-header">{getEngravingCaption(type)}</div>
                     <div className="engraving-lock-date">{formatEngravingDate(date)}</div>

--- a/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureFriendFurniView.tsx
@@ -66,10 +66,10 @@ export const FurnitureFriendFurniView: FC<{}> = (props) => {
                 <div className={`nitro-engraving-lock-view ${engravingTypeClass}`.trim()}>
                     <button type="button" className="engraving-lock-close" onClick={onClose} aria-label="Close" />
                     <div className="engraving-lock-avatar engraving-lock-avatar--left">
-                        <LayoutAvatarImageView direction={2} figure={figures[0]} />
+                        <LayoutAvatarImageView direction={2} figure={figures[0]} fit />
                     </div>
                     <div className="engraving-lock-avatar engraving-lock-avatar--right">
-                        <LayoutAvatarImageView direction={4} figure={figures[1]} />
+                        <LayoutAvatarImageView direction={4} figure={figures[1]} fit />
                     </div>
                     <div className="engraving-lock-header">{getEngravingCaption(type)}</div>
                     <div className="engraving-lock-date">{formatEngravingDate(date)}</div>

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -421,13 +421,14 @@
     background-image: url('@/assets/images/room-widgets/engraving-lock-widget/engraving-lock-spritesheet.png');
     background-position: 0 0;
     background-repeat: no-repeat;
+    background-size: 375px 630px;
     image-rendering: pixelated;
     color: #59224a;
     font-family: UbuntuCondensed, Ubuntu, sans-serif;
     font-weight: 700;
-    font-size: 13px;
+    font-size: 12px;
     line-height: 17px;
-    text-shadow: 0 1px #ffffff;
+    text-shadow: 0 1px 0 #ffffff;
     user-select: none;
 }
 
@@ -439,7 +440,7 @@
 .nitro-engraving-lock-view.engraving-lock-4 {
     background-position: 0 -420px;
     color: #f1dcc8;
-    text-shadow: 0 2px rgba(0, 0, 0, 0.4);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
 }
 
 .nitro-engraving-lock-view .engraving-lock-close {
@@ -465,10 +466,23 @@
 
 .nitro-engraving-lock-view .engraving-lock-avatar .avatar-image {
     position: absolute !important;
-    inset: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    left: 0 !important;
+    bottom: 0;
+    left: 50%;
+    width: 90px !important;
+    height: 130px !important;
+    margin-left: 0 !important;
+    transform: translateX(-50%);
+    image-rendering: pixelated;
+}
+
+.nitro-engraving-lock-view .engraving-lock-avatar--left .avatar-image {
+    margin-left: -10px !important;
+    transform: translateX(calc(-50% - 5px));
+}
+
+.nitro-engraving-lock-view .engraving-lock-avatar--right .avatar-image {
+    margin-left: -15px !important;
+    transform: translateX(calc(-50% - 7px));
 }
 
 .nitro-engraving-lock-view .engraving-lock-avatar--left {
@@ -495,25 +509,6 @@
     width: 97px;
     margin: 0;
     text-align: center;
-}
-
-.nitro-engraving-lock-view .engraving-lock-separator {
-    position: absolute;
-    top: 168px;
-    left: 40px;
-    width: 295px;
-    height: 1px;
-    margin: 0;
-    background: rgba(89, 34, 74, 0.22);
-    border: 0;
-}
-
-.nitro-engraving-lock-view.engraving-lock-3 .engraving-lock-separator {
-    background: rgba(97, 65, 16, 0.25);
-}
-
-.nitro-engraving-lock-view.engraving-lock-4 .engraving-lock-separator {
-    background: rgba(241, 220, 200, 0.25);
 }
 
 .nitro-engraving-lock-view .engraving-lock-name {

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -421,7 +421,7 @@
     background-image: url('@/assets/images/room-widgets/engraving-lock-widget/engraving-lock-spritesheet.png');
     background-position: 0 0;
     background-repeat: no-repeat;
-    background-size: 375px 630px;
+    background-size: 411px 630px;
     image-rendering: pixelated;
     color: #59224a;
     font-family: UbuntuCondensed, Ubuntu, sans-serif;
@@ -493,31 +493,36 @@
     left: 186px;
 }
 
-.nitro-engraving-lock-view .engraving-lock-header {
+.nitro-engraving-lock-view .engraving-lock-header,
+.nitro-engraving-lock-view .engraving-lock-date,
+.nitro-engraving-lock-view .engraving-lock-name {
     position: absolute;
+    display: block;
+    height: 17px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+
+.nitro-engraving-lock-view .engraving-lock-header {
     top: 126px;
     left: 82px;
     width: 217px;
-    margin: 0;
     text-align: center;
 }
 
 .nitro-engraving-lock-view .engraving-lock-date {
-    position: absolute;
     top: 151px;
     left: 143px;
     width: 97px;
-    margin: 0;
     text-align: center;
 }
 
 .nitro-engraving-lock-view .engraving-lock-name {
-    position: absolute;
     top: 175px;
-    margin: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .nitro-engraving-lock-view .engraving-lock-name--left {

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -413,62 +413,128 @@
     }
 }
 
+/* lovelock_engraving_xml.xml — 375×210, absolute layout */
 .nitro-engraving-lock-view {
+    position: relative;
     width: 375px;
     height: 210px;
-    background-position: 0px 0px;
     background-image: url('@/assets/images/room-widgets/engraving-lock-widget/engraving-lock-spritesheet.png');
+    background-position: 0 0;
+    background-repeat: no-repeat;
+    image-rendering: pixelated;
+    color: #59224a;
+    font-family: UbuntuCondensed, Ubuntu, sans-serif;
+    font-weight: 700;
+    font-size: 13px;
+    line-height: 17px;
+    text-shadow: 0 1px #ffffff;
+    user-select: none;
+}
 
-    color: #622e54;
-    font-weight: bold;
-    font-size: 16px;
-    text-shadow: 0px 1px white;
+.nitro-engraving-lock-view.engraving-lock-3 {
+    background-position: 0 -210px;
+    color: #614110;
+}
 
-    &.engraving-lock-3 {
-        background-position: 0px -210px;
-        color: #614110;
-    }
+.nitro-engraving-lock-view.engraving-lock-4 {
+    background-position: 0 -420px;
+    color: #f1dcc8;
+    text-shadow: 0 2px rgba(0, 0, 0, 0.4);
+}
 
-    &.engraving-lock-4 {
-        background-position: 0px -420px;
-        color: #f1dcc8;
-        text-shadow: 0px 2px rgba(0, 0, 0, 0.4);
+.nitro-engraving-lock-view .engraving-lock-close {
+    position: absolute;
+    top: 33px;
+    right: 24px;
+    width: 21px;
+    height: 17px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+}
 
-        .engraving-lock-avatar {
-            margin-bottom: 10px;
-        }
-    }
+.nitro-engraving-lock-view .engraving-lock-avatar {
+    position: absolute;
+    top: 7px;
+    width: 70px;
+    height: 115px;
+    overflow: hidden;
+    pointer-events: none;
+}
 
-    .engraving-lock-close {
-        position: absolute;
-        cursor: pointer;
-        width: 15px;
-        height: 15px;
-        top: 34px;
-        right: 27px;
-    }
+.nitro-engraving-lock-view .engraving-lock-avatar .avatar-image {
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    left: 0 !important;
+}
 
-    .engraving-lock-avatar {
-        width: 70px;
-        height: 120px;
+.nitro-engraving-lock-view .engraving-lock-avatar--left {
+    left: 115px;
+}
 
-        div {
-            position: absolute;
-            margin-top: -5px;
-        }
+.nitro-engraving-lock-view .engraving-lock-avatar--right {
+    left: 186px;
+}
 
-        &:nth-child(1) {
-            div {
-                margin-left: -10px;
-            }
-        }
+.nitro-engraving-lock-view .engraving-lock-header {
+    position: absolute;
+    top: 126px;
+    left: 82px;
+    width: 217px;
+    margin: 0;
+    text-align: center;
+}
 
-        &:nth-child(2) {
-            div {
-                margin-left: -15px;
-            }
-        }
-    }
+.nitro-engraving-lock-view .engraving-lock-date {
+    position: absolute;
+    top: 151px;
+    left: 143px;
+    width: 97px;
+    margin: 0;
+    text-align: center;
+}
+
+.nitro-engraving-lock-view .engraving-lock-separator {
+    position: absolute;
+    top: 168px;
+    left: 40px;
+    width: 295px;
+    height: 1px;
+    margin: 0;
+    background: rgba(89, 34, 74, 0.22);
+    border: 0;
+}
+
+.nitro-engraving-lock-view.engraving-lock-3 .engraving-lock-separator {
+    background: rgba(97, 65, 16, 0.25);
+}
+
+.nitro-engraving-lock-view.engraving-lock-4 .engraving-lock-separator {
+    background: rgba(241, 220, 200, 0.25);
+}
+
+.nitro-engraving-lock-view .engraving-lock-name {
+    position: absolute;
+    top: 175px;
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nitro-engraving-lock-view .engraving-lock-name--left {
+    left: 19px;
+    width: 150px;
+    text-align: right;
+}
+
+.nitro-engraving-lock-view .engraving-lock-name--right {
+    left: 199px;
+    width: 87px;
+    text-align: left;
 }
 
 .nitro-widget-high-score {

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -466,23 +466,24 @@
 
 .nitro-engraving-lock-view .engraving-lock-avatar .avatar-image {
     position: absolute !important;
-    bottom: 0;
-    left: 50%;
-    width: 90px !important;
-    height: 130px !important;
-    margin-left: 0 !important;
-    transform: translateX(-50%);
+    inset: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    left: 0 !important;
+    margin: 0 !important;
+    transform: none !important;
     image-rendering: pixelated;
 }
 
-.nitro-engraving-lock-view .engraving-lock-avatar--left .avatar-image {
-    margin-left: -10px !important;
-    transform: translateX(calc(-50% - 5px));
-}
-
-.nitro-engraving-lock-view .engraving-lock-avatar--right .avatar-image {
-    margin-left: -15px !important;
-    transform: translateX(calc(-50% - 7px));
+.nitro-engraving-lock-view .engraving-lock-avatar .avatar-image img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: bottom center;
+    transform: none !important;
+    image-rendering: pixelated;
 }
 
 .nitro-engraving-lock-view .engraving-lock-avatar--left {

--- a/src/css/widgets/FurnitureWidgets.css
+++ b/src/css/widgets/FurnitureWidgets.css
@@ -466,23 +466,13 @@
 
 .nitro-engraving-lock-view .engraving-lock-avatar .avatar-image {
     position: absolute !important;
-    inset: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    left: 0 !important;
+    top: auto !important;
+    bottom: 0 !important;
+    left: 50% !important;
+    width: 90px !important;
+    height: 130px !important;
     margin: 0 !important;
-    transform: none !important;
-    image-rendering: pixelated;
-}
-
-.nitro-engraving-lock-view .engraving-lock-avatar .avatar-image img {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    object-position: bottom center;
-    transform: none !important;
+    transform: translateX(-50%) !important;
     image-rendering: pixelated;
 }
 


### PR DESCRIPTION
## Summary

- Rebuilds the **love lock / friend furni engraving certificate** UI to match Habbo Air `lovelock_engraving_xml.xml` (375×210).
- Uses **absolute positioning** for avatars (inside the heart), caption, date, separator line, and partner names instead of the previous flex layout that misaligned text and sprites.
- Restores Air typography (`#59224a`, Ubuntu bold, white etching shadow) and the correct close-button hitbox (21×17 @ top-right).
- Keeps the **official Nitro** `engraving-lock-spritesheet.png` background (lovelock / wildwest / habboween variants unchanged).

## Out of scope

- **PurseView** styling and tooltip work is already in PR #313 — not included here.

## Test plan

- [ ] Place and lock a love lock with a partner; confirm both players see the certificate.
- [ ] Verify avatars render inside the heart, caption + date centered, names left/right at the bottom (Air layout).
- [ ] Close button dismisses the certificate.
- [ ] Repeat with wildwest (`type 3`) and habboween (`type 4`) engravings if available on the hotel.
- [ ] Confirm lock confirmation dialog (stage > 0) still works before engraving is finalized.
