### PR TITLE
Upgrade messenger with persistent AIR-inspired UI

### DIFF
--- a/src/api/friends/friendCategory.helpers.test.ts
+++ b/src/api/friends/friendCategory.helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { countFriendsByCategory, filterFriendsByCategory } from './friendCategory.helpers';
+import { countFriendsByCategory, filterFriendsByCategory, withUpdatedFriendCategories } from './friendCategory.helpers';
 import { MessengerFriend } from './MessengerFriend';
+import { MessengerSettings } from './MessengerSettings';
 
 const makeFriend = (id: number, categoryId: number): MessengerFriend => {
     const friend = new MessengerFriend();
@@ -40,5 +41,17 @@ describe('countFriendsByCategory', () => {
 
     it('is null-safe', () => {
         expect(countFriendsByCategory(null).size).toBe(0);
+    });
+});
+
+describe('withUpdatedFriendCategories', () => {
+    it('preserves limits and replaces categories, including an empty server list', () => {
+        const settings = new MessengerSettings(100, 200, 300, [ { id: 1, name: 'Old' } as any ]);
+        const updated = withUpdatedFriendCategories(settings, [ { id: 2, name: 'New' } as any ]);
+        const cleared = withUpdatedFriendCategories(updated, []);
+
+        expect(updated).toMatchObject({ userFriendLimit: 100, normalFriendLimit: 200, extendedFriendLimit: 300 });
+        expect(updated.categories.map(category => category.id)).toEqual([ 2 ]);
+        expect(cleared.categories).toEqual([]);
     });
 });

--- a/src/api/friends/friendCategory.helpers.ts
+++ b/src/api/friends/friendCategory.helpers.ts
@@ -1,4 +1,6 @@
+import { FriendCategoryData } from '@nitrots/nitro-renderer';
 import { MessengerFriend } from './MessengerFriend';
+import { MessengerSettings } from './MessengerSettings';
 
 /**
  * Filter a friend list to a single category. categoryId 0 means
@@ -26,4 +28,10 @@ export const countFriendsByCategory = (friends: MessengerFriend[]): Map<number, 
     }
 
     return counts;
+};
+
+export const withUpdatedFriendCategories = (settings: MessengerSettings, categories: FriendCategoryData[]): MessengerSettings => {
+    if (!settings) return settings;
+
+    return new MessengerSettings(settings.userFriendLimit, settings.normalFriendLimit, settings.extendedFriendLimit, [ ...(categories ?? []) ]);
 };

--- a/src/api/friends/index.ts
+++ b/src/api/friends/index.ts
@@ -10,3 +10,4 @@ export * from './MessengerThread';
 export * from './MessengerThreadChat';
 export * from './MessengerThreadChatGroup';
 export * from './OpenMessengerChat';
+export * from './messenger';

--- a/src/api/friends/messenger/MessengerConversation.ts
+++ b/src/api/friends/messenger/MessengerConversation.ts
@@ -1,0 +1,18 @@
+export interface MessengerConversation
+{
+    id: number;
+    type: number;
+    participantId: number;
+    name: string;
+    lastMessageId: number;
+    unreadCount: number;
+    updatedAt: number;
+}
+
+export interface MessengerHistoryState
+{
+    loading: boolean;
+    loaded: boolean;
+    hasMore: boolean;
+    error: boolean;
+}

--- a/src/api/friends/messenger/MessengerMessage.ts
+++ b/src/api/friends/messenger/MessengerMessage.ts
@@ -1,0 +1,15 @@
+export type MessengerMessageStatus = 'sending' | 'sent' | 'read' | 'failed';
+
+export interface MessengerMessage
+{
+    id: number;
+    clientId: string | null;
+    conversationId: number;
+    senderId: number;
+    type: number;
+    message: string;
+    metadata: string;
+    createdAt: number;
+    status: MessengerMessageStatus;
+    errorCode?: number;
+}

--- a/src/api/friends/messenger/index.ts
+++ b/src/api/friends/messenger/index.ts
@@ -1,0 +1,4 @@
+export * from './MessengerConversation';
+export * from './MessengerMessage';
+export * from './messengerReducer';
+export * from './messengerSelectors';

--- a/src/api/friends/messenger/messengerReducer.test.ts
+++ b/src/api/friends/messenger/messengerReducer.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { initialMessengerState, messengerReducer, selectMessageByClientId, selectMessages, selectMessengerIconState } from '.';
+import { MessengerIconState } from '../MessengerIconState';
+
+describe('messengerReducer', () =>
+{
+    it('deduplicates a realtime message already present in history', () =>
+    {
+        const message = { id: 41, clientId: null, conversationId: 7, senderId: 9, type: 0, message: 'hi', metadata: '', createdAt: 100, status: 'sent' as const };
+        const once = messengerReducer(initialMessengerState, { type: 'historyLoaded', conversationId: 7, messages: [ message ], hasMore: false });
+        const twice = messengerReducer(once, { type: 'messageReceived', message });
+
+        expect(selectMessages(twice, 7).map(item => item.id)).toEqual([ 41 ]);
+    });
+
+    it('replaces optimistic identity on acknowledgement', () =>
+    {
+        const optimistic = { id: 0, clientId: 'c-9', conversationId: 7, senderId: 1, type: 0, message: 'hello', metadata: '', createdAt: 100, status: 'sending' as const };
+        const pending = messengerReducer(initialMessengerState, { type: 'messageOptimistic', message: optimistic });
+        const acknowledged = messengerReducer(pending, { type: 'messageAcknowledged', clientId: 'c-9', messageId: 88, conversationId: 7, createdAt: 123456 });
+
+        expect(selectMessageByClientId(acknowledged, 'c-9')).toMatchObject({ id: 88, status: 'sent', createdAt: 123456 });
+        expect(selectMessages(acknowledged, 7)).toHaveLength(1);
+    });
+
+    it('keeps a failed optimistic message available for retry', () =>
+    {
+        const optimistic = { id: 0, clientId: 'c-10', conversationId: 7, senderId: 1, type: 0, message: 'hello', metadata: '', createdAt: 100, status: 'sending' as const };
+        const pending = messengerReducer(initialMessengerState, { type: 'messageOptimistic', message: optimistic });
+        const failed = messengerReducer(pending, { type: 'messageFailed', clientId: 'c-10', errorCode: 6 });
+
+        expect(selectMessageByClientId(failed, 'c-10')).toMatchObject({ status: 'failed', errorCode: 6 });
+    });
+
+    it('opens a direct draft and migrates it to the server conversation on acknowledgement', () =>
+    {
+        const opened = messengerReducer(initialMessengerState, { type: 'directConversationOpened', participantId: 9, name: 'Frank' });
+        const draftId = -9;
+        const optimistic = { id: 0, clientId: 'c-11', conversationId: draftId, senderId: 1, type: 0, message: 'hello', metadata: '', createdAt: 100, status: 'sending' as const };
+        const pending = messengerReducer(opened, { type: 'messageOptimistic', message: optimistic });
+        const acknowledged = messengerReducer(pending, { type: 'messageAcknowledged', clientId: 'c-11', messageId: 89, conversationId: 77, createdAt: 101 });
+
+        expect(acknowledged.selectedConversationId).toBe(77);
+        expect(acknowledged.conversationIds).toContain(77);
+        expect(acknowledged.conversationsById[77]).toMatchObject({ participantId: 9, name: 'Frank' });
+        expect(selectMessages(acknowledged, 77)).toHaveLength(1);
+        expect(selectMessages(acknowledged, draftId)).toHaveLength(0);
+    });
+
+    it('marks the toolbar unread when a realtime message arrives and clears it when read', () =>
+    {
+        const conversation = { id: 7, type: 0, participantId: 9, name: 'Frank', lastMessageId: 0, unreadCount: 0, updatedAt: 100 };
+        const loaded = messengerReducer(initialMessengerState, { type: 'summariesLoaded', conversations: [ conversation ] });
+        const message = { id: 41, clientId: null, conversationId: 7, senderId: 9, type: 0, message: 'hi', metadata: '', createdAt: 101, status: 'sent' as const };
+        const unread = messengerReducer(loaded, { type: 'messageReceived', message });
+
+        expect(unread.conversationsById[7].unreadCount).toBe(1);
+        expect(selectMessengerIconState(unread, false, false)).toBe(MessengerIconState.UNREAD);
+
+        const read = messengerReducer(unread, { type: 'readCursorAdvanced', conversationId: 7, readerId: 1, messageId: 41, ownUserId: 1 });
+        expect(read.conversationsById[7].unreadCount).toBe(0);
+        expect(selectMessengerIconState(read, false, false)).toBe(MessengerIconState.SHOW);
+    });
+
+    it('preserves a loaded conversation and its history when a later summary refresh omits it', () =>
+    {
+        const conversation = { id: 7, type: 0, participantId: 9, name: 'Frank', lastMessageId: 41, unreadCount: 0, updatedAt: 100 };
+        const message = { id: 41, clientId: null, conversationId: 7, senderId: 9, type: 0, message: 'history', metadata: '', createdAt: 100, status: 'sent' as const };
+        const loaded = messengerReducer(initialMessengerState, { type: 'summariesLoaded', conversations: [ conversation ] });
+        const withHistory = messengerReducer(loaded, { type: 'historyLoaded', conversationId: 7, messages: [ message ], hasMore: false });
+        const refreshed = messengerReducer(withHistory, { type: 'summariesLoaded', conversations: [] });
+
+        expect(refreshed.conversationIds).toEqual([ 7 ]);
+        expect(refreshed.conversationsById[7]).toEqual(conversation);
+        expect(selectMessages(refreshed, 7)).toEqual([ message ]);
+        expect(refreshed.historyByConversation[7]).toMatchObject({ loaded: true, hasMore: false });
+    });
+
+    it('keeps only the newest Staff Chat summary when the server returns duplicate conversation ids', () =>
+    {
+        const older = { id: 20, type: 1, participantId: 0, name: 'Staff Chat', lastMessageId: 40, unreadCount: 0, updatedAt: 100 };
+        const newer = { id: 21, type: 1, participantId: 0, name: ' staff chat ', lastMessageId: 41, unreadCount: 1, updatedAt: 110 };
+        const refreshed = messengerReducer(initialMessengerState, { type: 'summariesLoaded', conversations: [ older, newer ] });
+
+        expect(refreshed.conversationIds).toEqual([ 21 ]);
+        expect(refreshed.conversationsById[21]).toEqual(newer);
+    });
+
+    it('selects the server Staff Chat instead of creating a direct draft', () =>
+    {
+        const staffChat = { id: 21, type: 1, participantId: 0, name: 'Staff Chat', lastMessageId: 41, unreadCount: 0, updatedAt: 110 };
+        const loaded = messengerReducer(initialMessengerState, { type: 'summariesLoaded', conversations: [ staffChat ] });
+        const opened = messengerReducer(loaded, { type: 'directConversationOpened', participantId: -1, name: 'Staff Chat' });
+
+        expect(opened.selectedConversationId).toBe(21);
+        expect(opened.conversationIds).toEqual([ 21 ]);
+        expect(Object.values(opened.conversationsById)).toEqual([ staffChat ]);
+    });
+});

--- a/src/api/friends/messenger/messengerReducer.ts
+++ b/src/api/friends/messenger/messengerReducer.ts
@@ -1,0 +1,188 @@
+import { MessengerConversation, MessengerHistoryState } from './MessengerConversation';
+import { MessengerMessage } from './MessengerMessage';
+
+export interface MessengerState
+{
+    selectedConversationId: number;
+    conversationIds: number[];
+    conversationsById: Record<number, MessengerConversation>;
+    messagesByKey: Record<string, MessengerMessage>;
+    messageKeysByConversation: Record<number, string[]>;
+    historyByConversation: Record<number, MessengerHistoryState>;
+}
+
+export const initialMessengerState: MessengerState = {
+    selectedConversationId: 0, conversationIds: [], conversationsById: {}, messagesByKey: {}, messageKeysByConversation: {}, historyByConversation: {}
+};
+
+export type MessengerAction =
+    | { type: 'summariesLoaded'; conversations: MessengerConversation[] }
+    | { type: 'directConversationOpened'; participantId: number; name: string }
+    | { type: 'historyLoading'; conversationId: number }
+    | { type: 'historyLoaded'; conversationId: number; messages: MessengerMessage[]; hasMore: boolean }
+    | { type: 'historyFailed'; conversationId: number }
+    | { type: 'messageOptimistic'; message: MessengerMessage }
+    | { type: 'messageAcknowledged'; clientId: string; messageId: number; conversationId: number; createdAt: number }
+    | { type: 'messageFailed'; clientId: string; errorCode: number }
+    | { type: 'messageReceived'; message: MessengerMessage }
+    | { type: 'readCursorAdvanced'; conversationId: number; readerId: number; messageId: number; ownUserId: number };
+
+const keyFor = (message: MessengerMessage) => message.id > 0 ? `server:${ message.id }` : `client:${ message.clientId }`;
+const isStaffChat = (conversation: MessengerConversation) => conversation.name.trim().toLocaleLowerCase() === 'staff chat';
+
+const insertMessage = (state: MessengerState, message: MessengerMessage): MessengerState =>
+{
+    const key = keyFor(message);
+    const currentKeys = state.messageKeysByConversation[message.conversationId] || [];
+    if(state.messagesByKey[key]) return state;
+
+    const keys = [ ...currentKeys, key ].sort((a, b) =>
+    {
+        const left = a === key ? message : state.messagesByKey[a];
+        const right = b === key ? message : state.messagesByKey[b];
+        return (left.createdAt - right.createdAt) || (left.id - right.id);
+    });
+
+    return {
+        ...state,
+        messagesByKey: { ...state.messagesByKey, [key]: message },
+        messageKeysByConversation: { ...state.messageKeysByConversation, [message.conversationId]: keys }
+    };
+};
+
+export const messengerReducer = (state: MessengerState, action: MessengerAction): MessengerState =>
+{
+    switch(action.type)
+    {
+        case 'directConversationOpened':
+        {
+            if(action.participantId === -1 || action.name.trim().toLocaleLowerCase() === 'staff chat')
+            {
+                const staffChat = state.conversationIds.map(id => state.conversationsById[id]).find(conversation => conversation.type === 1 && isStaffChat(conversation));
+                return staffChat ? { ...state, selectedConversationId: staffChat.id } : state;
+            }
+            const existing = state.conversationIds.map(id => state.conversationsById[id]).find(conversation => conversation.type === 0 && conversation.participantId === action.participantId);
+            if(existing) return { ...state, selectedConversationId: existing.id };
+            const draftId = -action.participantId;
+            const draft: MessengerConversation = { id: draftId, type: 0, participantId: action.participantId, name: action.name, lastMessageId: 0, unreadCount: 0, updatedAt: Math.floor(Date.now() / 1000) };
+            return {
+                ...state,
+                selectedConversationId: draftId,
+                conversationIds: [ draftId, ...state.conversationIds ],
+                conversationsById: { ...state.conversationsById, [draftId]: draft }
+            };
+        }
+        case 'summariesLoaded':
+        {
+            const serverConversations = action.conversations.reduce<MessengerConversation[]>((result, conversation) =>
+            {
+                if(!isStaffChat(conversation)) return [ ...result, conversation ];
+                const duplicateIndex = result.findIndex(isStaffChat);
+                if(duplicateIndex === -1) return [ ...result, conversation ];
+                if(result[duplicateIndex].updatedAt >= conversation.updatedAt) return result;
+                const next = [ ...result ];
+                next[duplicateIndex] = conversation;
+                return next;
+            }, []);
+            const serverIds = serverConversations.map(item => item.id);
+            const preservedIds = state.conversationIds.filter(id =>
+            {
+                if(serverIds.indexOf(id) !== -1) return false;
+                const existing = state.conversationsById[id];
+                return !existing || !isStaffChat(existing) || !serverConversations.some(isStaffChat);
+            });
+
+            return {
+                ...state,
+                conversationIds: [ ...serverIds, ...preservedIds ],
+                conversationsById: {
+                    ...state.conversationsById,
+                    ...Object.fromEntries(serverConversations.map(item => [ item.id, item ]))
+                }
+            };
+        }
+        case 'historyLoading':
+            return { ...state, historyByConversation: { ...state.historyByConversation, [action.conversationId]: { ...(state.historyByConversation[action.conversationId] || { loaded: false, hasMore: true }), loading: true, error: false } } };
+        case 'historyLoaded':
+        {
+            let next = state;
+            action.messages.forEach(message => { next = insertMessage(next, message); });
+            return { ...next, historyByConversation: { ...next.historyByConversation, [action.conversationId]: { loading: false, loaded: true, hasMore: action.hasMore, error: false } } };
+        }
+        case 'historyFailed':
+            return { ...state, historyByConversation: { ...state.historyByConversation, [action.conversationId]: { ...(state.historyByConversation[action.conversationId] || { loaded: false, hasMore: true }), loading: false, error: true } } };
+        case 'messageOptimistic':
+            return insertMessage(state, action.message);
+        case 'messageReceived':
+        {
+            if(state.messagesByKey[keyFor(action.message)]) return state;
+            const next = insertMessage(state, action.message);
+            const conversation = next.conversationsById[action.message.conversationId];
+            if(!conversation) return next;
+            return {
+                ...next,
+                conversationsById: {
+                    ...next.conversationsById,
+                    [conversation.id]: {
+                        ...conversation,
+                        lastMessageId: action.message.id,
+                        unreadCount: conversation.unreadCount + 1,
+                        updatedAt: action.message.createdAt
+                    }
+                }
+            };
+        }
+        case 'messageAcknowledged':
+        {
+            const oldKey = `client:${ action.clientId }`;
+            const pending = state.messagesByKey[oldKey];
+            if(!pending) return state;
+            const newKey = `server:${ action.messageId }`;
+            const acknowledged = { ...pending, id: action.messageId, conversationId: action.conversationId, createdAt: action.createdAt, status: 'sent' as const };
+            const messagesByKey = { ...state.messagesByKey };
+            delete messagesByKey[oldKey];
+            messagesByKey[newKey] = acknowledged;
+            const keys = (state.messageKeysByConversation[pending.conversationId] || []).map(key => key === oldKey ? newKey : key);
+            if(pending.conversationId === action.conversationId) return { ...state, messagesByKey, messageKeysByConversation: { ...state.messageKeysByConversation, [pending.conversationId]: keys } };
+
+            const draft = state.conversationsById[pending.conversationId];
+            const conversationsById = { ...state.conversationsById };
+            delete conversationsById[pending.conversationId];
+            if(draft) conversationsById[action.conversationId] = { ...draft, id: action.conversationId, lastMessageId: action.messageId, updatedAt: action.createdAt };
+            const messageKeysByConversation = { ...state.messageKeysByConversation };
+            delete messageKeysByConversation[pending.conversationId];
+            messageKeysByConversation[action.conversationId] = keys;
+            return {
+                ...state,
+                selectedConversationId: state.selectedConversationId === pending.conversationId ? action.conversationId : state.selectedConversationId,
+                conversationIds: state.conversationIds.map(id => id === pending.conversationId ? action.conversationId : id),
+                conversationsById,
+                messagesByKey,
+                messageKeysByConversation
+            };
+        }
+        case 'messageFailed':
+        {
+            const key = `client:${ action.clientId }`;
+            const message = state.messagesByKey[key];
+            if(!message) return state;
+            return { ...state, messagesByKey: { ...state.messagesByKey, [key]: { ...message, status: 'failed', errorCode: action.errorCode } } };
+        }
+        case 'readCursorAdvanced':
+        {
+            const messagesByKey = { ...state.messagesByKey };
+            (state.messageKeysByConversation[action.conversationId] || []).forEach(key =>
+            {
+                const message = messagesByKey[key];
+                if(message.senderId === action.ownUserId && message.id > 0 && message.id <= action.messageId) messagesByKey[key] = { ...message, status: 'read' };
+            });
+            const conversation = state.conversationsById[action.conversationId];
+            const conversationsById = action.readerId === action.ownUserId && conversation
+                ? { ...state.conversationsById, [conversation.id]: { ...conversation, unreadCount: 0 } }
+                : state.conversationsById;
+            return { ...state, messagesByKey, conversationsById };
+        }
+        default:
+            return state;
+    }
+};

--- a/src/api/friends/messenger/messengerSelectors.ts
+++ b/src/api/friends/messenger/messengerSelectors.ts
@@ -1,0 +1,18 @@
+import { MessengerState } from './messengerReducer';
+import { MessengerIconState } from '../MessengerIconState';
+
+export const selectMessages = (state: MessengerState, conversationId: number) =>
+    (state.messageKeysByConversation[conversationId] || []).map(key => state.messagesByKey[key]).filter(Boolean);
+
+export const selectMessageByClientId = (state: MessengerState, clientId: string) =>
+    Object.values(state.messagesByKey).find(message => message.clientId === clientId) || null;
+
+export const selectConversations = (state: MessengerState) => state.conversationIds.map(id => state.conversationsById[id]).filter(Boolean);
+
+export const selectMessengerIconState = (state: MessengerState, hasLegacyThreads: boolean, hasLegacyUnread: boolean) =>
+{
+    const conversations = selectConversations(state);
+    if(hasLegacyUnread || conversations.some(conversation => conversation.unreadCount > 0)) return MessengerIconState.UNREAD;
+    if(hasLegacyThreads || conversations.length > 0) return MessengerIconState.SHOW;
+    return MessengerIconState.HIDDEN;
+};

--- a/src/common/layout/LayoutAvatarImageView.compact-head.test.ts
+++ b/src/common/layout/LayoutAvatarImageView.compact-head.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/common/layout/LayoutAvatarImageView.tsx'), 'utf8');
+
+describe('LayoutAvatarImageView compact heads', () =>
+{
+    it('rasterizes and caches compact heads at the requested final size', () =>
+    {
+        expect(source).toMatch(/compactHeadSize\?:\s*number/);
+        expect(source).toMatch(/compactHeadPadding\?:\s*number/);
+        expect(source).toMatch(/cropTransparentImageUrl\(imageUrl,\s*compactHeadSize,\s*compactHeadPadding\)/);
+        expect(source).toMatch(/figureKey\s*=\s*\[figure, gender, direction, headOnly, compactHead, compactHeadSize, compactHeadPadding\]/);
+    });
+});

--- a/src/common/layout/LayoutAvatarImageView.tsx
+++ b/src/common/layout/LayoutAvatarImageView.tsx
@@ -1,6 +1,7 @@
 import { AvatarScaleType, AvatarSetType, GetAvatarRenderManager } from '@nitrots/nitro-renderer';
 import { CSSProperties, FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Base, BaseProps } from '../Base';
+import { cropTransparentImageUrl } from './avatarImageCrop';
 
 const AVATAR_CACHE_MAX_SIZE = 200;
 const AVATAR_IMAGE_CACHE: Map<string, string> = new Map();
@@ -12,10 +13,13 @@ export interface LayoutAvatarImageViewProps extends BaseProps<HTMLDivElement> {
     direction?: number;
     scale?: number;
     fit?: boolean;
+    compactHead?: boolean;
+    compactHeadSize?: number;
+    compactHeadPadding?: number;
 }
 
 export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => {
-    const { figure = '', gender = '', headOnly = false, direction = 0, scale = 1, fit = false, classNames = [], style = {}, ...rest } = props;
+    const { figure = '', gender = '', headOnly = false, direction = 0, scale = 1, fit = false, compactHead = false, compactHeadSize = 22, compactHeadPadding = 1, classNames = [], style = {}, ...rest } = props;
     const [avatarUrl, setAvatarUrl] = useState<string>(null);
     const [isReady, setIsReady] = useState<boolean>(false);
     const isDisposed = useRef(false);
@@ -33,9 +37,10 @@ export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => 
         }
 
         if (classNames.length) newClassNames.push(...classNames);
+        if (compactHead) newClassNames.push('compact-head');
 
         return newClassNames;
-    }, [classNames, headOnly, fit]);
+    }, [classNames, headOnly, fit, compactHead]);
 
     const getStyle = useMemo(() => {
         let newStyle: CSSProperties = {};
@@ -43,9 +48,9 @@ export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => 
         if (!fit && avatarUrl && avatarUrl.length) newStyle.backgroundImage = `url('${avatarUrl}')`;
 
         if (headOnly && !fit) {
-            newStyle.backgroundSize = '130px auto';
-            newStyle.backgroundPosition = '51% 40%';
-            newStyle.imageRendering = 'pixelated';
+            newStyle.backgroundSize = compactHead ? `${ compactHeadSize }px ${ compactHeadSize }px` : '130px auto';
+            newStyle.backgroundPosition = compactHead ? 'center' : '51% 40%';
+            newStyle.imageRendering = compactHead ? 'auto' : 'pixelated';
         }
 
         if (scale !== 1) {
@@ -57,18 +62,18 @@ export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => 
         if (Object.keys(style).length) newStyle = { ...newStyle, ...style };
 
         return newStyle;
-    }, [avatarUrl, scale, style, headOnly, fit]);
+    }, [avatarUrl, scale, style, headOnly, fit, compactHead, compactHeadSize]);
 
     useEffect(() => {
         if (!isReady) return;
 
         const requestId = ++requestIdRef.current;
-        const figureKey = [figure, gender, direction, headOnly].join('-');
+        const figureKey = [figure, gender, direction, headOnly, compactHead, compactHeadSize, compactHeadPadding].join('-');
 
         if (AVATAR_IMAGE_CACHE.has(figureKey)) {
             setAvatarUrl(AVATAR_IMAGE_CACHE.get(figureKey));
         } else {
-            const resetFigure = (_figure: string) => {
+            const resetFigure = async (_figure: string) => {
                 if (isDisposed.current || requestIdRef.current !== requestId) return;
 
                 const avatarImage = GetAvatarRenderManager().createAvatarImage(_figure, AvatarScaleType.LARGE, gender, {
@@ -83,7 +88,9 @@ export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => 
 
                 avatarImage.setDirection(setType, direction);
 
-                const imageUrl = avatarImage.processAsImageUrl(setType);
+                let imageUrl = avatarImage.processAsImageUrl(setType);
+
+                if(imageUrl && headOnly && compactHead) imageUrl = await cropTransparentImageUrl(imageUrl, compactHeadSize, compactHeadPadding);
 
                 if (imageUrl && !isDisposed.current && requestIdRef.current === requestId) {
                     if (!avatarImage.isPlaceholder()) {
@@ -103,7 +110,7 @@ export const LayoutAvatarImageView: FC<LayoutAvatarImageViewProps> = (props) => 
 
             resetFigure(figure);
         }
-    }, [figure, gender, direction, headOnly, isReady]);
+    }, [figure, gender, direction, headOnly, compactHead, compactHeadSize, compactHeadPadding, isReady]);
 
     useEffect(() => {
         isDisposed.current = false;

--- a/src/common/layout/avatarImageCrop.test.ts
+++ b/src/common/layout/avatarImageCrop.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { findOpaqueBounds, fitBoundsIntoSquare } from './avatarImageCrop';
+
+describe('findOpaqueBounds', () =>
+{
+    it('returns the tight rectangle containing non-transparent pixels', () =>
+    {
+        const pixels = new Uint8ClampedArray(4 * 4 * 4);
+        const setAlpha = (x: number, y: number) => { pixels[((y * 4) + x) * 4 + 3] = 255; };
+        setAlpha(1, 1);
+        setAlpha(2, 1);
+        setAlpha(2, 3);
+
+        expect(findOpaqueBounds(pixels, 4, 4)).toEqual({ x: 1, y: 1, width: 2, height: 3 });
+    });
+
+    it('returns the full image when every pixel is transparent', () =>
+    {
+        expect(findOpaqueBounds(new Uint8ClampedArray(3 * 2 * 4), 3, 2)).toEqual({ x: 0, y: 0, width: 3, height: 2 });
+    });
+});
+
+describe('fitBoundsIntoSquare', () =>
+{
+    it('centers the cropped head in a 22px thumbnail without browser-side scaling', () =>
+    {
+        expect(fitBoundsIntoSquare({ x: 0, y: 0, width: 40, height: 20 }, 22, 1)).toEqual({ x: 1, y: 6, width: 20, height: 10 });
+    });
+});

--- a/src/common/layout/avatarImageCrop.ts
+++ b/src/common/layout/avatarImageCrop.ts
@@ -1,0 +1,74 @@
+export interface OpaqueBounds
+{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export const findOpaqueBounds = (pixels: Uint8ClampedArray, width: number, height: number): OpaqueBounds =>
+{
+    let left = width;
+    let top = height;
+    let right = -1;
+    let bottom = -1;
+
+    for(let y = 0; y < height; y++)
+    {
+        for(let x = 0; x < width; x++)
+        {
+            if(pixels[((y * width) + x) * 4 + 3] === 0) continue;
+            left = Math.min(left, x);
+            top = Math.min(top, y);
+            right = Math.max(right, x);
+            bottom = Math.max(bottom, y);
+        }
+    }
+
+    if(right < left || bottom < top) return { x: 0, y: 0, width, height };
+    return { x: left, y: top, width: right - left + 1, height: bottom - top + 1 };
+};
+
+export const fitBoundsIntoSquare = (bounds: OpaqueBounds, size: number = 22, padding: number = 1): OpaqueBounds =>
+{
+    const availableSize = Math.max(1, size - (padding * 2));
+    const scale = Math.min(availableSize / bounds.width, availableSize / bounds.height);
+    const width = Math.max(1, Math.round(bounds.width * scale));
+    const height = Math.max(1, Math.round(bounds.height * scale));
+
+    return { x: Math.floor((size - width) / 2), y: Math.floor((size - height) / 2), width, height };
+};
+
+export const cropTransparentImageUrl = (imageUrl: string, targetSize: number = 22, padding: number = 1): Promise<string> => new Promise(resolve =>
+{
+    const image = new Image();
+    image.onload = () =>
+    {
+        try
+        {
+            const source = document.createElement('canvas');
+            source.width = image.naturalWidth;
+            source.height = image.naturalHeight;
+            const sourceContext = source.getContext('2d', { willReadFrequently: true });
+            if(!sourceContext) return resolve(imageUrl);
+            sourceContext.drawImage(image, 0, 0);
+            const bounds = findOpaqueBounds(sourceContext.getImageData(0, 0, source.width, source.height).data, source.width, source.height);
+            const destination = fitBoundsIntoSquare(bounds, targetSize, padding);
+            const output = document.createElement('canvas');
+            output.width = targetSize;
+            output.height = targetSize;
+            const outputContext = output.getContext('2d');
+            if(!outputContext) return resolve(imageUrl);
+            outputContext.imageSmoothingEnabled = true;
+            outputContext.imageSmoothingQuality = 'high';
+            outputContext.drawImage(source, bounds.x, bounds.y, bounds.width, bounds.height, destination.x, destination.y, destination.width, destination.height);
+            resolve(output.toDataURL('image/png'));
+        }
+        catch
+        {
+            resolve(imageUrl);
+        }
+    };
+    image.onerror = () => resolve(imageUrl);
+    image.src = imageUrl;
+});

--- a/src/components/friends/views/friends-list/FriendsListView.tsx
+++ b/src/components/friends/views/friends-list/FriendsListView.tsx
@@ -24,6 +24,10 @@ export const FriendsListView: FC<{}> = (props) => {
     const filteredOnlineFriends = filterFriendsByCategory(onlineFriends, selectedCategoryId);
     const filteredOfflineFriends = filterFriendsByCategory(offlineFriends, selectedCategoryId);
 
+    useEffect(() => {
+        if (selectedCategoryId && !categories.some((category) => category.id === selectedCategoryId)) setSelectedCategoryId(0);
+    }, [categories, selectedCategoryId]);
+
     const removeFriendsText = useMemo(() => {
         if (!selectedFriendsIds || !selectedFriendsIds.length) return '';
 

--- a/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
+++ b/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
@@ -4,6 +4,7 @@ import { LayoutAvatarImageView, NitroCardAccordionItemView, UserProfileIconView 
 import { useFriends } from '../../../../../hooks';
 import { resolveAvatarFigure } from '../resolveAvatarFigure';
 import { resolveAvatarGender } from '../resolveAvatarGender';
+import { canFollowFriendListEntry } from './friendsListActions.helpers';
 
 export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: boolean; selectFriend: (userId: number) => void }> = (props) => {
     const { friend = null, selected = false, selectFriend = null } = props;
@@ -67,6 +68,8 @@ export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: b
                         figure={resolveAvatarFigure(friend.figure, friend.gender)}
                         gender={resolveAvatarGender(friend.gender)}
                         headOnly={true}
+                        compactHead={true}
+                        compactHeadSize={23}
                         direction={2}
                     />
                 </div>
@@ -78,7 +81,7 @@ export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: b
             <div className="friends-list-actions">
                 {!isRelationshipOpen && (
                     <>
-                        {friend.online && (
+                        {canFollowFriendListEntry(friend) && (
                             <div
                                 className="nitro-friends-spritesheet icon-follow cursor-pointer"
                                 title={LocalizeText('friendlist.tip.follow')}

--- a/src/components/friends/views/friends-list/friends-list-group/friendsListActions.helpers.test.ts
+++ b/src/components/friends/views/friends-list/friends-list-group/friendsListActions.helpers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { canFollowFriendListEntry } from './friendsListActions.helpers';
+
+describe('canFollowFriendListEntry', () =>
+{
+    it('hides Follow for Staff Chat regardless of its synthetic id', () =>
+    {
+        expect(canFollowFriendListEntry({ id: -1, name: 'Staff Chat', online: true })).toBe(false);
+        expect(canFollowFriendListEntry({ id: 42, name: ' staff chat ', online: true })).toBe(false);
+    });
+
+    it('shows Follow only for ordinary online friends', () =>
+    {
+        expect(canFollowFriendListEntry({ id: 7, name: 'tester1', online: true })).toBe(true);
+        expect(canFollowFriendListEntry({ id: 7, name: 'tester1', online: false })).toBe(false);
+    });
+});

--- a/src/components/friends/views/friends-list/friends-list-group/friendsListActions.helpers.ts
+++ b/src/components/friends/views/friends-list/friends-list-group/friendsListActions.helpers.ts
@@ -1,0 +1,4 @@
+import { MessengerFriend } from '../../../../../api';
+
+export const canFollowFriendListEntry = (friend: Pick<MessengerFriend, 'id' | 'name' | 'online'>) =>
+    friend.online && friend.id > 0 && (friend.name || '').trim().toLocaleLowerCase() !== 'staff chat';

--- a/src/components/friends/views/messenger/FriendsMessengerView.scroll.test.ts
+++ b/src/components/friends/views/messenger/FriendsMessengerView.scroll.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('FriendsMessengerView routing and scroll behavior', () =>
+{
+    it('does not dereference the legacy message box when the persistent view is mounted', () =>
+    {
+        const source = readFileSync(join(process.cwd(), 'src/components/friends/views/messenger/FriendsMessengerView.tsx'), 'utf8');
+
+        expect(source).toContain('if(!messagesBox.current) return;');
+    });
+
+    it('routes Staff Chat and direct chats through the same persistent window', () =>
+    {
+        const source = readFileSync(join(process.cwd(), 'src/components/friends/views/messenger/FriendsMessengerView.tsx'), 'utf8');
+
+        expect(source).not.toContain('isLegacyStaffChat');
+        expect(source).not.toContain('shouldUseLegacyStaffChat');
+        expect(source).toContain('persistentMessenger.actions.openDirectConversation(participantId, friend.name)');
+        expect(source).toContain('if(participantId === -1)');
+        expect(source).toContain('legacyStaffThread={activeThread?.participant?.id === -1 ? activeThread : null}');
+    });
+
+    it('keeps the Staff Chat avatar in the persistent tab bar', () =>
+    {
+        const source = readFileSync(join(process.cwd(), 'src/components/friends/views/messenger/FriendsPersistentMessengerView.tsx'), 'utf8');
+
+        expect(source).toContain('figure={STAFF_CHAT_FIGURE}');
+    });
+});

--- a/src/components/friends/views/messenger/FriendsMessengerView.tsx
+++ b/src/components/friends/views/messenger/FriendsMessengerView.tsx
@@ -6,6 +6,7 @@ import { DraggableWindowPosition, LayoutAvatarImageView, NitroCardContentView, N
 import { useFriends, useHelp, useMessenger, useTranslation } from '../../../../hooks';
 import { resolveAvatarFigure } from '../friends-list/resolveAvatarFigure';
 import { FriendsMessengerThreadView } from './messenger-thread/FriendsMessengerThreadView';
+import { FriendsPersistentMessengerView } from './FriendsPersistentMessengerView';
 
 export const FriendsMessengerView: FC<{}> = (props) => {
     const [isVisible, setIsVisible] = useState(false);
@@ -19,7 +20,8 @@ export const FriendsMessengerView: FC<{}> = (props) => {
         setActiveThreadId = null,
         closeThread = null,
         typingUserIds = [],
-        sendTypingStatus = null
+        sendTypingStatus = null,
+        persistentMessenger = null
     } = useMessenger();
     const { getFriend = null } = useFriends();
     const { report = null } = useHelp();
@@ -116,7 +118,27 @@ export const FriendsMessengerView: FC<{}> = (props) => {
                         return;
                     }
 
-                    const thread = getMessageThread(parseInt(parts[1]));
+                    const participantId = parseInt(parts[1]);
+                    const friend = getFriend(participantId);
+                    if(!friend) return;
+
+                    if(participantId === -1)
+                    {
+                        const thread = getMessageThread(participantId);
+                        if(!thread) return;
+                        setActiveThreadId(thread.threadId);
+                        setIsVisible(true);
+                        return;
+                    }
+
+                    if(persistentMessenger)
+                    {
+                        persistentMessenger.actions.openDirectConversation(participantId, friend.name);
+                        setIsVisible(true);
+                        return;
+                    }
+
+                    const thread = getMessageThread(participantId);
 
                     if (!thread) return;
 
@@ -130,10 +152,11 @@ export const FriendsMessengerView: FC<{}> = (props) => {
         AddLinkEventTracker(linkTracker);
 
         return () => RemoveLinkEventTracker(linkTracker);
-    }, [getMessageThread, setActiveThreadId]);
+    }, [getFriend, getMessageThread, persistentMessenger, setActiveThreadId]);
 
     useEffect(() => {
         if (!isVisible || !activeThread) return;
+        if(!messagesBox.current) return;
 
         messagesBox.current.scrollTop = messagesBox.current.scrollHeight;
     }, [isVisible, activeThread]);
@@ -162,6 +185,16 @@ export const FriendsMessengerView: FC<{}> = (props) => {
     }, [isVisible, activeThread, lastThreadId, visibleThreads, setActiveThreadId]);
 
     if (!isVisible) return null;
+
+    if (persistentMessenger) {
+        return <FriendsPersistentMessengerView
+            messenger={persistentMessenger}
+            legacyStaffThread={activeThread?.participant?.id === -1 ? activeThread : null}
+            onClose={() => setIsVisible(false)}
+            onCloseStaff={() => activeThread && closeThread(activeThread.threadId)}
+            onSendStaff={(text) => activeThread && sendMessage(activeThread, GetSessionDataManager().userId, text)}
+        />;
+    }
 
     return (
         <NitroCardView
@@ -200,7 +233,7 @@ export const FriendsMessengerView: FC<{}> = (props) => {
                                         className={'messenger-avatar-tab' + (activeThread === thread ? ' active' : '') + (thread.unread ? ' unread' : '')}
                                         onClick={(event) => setActiveThreadId(thread.threadId)}
                                     >
-                                        <LayoutAvatarImageView figure={figure} headOnly={true} direction={isStaff ? 3 : 2} />
+                                        <LayoutAvatarImageView figure={figure} headOnly={true} compactHead={true} compactHeadSize={36} compactHeadPadding={0} direction={isStaff ? 3 : 2} />
                                     </button>
                                 );
                             })}

--- a/src/components/friends/views/messenger/FriendsPersistentMessengerView.tsx
+++ b/src/components/friends/views/messenger/FriendsPersistentMessengerView.tsx
@@ -1,0 +1,168 @@
+import { FollowFriendMessageComposer, GetSessionDataManager } from '@nitrots/nitro-renderer';
+import { FC, KeyboardEvent, UIEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { FaArrowLeft, FaCopy, FaExclamationTriangle, FaSearch, FaTimes, FaUsers } from 'react-icons/fa';
+import { GetUserProfile, LocalizeText, MessengerConversation, MessengerMessage, MessengerThread, ReportType, selectConversations, selectMessages, SendMessageComposer } from '../../../../api';
+import { DraggableWindowPosition, LayoutAvatarImageView, NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
+import { useFriends, useHelp } from '../../../../hooks';
+import { resolveAvatarFigure } from '../friends-list/resolveAvatarFigure';
+import { FriendsMessengerThreadView } from './messenger-thread/FriendsMessengerThreadView';
+import { canFollowMessengerConversation, filterMessengerConversations, resolveConversationAfterClose, restoreConversationsWithNewMessages } from './persistentMessenger.helpers';
+import { MessengerMessageStatusView } from './MessengerMessageStatusView';
+
+interface PersistentMessengerApi
+{
+    state: any;
+    history: { loadInitial: (conversationId: number) => void; loadOlder: (conversationId: number) => void };
+    actions: { openDirectConversation: (participantId: number, name: string) => void; sendMessage: (conversationId: number, recipientId: number, text: string) => any; retryMessage: (clientId: string) => any; markRead: (conversationId: number, messageId: number) => void };
+}
+
+const STAFF_CHAT_FIGURE = 'ha-3409-1413-70.lg-285-89.ch-3032-1334-109.sh-3016-110.hd-185-1359.ca-3225-110-62.wa-3264-62-62.fa-1206-90.hr-3322-1403';
+
+interface FriendsPersistentMessengerViewProps
+{
+    messenger: PersistentMessengerApi;
+    legacyStaffThread?: MessengerThread;
+    onClose: () => void;
+    onCloseStaff: () => void;
+    onSendStaff: (text: string) => void;
+}
+
+export const FriendsPersistentMessengerView: FC<FriendsPersistentMessengerViewProps> = ({ messenger, legacyStaffThread = null, onClose, onCloseStaff, onSendStaff }) =>
+{
+    const conversations = useMemo(() => selectConversations(messenger.state), [ messenger.state.conversationIds, messenger.state.conversationsById ]);
+    const [ activeId, setActiveId ] = useState(conversations[0]?.id || 0);
+    const [ mode, setMode ] = useState<'conversation' | 'inbox'>('conversation');
+    const [ query, setQuery ] = useState('');
+    const [ text, setText ] = useState('');
+    const [ staffActive, setStaffActive ] = useState(false);
+    const [ hiddenConversationIds, setHiddenConversationIds ] = useState<number[]>([]);
+    const previousConversationsRef = useRef(conversations);
+    const { getFriend } = useFriends();
+    const { report } = useHelp();
+    const active = conversations.find(item => item.id === activeId) || conversations[0] || null;
+    const messages = active ? selectMessages(messenger.state, active.id) : [];
+    const filtered = useMemo(() => filterMessengerConversations(conversations, query), [ conversations, query ]);
+    const visibleConversations = useMemo(() => conversations.filter(conversation => hiddenConversationIds.indexOf(conversation.id) === -1), [ conversations, hiddenConversationIds ]);
+
+    useEffect(() => { if(active) messenger.history.loadInitial(active.id); }, [ active?.id ]);
+    useEffect(() => setStaffActive(!!legacyStaffThread), [ legacyStaffThread ]);
+    useEffect(() =>
+    {
+        if(!messenger.state.selectedConversationId) return;
+        setHiddenConversationIds(current => current.filter(id => id !== messenger.state.selectedConversationId));
+        setStaffActive(false);
+        setActiveId(messenger.state.selectedConversationId);
+        setMode('conversation');
+    }, [ messenger.state.selectedConversationId ]);
+    useEffect(() =>
+    {
+        setHiddenConversationIds(current => restoreConversationsWithNewMessages(current, previousConversationsRef.current, conversations));
+        previousConversationsRef.current = conversations;
+    }, [ conversations ]);
+    useEffect(() =>
+    {
+        const last = messages.filter(message => message.id > 0).at(-1);
+        if(active && last) messenger.actions.markRead(active.id, last.id);
+    }, [ active?.id, messages.length ]);
+
+    const selectConversation = (conversation: MessengerConversation) =>
+    {
+        setStaffActive(false);
+        setHiddenConversationIds(current => current.filter(id => id !== conversation.id));
+        setActiveId(conversation.id);
+        setMode('conversation');
+    };
+    const closeConversation = () =>
+    {
+        if(!active) return;
+        const nextHiddenIds = hiddenConversationIds.indexOf(active.id) === -1 ? [ ...hiddenConversationIds, active.id ] : hiddenConversationIds;
+        const nextId = resolveConversationAfterClose(conversations, nextHiddenIds, active.id);
+        setHiddenConversationIds(nextHiddenIds);
+        setActiveId(nextId);
+        setMode(nextId ? 'conversation' : 'inbox');
+    };
+    const send = () =>
+    {
+        const value = text.trim();
+        if(staffActive)
+        {
+            if(!legacyStaffThread || !value) return;
+            onSendStaff(value);
+            setText('');
+            return;
+        }
+        if(!active || !value) return;
+        messenger.actions.sendMessage(active.id, active.participantId, value);
+        setText('');
+    };
+    const keyDown = (event: KeyboardEvent<HTMLInputElement>) => { if(event.key === 'Enter') send(); };
+    const scroll = (event: UIEvent<HTMLDivElement>) => { if(active && event.currentTarget.scrollTop < 48) messenger.history.loadOlder(active.id); };
+
+    const avatar = (conversation: MessengerConversation, size: number, padding: number = 1) =>
+    {
+        if(conversation.type === 1) return <LayoutAvatarImageView figure={STAFF_CHAT_FIGURE} headOnly compactHead compactHeadSize={size} compactHeadPadding={padding} direction={3} />;
+        const friend = conversation.participantId > 0 ? getFriend(conversation.participantId) : null;
+        if(!friend) return null;
+        return <LayoutAvatarImageView figure={resolveAvatarFigure(friend.figure, friend.gender)} headOnly compactHead compactHeadSize={size} compactHeadPadding={padding} direction={2} />;
+    };
+
+    return (
+        <NitroCardView className="messenger-card messenger-persistent" theme="primary-slim" uniqueKey="persistent-messenger" windowPosition={DraggableWindowPosition.TOP_CENTER} offsetTop={8} isResizable={false}>
+            <NitroCardHeaderView headerText={LocalizeText('messenger.window.title', [ 'OPEN_CHAT_COUNT' ], [ (conversations.length + (legacyStaffThread ? 1 : 0)).toString() ])} onCloseClick={onClose} />
+            <NitroCardContentView className="p-0" gap={0} overflow="hidden">
+                <div className="messenger-card-body">
+                    <div className="messenger-avatar-bar">
+                        {legacyStaffThread && <button className={`messenger-avatar-tab ${ staffActive ? 'active' : '' } ${ legacyStaffThread.unread ? 'unread' : '' }`} onClick={() => { setStaffActive(true); setMode('conversation'); }} aria-label={legacyStaffThread.participant.name} aria-selected={staffActive}><LayoutAvatarImageView figure={STAFF_CHAT_FIGURE} headOnly compactHead compactHeadSize={36} compactHeadPadding={0} direction={3} /></button>}
+                        {visibleConversations.slice(0, 7).map(conversation => (
+                            <button key={conversation.id} className={`messenger-avatar-tab ${ active?.id === conversation.id ? 'active' : '' } ${ conversation.unreadCount ? 'unread' : '' }`} onClick={() => selectConversation(conversation)} aria-label={conversation.name} aria-selected={active?.id === conversation.id}>
+                                {avatar(conversation, 36, 0)}
+                                {conversation.unreadCount > 0 && <span className="messenger-unread-badge">{conversation.unreadCount}</span>}
+                            </button>
+                        ))}
+                        <button className="messenger-all-button" onClick={() => { setStaffActive(false); setMode('inbox'); }}>{LocalizeText('generic.all')} {conversations.length + (legacyStaffThread ? 1 : 0)}</button>
+                    </div>
+
+                    {mode === 'inbox' && (
+                        <div className="messenger-inbox" data-testid="messenger-inbox">
+                            <label className="messenger-search"><FaSearch /><input value={query} onChange={event => setQuery(event.target.value)} placeholder={LocalizeText('generic.search')} /></label>
+                            <div className="messenger-inbox-list">
+                                {filtered.map(conversation => <button key={conversation.id} className="messenger-inbox-row" onClick={() => selectConversation(conversation)}><span className="messenger-inbox-avatar">{avatar(conversation, 24) || <FaUsers />}</span><span><b>{conversation.name}</b><small>{conversation.unreadCount ? `${ conversation.unreadCount } ${ LocalizeText('notifications.messages') }` : LocalizeText('messenger.window.input.default', [ 'FRIEND_NAME' ], [ conversation.name ])}</small></span></button>)}
+                            </div>
+                        </div>
+                    )}
+
+                    {mode === 'conversation' && staffActive && legacyStaffThread && (
+                        <div className="messenger-conversation" data-testid="messenger-staff-conversation">
+                            <div className="messenger-thread-header"><span className="messenger-thread-name">{legacyStaffThread.participant.name}</span><div className="messenger-actions"><button className="messenger-btn close-conversation" onClick={onCloseStaff} title={LocalizeText('generic.close')} aria-label={LocalizeText('generic.close')}><FaTimes /></button></div></div>
+                            <div className="chat-messages"><FriendsMessengerThreadView thread={legacyStaffThread} /></div>
+                            <div className="messenger-input-row"><input maxLength={255} value={text} onChange={event => setText(event.target.value)} onKeyDown={keyDown} placeholder={LocalizeText('messenger.window.input.default', [ 'FRIEND_NAME' ], [ legacyStaffThread.participant.name ])} /><button className="messenger-btn send" onClick={send}>{LocalizeText('widgets.chatinput.say')}</button></div>
+                        </div>
+                    )}
+
+                    {mode === 'conversation' && !staffActive && active && (
+                        <div className="messenger-conversation" data-testid="messenger-conversation">
+                            <div className="messenger-thread-header">
+                                <button className="messenger-mobile-back" onClick={() => setMode('inbox')}><FaArrowLeft /></button>
+                                <span className="messenger-thread-name">{active.name}</span>
+                                <div className="messenger-actions">
+                                    {canFollowMessengerConversation(active) && <button className="messenger-btn" onClick={() => SendMessageComposer(new FollowFriendMessageComposer(active.participantId))}>{LocalizeText('friendlist.follow')}</button>}
+                                    {active.participantId > 0 && <button className="messenger-btn" onClick={() => GetUserProfile(active.participantId)}>{LocalizeText('extendedprofile.caption')}</button>}
+                                    {active.participantId > 0 && <button className="messenger-btn danger" onClick={() => report(ReportType.IM, { reportedUserId: active.participantId })}><FaExclamationTriangle /></button>}
+                                    <button className="messenger-btn close-conversation" onClick={closeConversation} title={LocalizeText('generic.close')} aria-label={LocalizeText('generic.close')}><FaTimes /></button>
+                                </div>
+                            </div>
+                            <div className="chat-messages persistent-message-list" onScroll={scroll}>
+                                {messenger.state.historyByConversation[active.id]?.loading && <div className="messenger-history-state">{LocalizeText('generic.loading')}</div>}
+                                {messages.map((message: MessengerMessage) => {
+                                    const own = message.senderId === GetSessionDataManager().userId;
+                                    return <div key={message.id || message.clientId} className={`persistent-message ${ own ? 'own' : 'incoming' }`}><div className="persistent-message-bubble"><span>{message.message}</span><button title="Copy" onClick={() => void navigator.clipboard?.writeText(message.message)}><FaCopy /></button></div><small className="persistent-message-meta"><span>{new Date(message.createdAt * 1000).toLocaleTimeString()}</span>{own && message.status !== 'failed' && message.status !== 'sending' && <MessengerMessageStatusView isRead={message.status === 'read'} />}{own && message.status === 'failed' && <span className="messenger-message-failed">!</span>}{own && message.status === 'sending' && <span className="messenger-message-sending">…</span>}</small>{message.status === 'failed' && message.clientId && <button className="messenger-retry" onClick={() => messenger.actions.retryMessage(message.clientId)}>Retry</button>}</div>;
+                                })}
+                            </div>
+                            <div className="messenger-input-row"><input maxLength={255} value={text} onChange={event => setText(event.target.value)} onKeyDown={keyDown} placeholder={LocalizeText('messenger.window.input.default', [ 'FRIEND_NAME' ], [ active.name ])} /><button className="messenger-btn send" onClick={send}>{LocalizeText('widgets.chatinput.say')}</button></div>
+                        </div>
+                    )}
+                </div>
+            </NitroCardContentView>
+        </NitroCardView>
+    );
+};

--- a/src/components/friends/views/messenger/MessengerMessageStatusView.test.tsx
+++ b/src/components/friends/views/messenger/MessengerMessageStatusView.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessengerMessageStatusView } from './MessengerMessageStatusView';
+
+describe('MessengerMessageStatusView', () =>
+{
+    it('renders one neutral check for a sent message', () =>
+    {
+        const { container } = render(<MessengerMessageStatusView isRead={false} />);
+
+        expect(screen.getByLabelText('sent')).toBeInTheDocument();
+        expect(container.querySelectorAll('.messenger-status-check')).toHaveLength(1);
+    });
+
+    it('renders two checks for a read message', () =>
+    {
+        const { container } = render(<MessengerMessageStatusView isRead />);
+
+        expect(screen.getByLabelText('read')).toBeInTheDocument();
+        expect(container.querySelectorAll('.messenger-status-check')).toHaveLength(2);
+    });
+});

--- a/src/components/friends/views/messenger/MessengerMessageStatusView.tsx
+++ b/src/components/friends/views/messenger/MessengerMessageStatusView.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { FaCheck } from 'react-icons/fa';
+
+export const MessengerMessageStatusView: FC<{ isRead: boolean; className?: string }> = ({ isRead, className = '' }) =>
+{
+    return (
+        <span className={`messenger-message-status ${ isRead ? 'read' : 'sent' } ${ className }`.trim()} aria-label={isRead ? 'read' : 'sent'}>
+            <FaCheck className="messenger-status-check first" aria-hidden="true" />
+            {isRead && <FaCheck className="messenger-status-check second" aria-hidden="true" />}
+        </span>
+    );
+};

--- a/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadGroup.tsx
+++ b/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadGroup.tsx
@@ -4,6 +4,8 @@ import { GetGroupChatData, LocalizeText, MessengerGroupType, MessengerThread, Me
 import { Base, Flex, LayoutAvatarImageView } from '../../../../../common';
 import { useFriends } from '../../../../../hooks';
 import { resolveAvatarFigure } from '../../friends-list/resolveAvatarFigure';
+import { getMessageStatusPresentation } from './messageStatus.helpers';
+import { MessengerMessageStatusView } from '../MessengerMessageStatusView';
 
 export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: MessengerThreadChatGroup }> = (props) => {
     const { thread = null, group = null } = props;
@@ -22,6 +24,10 @@ export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: M
     }, [thread, group, groupChatData]);
 
     if (!thread || !group) return null;
+
+    const lastChat = group.chats[group.chats.length - 1];
+    const showMessageStatus = isOwnChat && group.type === MessengerGroupType.PRIVATE_CHAT && lastChat.type === MessengerThreadChat.CHAT;
+    const messageStatus = getMessageStatusPresentation(lastChat.status);
 
     if (!group.userId) {
         return (
@@ -60,9 +66,11 @@ export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: M
                             getFriend?.(thread.participant.id)?.gender ?? thread.participant.gender
                         )}
                         headOnly={true}
+                        compactHead={true}
+                        compactHeadSize={24}
                     />
                 )}
-                {groupChatData && !isOwnChat && <LayoutAvatarImageView direction={2} figure={groupChatData.figure} headOnly={true} />}
+                {groupChatData && !isOwnChat && <LayoutAvatarImageView direction={2} figure={groupChatData.figure} headOnly={true} compactHead={true} compactHeadSize={24} />}
             </Base>
             <Base className="messenger-message-body">
                 <Base className={'messenger-message-name ' + (isOwnChat ? 'text-end' : '')}>
@@ -94,16 +102,16 @@ export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: M
                         );
                     })}
                 </Base>
-                <Base className="messenger-message-time">{group.chats[0].date.toLocaleTimeString()}</Base>
-                {isOwnChat && group.type === MessengerGroupType.PRIVATE_CHAT && group.chats[group.chats.length - 1].type === MessengerThreadChat.CHAT && (
-                    <Base className={'messenger-message-status ' + (group.chats[group.chats.length - 1].status === MessengerThreadChat.READ ? 'read' : '')}>
-                        {group.chats[group.chats.length - 1].status === MessengerThreadChat.READ ? '✓✓' : '✓'}
-                    </Base>
-                )}
+                <Base className={'messenger-message-meta ' + (isOwnChat ? 'own' : '')}>
+                    <span className="messenger-message-time">{group.chats[0].date.toLocaleTimeString()}</span>
+                    {showMessageStatus && (
+                        <MessengerMessageStatusView isRead={messageStatus.isRead} />
+                    )}
+                </Base>
             </Base>
             {isOwnChat && (
                 <Base shrink className="message-avatar">
-                    <LayoutAvatarImageView direction={4} figure={GetSessionDataManager().figure} headOnly={true} />
+                    <LayoutAvatarImageView direction={4} figure={GetSessionDataManager().figure} headOnly={true} compactHead={true} compactHeadSize={24} />
                 </Base>
             )}
         </Flex>

--- a/src/components/friends/views/messenger/messenger-thread/messageStatus.helpers.test.ts
+++ b/src/components/friends/views/messenger/messenger-thread/messageStatus.helpers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { MessengerThreadChat } from '../../../../../api';
+import { getMessageStatusPresentation } from './messageStatus.helpers';
+
+describe('getMessageStatusPresentation', () =>
+{
+    it('renders one muted tick for a sent message', () =>
+    {
+        expect(getMessageStatusPresentation(MessengerThreadChat.SENT)).toEqual({ ticks: '✓', isRead: false });
+    });
+
+    it('renders two blue ticks for a read message', () =>
+    {
+        expect(getMessageStatusPresentation(MessengerThreadChat.READ)).toEqual({ ticks: '✓✓', isRead: true });
+    });
+});

--- a/src/components/friends/views/messenger/messenger-thread/messageStatus.helpers.ts
+++ b/src/components/friends/views/messenger/messenger-thread/messageStatus.helpers.ts
@@ -1,0 +1,14 @@
+import { MessengerThreadChat } from '../../../../../api';
+
+export interface MessageStatusPresentation
+{
+    ticks: string;
+    isRead: boolean;
+}
+
+export const getMessageStatusPresentation = (status: number): MessageStatusPresentation =>
+{
+    const isRead = status === MessengerThreadChat.READ;
+
+    return { ticks: isRead ? '✓✓' : '✓', isRead };
+};

--- a/src/components/friends/views/messenger/persistentMessenger.helpers.test.ts
+++ b/src/components/friends/views/messenger/persistentMessenger.helpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { canFollowMessengerConversation, filterMessengerConversations, resolveConversationAfterClose, restoreConversationsWithNewMessages } from './persistentMessenger.helpers';
+
+const conversations = [
+    { id: 1, type: 0, participantId: 7, name: 'Alex', lastMessageId: 4, unreadCount: 0, updatedAt: 10 },
+    { id: 2, type: 1, participantId: 0, name: 'Wired Lab', lastMessageId: 8, unreadCount: 3, updatedAt: 20 }
+];
+
+describe('filterMessengerConversations', () =>
+{
+    it('filters names case-insensitively and preserves activity order', () =>
+    {
+        expect(filterMessengerConversations(conversations, 'wired').map(item => item.id)).toEqual([ 2 ]);
+        expect(filterMessengerConversations(conversations, '').map(item => item.id)).toEqual([ 2, 1 ]);
+    });
+});
+
+describe('canFollowMessengerConversation', () =>
+{
+    it('hides Follow for Staff Chat and keeps it for ordinary direct chats', () =>
+    {
+        expect(canFollowMessengerConversation(conversations[0])).toBe(true);
+        expect(canFollowMessengerConversation({ ...conversations[0], participantId: -1, name: 'Staff Chat' })).toBe(false);
+        expect(canFollowMessengerConversation({ ...conversations[0], name: 'staff chat' })).toBe(false);
+    });
+});
+
+describe('resolveConversationAfterClose', () =>
+{
+    it('selects the next visible conversation and falls back to an earlier one', () =>
+    {
+        expect(resolveConversationAfterClose(conversations, [], 1)).toBe(2);
+        expect(resolveConversationAfterClose(conversations, [ 2 ], 1)).toBe(0);
+        expect(resolveConversationAfterClose(conversations, [], 2)).toBe(1);
+    });
+});
+
+describe('restoreConversationsWithNewMessages', () =>
+{
+    it('restores hidden conversations when their message or unread cursor advances', () =>
+    {
+        const previous = conversations.map(item => ({ ...item }));
+        const current = conversations.map(item => item.id === 1 ? { ...item, lastMessageId: 5 } : { ...item, unreadCount: 4 });
+
+        expect(restoreConversationsWithNewMessages([ 1, 2 ], previous, current)).toEqual([]);
+        expect(restoreConversationsWithNewMessages([ 1, 2 ], previous, previous)).toEqual([ 1, 2 ]);
+    });
+});

--- a/src/components/friends/views/messenger/persistentMessenger.helpers.ts
+++ b/src/components/friends/views/messenger/persistentMessenger.helpers.ts
@@ -1,0 +1,35 @@
+import { MessengerConversation } from '../../../../api';
+
+export const filterMessengerConversations = (conversations: MessengerConversation[], query: string) =>
+{
+    const normalized = query.trim().toLocaleLowerCase();
+    return [ ...conversations ]
+        .filter(conversation => !normalized || conversation.name.toLocaleLowerCase().includes(normalized))
+        .sort((left, right) => right.updatedAt - left.updatedAt);
+};
+
+export const canFollowMessengerConversation = (conversation: MessengerConversation) =>
+    conversation.participantId > 0 && conversation.name.trim().toLocaleLowerCase() !== 'staff chat';
+
+export const resolveConversationAfterClose = (conversations: MessengerConversation[], hiddenIds: number[], closedId: number) =>
+{
+    const closedIndex = conversations.findIndex(conversation => conversation.id === closedId);
+    const isVisible = (conversation: MessengerConversation) => conversation.id !== closedId && hiddenIds.indexOf(conversation.id) === -1;
+
+    if(closedIndex >= 0)
+    {
+        const next = conversations.slice(closedIndex + 1).find(isVisible);
+        if(next) return next.id;
+    }
+
+    return conversations.find(isVisible)?.id || 0;
+};
+
+export const restoreConversationsWithNewMessages = (hiddenIds: number[], previous: MessengerConversation[], current: MessengerConversation[]) =>
+    hiddenIds.filter(id =>
+    {
+        const before = previous.find(conversation => conversation.id === id);
+        const after = current.find(conversation => conversation.id === id);
+        if(!before || !after) return true;
+        return after.lastMessageId <= before.lastMessageId && after.unreadCount <= before.unreadCount;
+    });

--- a/src/css/friends/FriendsView.css
+++ b/src/css/friends/FriendsView.css
@@ -524,17 +524,14 @@
 
         & .avatar-image {
             position: absolute !important;
-            inset: 0 !important;
-            width: 100% !important;
-            height: 100% !important;
+            inset: 50% auto auto 50% !important;
+            width: 36px !important;
+            height: 36px !important;
             margin: 0 !important;
-            /* head-only image at native size (no scaling -> never grainy),
-               centred in the tab. Tweak the 2nd value of background-position
-               to raise (smaller %) or lower (larger %) the face. */
-            background-size: auto !important;
-            background-position: center 35% !important;
-            transform: none !important;
-            image-rendering: pixelated !important;
+            background-size: 36px 36px !important;
+            background-position: center !important;
+            transform: translate(-50%, -50%) !important;
+            image-rendering: auto !important;
         }
     }
 
@@ -630,13 +627,14 @@
 
             & .avatar-image {
                 position: absolute;
-                inset: 0;
-                width: 100%;
-                height: 100%;
+                inset: 50% auto auto 50%;
+                width: 30px;
+                height: 30px;
                 margin: 0;
-                background-size: 74px auto !important;
-                background-position: -18px -24px !important;
-                transform: none;
+                background-size: 30px 30px !important;
+                background-position: center !important;
+                transform: translate(-50%, -50%);
+                image-rendering: auto !important;
             }
         }
 
@@ -840,6 +838,7 @@
 
 /* Per-friend assign-to-group dropdown */
 .friends-list-group-assign {
+    position: relative;
     display: inline-flex;
 }
 
@@ -932,16 +931,98 @@
     opacity: 0.6;
 }
 
+.messenger-message-meta {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    min-height: 11px;
+}
+
+.messenger-message-meta.own {
+    justify-content: flex-end;
+}
+
 .messenger-message-status {
-    margin-top: 1px;
-    font-size: 10px;
-    line-height: 10px;
-    text-align: right;
-    opacity: 0.6;
+    position: relative;
+    display: inline-block;
+    width: 13px;
+    height: 11px;
+    color: #7a858b;
 }
 .messenger-message-status.read {
-    color: #4fc3f7;
-    opacity: 1;
+    color: #34b7f1;
+}
+
+.messenger-status-check {
+    position: absolute;
+    top: 1px;
+    left: 0;
+    width: 9px;
+    height: 9px;
+    stroke-width: 1;
+}
+
+.messenger-status-check.second {
+    left: 4px;
+}
+
+.persistent-message-meta {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.messenger-persistent .messenger-conversation,
+.messenger-persistent .messenger-inbox {
+    display: flex;
+    min-height: 0;
+    flex: 1;
+    flex-direction: column;
+}
+
+.messenger-all-button,
+.messenger-mobile-back,
+.messenger-search,
+.messenger-inbox-row,
+.persistent-message-bubble,
+.messenger-retry {
+    border: 1px solid rgba(0, 0, 0, .25);
+    border-radius: 4px;
+    background: linear-gradient(#fff, #e8edef);
+    color: #111;
+}
+
+.messenger-all-button { margin-left: auto; padding: 5px 9px; font-size: 12px; font-weight: 700; }
+.messenger-unread-badge { position: absolute; top: -3px; right: -3px; min-width: 16px; padding: 1px 4px; border-radius: 999px; background: #d94444; color: #fff; font-size: 9px; }
+.messenger-search { display: flex; align-items: center; gap: 6px; margin: 8px; padding: 5px 8px; background: #fff; }
+.messenger-search input { width: 100%; border: 0; background: transparent; outline: 0; }
+.messenger-inbox-list { min-height: 0; overflow-y: auto; padding: 0 8px 8px; }
+.messenger-inbox-row { display: flex; width: 100%; min-height: 48px; align-items: center; gap: 8px; margin-bottom: 4px; padding: 5px 8px; text-align: left; }
+.messenger-inbox-avatar { position: relative; display: flex !important; width: 38px; height: 38px; flex: 0 0 38px; align-items: center; justify-content: center; overflow: hidden; }
+.messenger-inbox-avatar .avatar-image { inset: 50% auto auto 50% !important; width: 24px !important; height: 24px !important; background-size: 24px 24px !important; background-position: center !important; transform: translate(-50%, -50%) !important; image-rendering: auto !important; }
+.messenger-inbox-row span { display: flex; min-width: 0; flex-direction: column; }
+.messenger-inbox-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: .7; }
+.persistent-message-list { scroll-anchor: none; }
+.persistent-message { display: flex; max-width: 78%; flex-direction: column; align-items: flex-start; }
+.persistent-message.own { margin-left: auto; align-items: flex-end; }
+.persistent-message-bubble,
+.persistent-message > small {
+    font-family: UbuntuCondensed, Ubuntu, sans-serif;
+}
+.persistent-message-bubble span { font-family: UbuntuCondensed, Ubuntu, sans-serif !important; }
+.persistent-message-bubble { display: flex; gap: 6px; padding: 7px 9px; border-radius: 12px 12px 12px 3px; background: #fff; }
+.persistent-message.own .persistent-message-bubble { border-radius: 12px 12px 3px 12px; background: #c8edf2; }
+.persistent-message-bubble button { padding: 0; border: 0; background: transparent; opacity: 0; }
+.persistent-message-bubble:hover button { opacity: .55; }
+.messenger-history-state { padding: 4px; text-align: center; font-size: 11px; opacity: .7; }
+.messenger-retry { padding: 2px 6px; color: #a81a12; font-size: 10px; }
+.messenger-mobile-back { display: none; padding: 4px 6px; }
+.messenger-btn.close-conversation { width: 24px; padding: 0; background: #d7d7d7; color: #111 !important; }
+
+@media (max-width: 520px) {
+    .messenger-persistent .messenger-mobile-back { display: inline-flex; }
+    .messenger-persistent .messenger-thread-header .messenger-actions .messenger-btn:not(.danger):not(.close-conversation) { display: none; }
+    .messenger-persistent .persistent-message { max-width: 88%; }
 }
 
 .messenger-typing-indicator {
@@ -953,8 +1034,8 @@
 
 .nitro-friends .friends-list-avatar {
     position: relative !important;
-    width: 32px;
-    height: 36px;
+    width: 23px;
+    height: 23px;
     flex-shrink: 0;
     overflow: hidden;
 }
@@ -965,9 +1046,10 @@
     width: 100% !important;
     height: 100% !important;
     margin: 0 !important;
-    background-size: 66px auto !important;
-    background-position: -16px -21px !important;
+    background-size: 23px 23px !important;
+    background-position: center !important;
     transform: none !important;
+    image-rendering: auto !important;
 }
 
 .nitro-friends .nitro-card-accordion-set-header > div,

--- a/src/css/friends/FriendsView.messenger-visuals.test.ts
+++ b/src/css/friends/FriendsView.messenger-visuals.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(join(process.cwd(), 'src/css/friends/FriendsView.css'), 'utf8');
+const persistentMessenger = readFileSync(join(process.cwd(), 'src/components/friends/views/messenger/FriendsPersistentMessengerView.tsx'), 'utf8');
+
+describe('Messenger and Friend List visual CSS', () =>
+{
+    it('uses the client condensed font for persistent messages', () =>
+    {
+        expect(css).toMatch(/\.persistent-message-bubble\s*,\s*\.persistent-message\s*>\s*small\s*\{[^}]*font-family:\s*UbuntuCondensed, Ubuntu, sans-serif;/s);
+    });
+
+    it('crops Friend List heads at the native renderer resolution', () =>
+    {
+        expect(css).toMatch(/\.nitro-friends\s+\.friends-list-avatar\s*\{[^}]*width:\s*23px;[^}]*height:\s*23px;/s);
+        expect(css).toMatch(/\.nitro-friends\s+\.friends-list-avatar\s+\.avatar-image\s*\{[^}]*background-size:\s*23px 23px !important;[^}]*background-position:\s*center !important;[^}]*image-rendering:\s*auto !important;/s);
+        expect(css).toMatch(/&\s+\.messenger-avatar-tab\s*\{[\s\S]*?width:\s*36px;[\s\S]*?&\s+\.avatar-image\s*\{[^}]*width:\s*36px !important;[^}]*height:\s*36px !important;[^}]*background-size:\s*36px 36px !important;/s);
+    });
+
+    it('places compact Telegram-style delivery ticks beside the timestamp', () =>
+    {
+        expect(css).toMatch(/\.messenger-message-meta\s*\{[^}]*display:\s*flex;[^}]*align-items:\s*center;/s);
+        expect(css).toMatch(/\.messenger-message-status\.read\s*\{[^}]*color:\s*#34b7f1;/s);
+        expect(css).toMatch(/\.messenger-status-check\s*\{[^}]*position:\s*absolute;/s);
+    });
+
+    it('removes the inactive ellipsis action', () =>
+    {
+        expect(persistentMessenger).not.toContain('FaEllipsisH');
+    });
+
+    it('keeps the conversation close action visible on compact layouts', () =>
+    {
+        expect(css).toMatch(/\.messenger-persistent\s+\.messenger-thread-header\s+\.messenger-actions\s+\.messenger-btn:not\(\.danger\):not\(\.close-conversation\)\s*\{\s*display:\s*none;/s);
+    });
+
+    it('anchors inbox avatars inside their own compact viewport', () =>
+    {
+        expect(css).toMatch(/\.messenger-inbox-avatar\s*\{[^}]*position:\s*relative;[^}]*width:\s*38px;[^}]*height:\s*38px;[^}]*overflow:\s*hidden;/s);
+        expect(css).toMatch(/\.messenger-inbox-avatar\s+\.avatar-image\s*\{[^}]*width:\s*24px !important;[^}]*height:\s*24px !important;[^}]*background-size:\s*24px 24px !important;[^}]*background-position:\s*center !important;[^}]*image-rendering:\s*auto !important;/s);
+        expect(css).toMatch(/&\s+\.message-avatar\s*\{[^}]*width:\s*36px;[^}]*height:\s*36px;[\s\S]*?&\s+\.avatar-image\s*\{[^}]*width:\s*30px;[^}]*height:\s*30px;[^}]*background-size:\s*30px 30px !important;/s);
+    });
+
+    it('anchors the friend category menu to the clicked folder', () =>
+    {
+        expect(css).toMatch(/\.friends-list-group-assign\s*\{[^}]*position:\s*relative;/s);
+    });
+});

--- a/src/hooks/friends/index.ts
+++ b/src/hooks/friends/index.ts
@@ -1,2 +1,3 @@
 export * from './useFriends';
 export * from './useMessenger';
+export * from './messenger';

--- a/src/hooks/friends/messenger/index.ts
+++ b/src/hooks/friends/messenger/index.ts
@@ -1,0 +1,5 @@
+export * from './messengerControllers';
+export * from './useMessengerActions';
+export * from './useMessengerHistory';
+export * from './useMessengerRealtime';
+export * from './useMessengerStore';

--- a/src/hooks/friends/messenger/messengerControllers.test.ts
+++ b/src/hooks/friends/messenger/messengerControllers.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initialMessengerState, messengerReducer, MessengerState } from '../../../api';
+import { createMessengerActionsController, createMessengerHistoryController } from '.';
+
+describe('messenger controllers', () =>
+{
+    it('does not request the same history cursor twice while loading', () =>
+    {
+        let state: MessengerState = { ...initialMessengerState, historyByConversation: { 7: { loading: false, loaded: true, hasMore: true, error: false } } };
+        const send = vi.fn();
+        const dispatch = (action: any) => { state = messengerReducer(state, action); };
+        const controller = createMessengerHistoryController(() => state, dispatch, send, (conversationId, beforeMessageId, limit) => ({ conversationId, beforeMessageId, limit }));
+
+        controller.loadOlder(7);
+        controller.loadOlder(7);
+
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not request server history for a direct draft', () =>
+    {
+        const send = vi.fn();
+        const controller = createMessengerHistoryController(() => initialMessengerState, vi.fn(), send, () => ({}));
+
+        controller.loadInitial(-12);
+
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it('retries a failed message with a new confirmation id', () =>
+    {
+        let state = initialMessengerState;
+        const dispatch = (action: any) => { state = messengerReducer(state, action); };
+        const send = vi.fn();
+        const actions = createMessengerActionsController(() => state, dispatch, send, () => 1, 100, (conversationId, recipientId, confirmationId, type, text, metadata) => ({ conversationId, recipientId, confirmationId, type, text, metadata }));
+
+        const first = actions.sendMessage(7, 0, 'hello');
+        dispatch({ type: 'messageFailed', clientId: first.clientId, errorCode: 6 });
+        const retried = actions.retryMessage(first.clientId);
+
+        expect(retried.confirmationId).not.toBe(first.confirmationId);
+        expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the recipient when retrying a direct draft', () =>
+    {
+        let state = initialMessengerState;
+        const dispatch = (action: any) => { state = messengerReducer(state, action); };
+        const send = vi.fn();
+        const actions = createMessengerActionsController(() => state, dispatch, send, () => 1, 1, (conversationId, recipientId) => ({ conversationId, recipientId }));
+        actions.openDirectConversation(9, 'Frank');
+        const first = actions.sendMessage(-9, 9, 'hello');
+        dispatch({ type: 'messageFailed', clientId: first.clientId, errorCode: 7 });
+
+        actions.retryMessage(first.clientId);
+
+        expect(send).toHaveBeenLastCalledWith({ conversationId: -9, recipientId: 9 });
+    });
+
+    it('marks an unacknowledged message as failed after ten seconds', () =>
+    {
+        let state = initialMessengerState;
+        const dispatch = (action: any) => { state = messengerReducer(state, action); };
+        let timeout: () => void = () => undefined;
+        const actions = createMessengerActionsController(() => state, dispatch, vi.fn(), () => 1, 1, () => ({}), undefined, callback => { timeout = callback; });
+
+        const sent = actions.sendMessage(7, 0, 'hello');
+        timeout();
+
+        expect(state.messagesByKey[`client:${ sent.clientId }`]?.status).toBe('failed');
+    });
+
+    it('selects a persistent direct conversation from a friend-list click', () =>
+    {
+        let state = initialMessengerState;
+        const dispatch = (action: any) => { state = messengerReducer(state, action); };
+        const actions = createMessengerActionsController(() => state, dispatch, vi.fn(), () => 1);
+
+        actions.openDirectConversation(12, 'Duckie');
+
+        expect(state.selectedConversationId).toBe(-12);
+        expect(state.conversationsById[-12]).toMatchObject({ participantId: 12, name: 'Duckie' });
+    });
+});

--- a/src/hooks/friends/messenger/messengerControllers.ts
+++ b/src/hooks/friends/messenger/messengerControllers.ts
@@ -1,0 +1,78 @@
+import { MarkMessengerReadComposer, RequestMessengerHistoryComposer, SendMessengerMessageComposer } from '@nitrots/nitro-renderer';
+import { MessengerMessage, MessengerState, selectMessageByClientId, selectMessages } from '../../../api';
+import { MessengerAction } from '../../../api/friends/messenger/messengerReducer';
+
+type Dispatch = (action: MessengerAction) => void;
+type Send = (composer: object) => void;
+
+export const createMessengerHistoryController = (
+    getState: () => MessengerState,
+    dispatch: Dispatch,
+    send: Send,
+    makeRequest: (conversationId: number, beforeMessageId: number, limit: number) => object = (conversationId, beforeMessageId, limit) => new RequestMessengerHistoryComposer(conversationId, beforeMessageId, limit)
+) => ({
+    loadInitial(conversationId: number)
+    {
+        if(conversationId <= 0) return;
+        const history = getState().historyByConversation[conversationId];
+        if(history?.loading || history?.loaded) return;
+        dispatch({ type: 'historyLoading', conversationId });
+        send(makeRequest(conversationId, 0, 30));
+    },
+    loadOlder(conversationId: number)
+    {
+        const state = getState();
+        const history = state.historyByConversation[conversationId];
+        if(history?.loading || history?.hasMore === false) return;
+        const beforeMessageId = selectMessages(state, conversationId).find(message => message.id > 0)?.id || 0;
+        dispatch({ type: 'historyLoading', conversationId });
+        send(makeRequest(conversationId, beforeMessageId, 30));
+    }
+});
+
+export const createMessengerActionsController = (
+    getState: () => MessengerState,
+    dispatch: Dispatch,
+    send: Send,
+    getOwnUserId: () => number,
+    initialConfirmationId: number = 1,
+    makeSend: (conversationId: number, recipientId: number, confirmationId: number, type: number, text: string, metadata: string) => object = (conversationId, recipientId, confirmationId, type, text, metadata) => new SendMessengerMessageComposer(conversationId, recipientId, confirmationId, type, text, metadata),
+    makeRead: (conversationId: number, messageId: number) => object = (conversationId, messageId) => new MarkMessengerReadComposer(conversationId, messageId),
+    scheduleTimeout: (callback: () => void, delay: number) => unknown = (callback, delay) => globalThis.setTimeout(callback, delay)
+) =>
+{
+    let nextConfirmationId = initialConfirmationId;
+
+    const sendMessage = (conversationId: number, recipientId: number, text: string, type: number = 0, metadata: string = '') =>
+    {
+        const confirmationId = nextConfirmationId++;
+        const clientId = `c-${ confirmationId }`;
+        const message: MessengerMessage = { id: 0, clientId, conversationId, senderId: getOwnUserId(), type, message: text, metadata, createdAt: Math.floor(Date.now() / 1000), status: 'sending' };
+        dispatch({ type: 'messageOptimistic', message });
+        send(makeSend(conversationId, recipientId, confirmationId, type, text, metadata));
+        scheduleTimeout(() =>
+        {
+            if(selectMessageByClientId(getState(), clientId)?.status === 'sending') dispatch({ type: 'messageFailed', clientId, errorCode: 7 });
+        }, 10_000);
+        return { clientId, confirmationId };
+    };
+
+    return {
+        openDirectConversation(participantId: number, name: string)
+        {
+            dispatch({ type: 'directConversationOpened', participantId, name });
+        },
+        sendMessage,
+        retryMessage(clientId: string)
+        {
+            const failed = selectMessageByClientId(getState(), clientId);
+            if(!failed || failed.status !== 'failed') return null;
+            const recipientId = getState().conversationsById[failed.conversationId]?.participantId || 0;
+            return sendMessage(failed.conversationId, recipientId, failed.message, failed.type, failed.metadata);
+        },
+        markRead(conversationId: number, messageId: number)
+        {
+            send(makeRead(conversationId, messageId));
+        }
+    };
+};

--- a/src/hooks/friends/messenger/useMessengerActions.ts
+++ b/src/hooks/friends/messenger/useMessengerActions.ts
@@ -1,0 +1,10 @@
+import { GetSessionDataManager } from '@nitrots/nitro-renderer';
+import { SendMessageComposer as SendPacket } from '../../../api';
+import { createMessengerActionsController } from './messengerControllers';
+import { useMessengerStore } from './useMessengerStore';
+
+export const useMessengerActions = () =>
+{
+    const { getState, dispatch } = useMessengerStore();
+    return createMessengerActionsController(getState, dispatch, SendPacket, () => GetSessionDataManager().userId);
+};

--- a/src/hooks/friends/messenger/useMessengerHistory.ts
+++ b/src/hooks/friends/messenger/useMessengerHistory.ts
@@ -1,0 +1,9 @@
+import { SendMessageComposer as SendPacket } from '../../../api';
+import { createMessengerHistoryController } from './messengerControllers';
+import { useMessengerStore } from './useMessengerStore';
+
+export const useMessengerHistory = () =>
+{
+    const { getState, dispatch } = useMessengerStore();
+    return createMessengerHistoryController(getState, dispatch, SendPacket);
+};

--- a/src/hooks/friends/messenger/useMessengerRealtime.ts
+++ b/src/hooks/friends/messenger/useMessengerRealtime.ts
@@ -1,0 +1,41 @@
+import { GetSessionDataManager, MessengerConversationsEvent, MessengerHistoryEvent, MessengerMessageAckEvent, MessengerMessageEvent, MessengerMessageFailedEvent, MessengerReadCursorEvent, RequestMessengerConversationsComposer } from '@nitrots/nitro-renderer';
+import { useEffect } from 'react';
+import { MessengerMessage, SendMessageComposer as SendPacket } from '../../../api';
+import { useMessageEvent } from '../../events';
+import { useMessengerStore } from './useMessengerStore';
+
+export const useMessengerRealtime = () =>
+{
+    const { state, dispatch } = useMessengerStore();
+
+    useEffect(() => SendPacket(new RequestMessengerConversationsComposer()), []);
+    useMessageEvent<MessengerConversationsEvent>(MessengerConversationsEvent, event => dispatch({ type: 'summariesLoaded', conversations: event.getParser().conversations }));
+    useMessageEvent<MessengerHistoryEvent>(MessengerHistoryEvent, event =>
+    {
+        const parser = event.getParser();
+        const messages = parser.messages.map(message => ({ ...message, clientId: null, status: 'sent' as const } satisfies MessengerMessage));
+        dispatch({ type: 'historyLoaded', conversationId: parser.conversationId, messages, hasMore: parser.hasMore });
+    });
+    useMessageEvent<MessengerMessageAckEvent>(MessengerMessageAckEvent, event =>
+    {
+        const parser = event.getParser();
+        dispatch({ type: 'messageAcknowledged', clientId: `c-${ parser.confirmationId }`, messageId: parser.messageId, conversationId: parser.conversationId, createdAt: parser.createdAt });
+    });
+    useMessageEvent<MessengerMessageFailedEvent>(MessengerMessageFailedEvent, event =>
+    {
+        const parser = event.getParser();
+        dispatch({ type: 'messageFailed', clientId: `c-${ parser.confirmationId }`, errorCode: parser.errorCode });
+    });
+    useMessageEvent<MessengerMessageEvent>(MessengerMessageEvent, event =>
+    {
+        dispatch({ type: 'messageReceived', message: { ...event.getParser().message, clientId: null, status: 'sent' } });
+        SendPacket(new RequestMessengerConversationsComposer());
+    });
+    useMessageEvent<MessengerReadCursorEvent>(MessengerReadCursorEvent, event =>
+    {
+        const parser = event.getParser();
+        dispatch({ type: 'readCursorAdvanced', conversationId: parser.conversationId, readerId: parser.readerId, messageId: parser.messageId, ownUserId: GetSessionDataManager().userId });
+    });
+
+    return state;
+};

--- a/src/hooks/friends/messenger/useMessengerStore.ts
+++ b/src/hooks/friends/messenger/useMessengerStore.ts
@@ -1,0 +1,13 @@
+import { useReducer, useRef } from 'react';
+import { useBetween } from 'use-between';
+import { initialMessengerState, messengerReducer } from '../../../api';
+
+const useMessengerStoreState = () =>
+{
+    const [ state, dispatch ] = useReducer(messengerReducer, initialMessengerState);
+    const stateRef = useRef(state);
+    stateRef.current = state;
+    return { state, dispatch, getState: () => stateRef.current };
+};
+
+export const useMessengerStore = () => useBetween(useMessengerStoreState);

--- a/src/hooks/friends/useFriends.ts
+++ b/src/hooks/friends/useFriends.ts
@@ -22,7 +22,7 @@ import {
 } from '@nitrots/nitro-renderer';
 import { useEffect, useMemo, useState } from 'react';
 import { useBetween } from 'use-between';
-import { CloneObject, LocalizeText, MessengerFriend, MessengerRequest, MessengerSettings, NotificationAlertType, SendMessageComposer } from '../../api';
+import { CloneObject, LocalizeText, MessengerFriend, MessengerRequest, MessengerSettings, NotificationAlertType, SendMessageComposer, withUpdatedFriendCategories } from '../../api';
 import { useMessageEvent } from '../events';
 import { useNotification } from '../notification';
 
@@ -178,6 +178,8 @@ const useFriendsStore = () => {
 
     useMessageEvent<FriendListUpdateEvent>(FriendListUpdateEvent, (event) => {
         const parser = event.getParser();
+
+        setSettings((previous) => withUpdatedFriendCategories(previous, parser.categories));
 
         setFriends((prevValue) => {
             const newValue = [...prevValue];

--- a/src/hooks/friends/useMessenger.ts
+++ b/src/hooks/friends/useMessenger.ts
@@ -19,6 +19,7 @@ import {
     MessengerThreadChat,
     NotificationAlertType,
     PlaySound,
+    selectMessengerIconState,
     SendMessageComposer,
     SoundNames
 } from '../../api';
@@ -26,8 +27,12 @@ import { useMessageEvent } from '../events';
 import { useNotification } from '../notification';
 import { IResolvedTranslation, useTranslation } from '../translation';
 import { useFriends } from './useFriends';
+import { useMessengerActions, useMessengerHistory, useMessengerRealtime } from './messenger';
 
 const useMessengerState = () => {
+    const persistentState = useMessengerRealtime();
+    const persistentHistory = useMessengerHistory();
+    const persistentActions = useMessengerActions();
     const [messageThreads, setMessageThreads] = useState<MessengerThread[]>([]);
     const [activeThreadId, setActiveThreadId] = useState<number>(-1);
     const [hiddenThreadIds, setHiddenThreadIds] = useState<number[]>([]);
@@ -281,24 +286,8 @@ const useMessengerState = () => {
     }, [activeThreadId]);
 
     useEffect(() => {
-        setIconState((prevValue) => {
-            if (!visibleThreads.length) return MessengerIconState.HIDDEN;
-
-            let isUnread = false;
-
-            for (const thread of visibleThreads) {
-                if (thread.unreadCount > 0) {
-                    isUnread = true;
-
-                    break;
-                }
-            }
-
-            if (isUnread) return MessengerIconState.UNREAD;
-
-            return MessengerIconState.SHOW;
-        });
-    }, [visibleThreads]);
+        setIconState(selectMessengerIconState(persistentState, visibleThreads.length > 0, visibleThreads.some(thread => thread.unreadCount > 0)));
+    }, [persistentState, visibleThreads]);
 
     return {
         messageThreads,
@@ -310,7 +299,8 @@ const useMessengerState = () => {
         closeThread,
         sendMessage,
         typingUserIds,
-        sendTypingStatus
+        sendTypingStatus,
+        persistentMessenger: { state: persistentState, history: persistentHistory, actions: persistentActions }
     };
 };
 


### PR DESCRIPTION
﻿## What changed

- adds a normalized persistent Messenger store with paged history, optimistic sends, acknowledgements, read state, retries and timeout handling
- adds an AIR-inspired responsive Messenger using client CSS and existing avatar rendering
- keeps Staff Chat and direct conversations as tabs in the same window while preserving the permission-gated legacy broadcast transport
- adds friend categories, per-friend category assignment and filtering
- improves avatar sizing, delivery indicators, unread badges and conversation closing

## Why

The legacy Messenger only represented transient client threads and could not consume persistent conversation history. Staff Chat remains a synthetic permission-gated broadcast, so the UI integrates it as a tab without incorrectly treating it as a database conversation.

## Validation

- full UI test suite passes
- production UI build passes
