### PR TITLE
Style user moderation actions with Habbo button chrome

### DIFF
--- a/src/components/mod-tools/views/user/ModToolsUserView.actions.test.ts
+++ b/src/components/mod-tools/views/user/ModToolsUserView.actions.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('ModToolsUserView action buttons', () => {
+    it('uses the active blue treatment for regular actions', () => {
+        const source = readFileSync(join(process.cwd(), 'src/components/mod-tools/views/user/ModToolsUserView.tsx'), 'utf8');
+        const actionBar = source.slice(source.indexOf('{/* Action bar */}'));
+
+        expect(actionBar.match(/variant="primary"/g)).toHaveLength(3);
+        expect(actionBar.match(/mod-tools-action-button/g)).toHaveLength(3);
+        expect(actionBar.match(/variant="danger"/g)).toHaveLength(1);
+        expect(actionBar.match(/mod-tools-danger-button/g)).toHaveLength(1);
+    });
+});

--- a/src/components/mod-tools/views/user/ModToolsUserView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserView.tsx
@@ -208,16 +208,16 @@ export const ModToolsUserView: FC<ModToolsUserViewProps> = (props) => {
 
                     {/* Action bar */}
                     <div className="grid grid-cols-2 gap-1.5 pt-1 border-t border-zinc-200">
-                        <Button gap={1} variant="secondary" onClick={() => CreateLinkEvent(`mod-tools/open-user-chatlog/${userId}`)}>
+                        <Button gap={1} variant="primary" classNames={['mod-tools-action-button']} onClick={() => CreateLinkEvent(`mod-tools/open-user-chatlog/${userId}`)}>
                             <FaCommentDots size={12} /> {LocalizeText('modtools.userinfo.button.room.chat')}
                         </Button>
-                        <Button gap={1} variant="secondary" onClick={() => setSendMessageVisible((prev) => !prev)}>
+                        <Button gap={1} variant="primary" classNames={['mod-tools-action-button']} onClick={() => setSendMessageVisible((prev) => !prev)}>
                             <FaEnvelope size={12} /> {LocalizeText('modtools.userinfo.button.send.message')}
                         </Button>
-                        <Button gap={1} variant="secondary" onClick={() => setRoomVisitsVisible((prev) => !prev)}>
+                        <Button gap={1} variant="primary" classNames={['mod-tools-action-button']} onClick={() => setRoomVisitsVisible((prev) => !prev)}>
                             <FaDoorOpen size={12} /> {LocalizeText('modtools.userinfo.button.room.visits')}
                         </Button>
-                        <Button gap={1} variant="danger" onClick={() => setModActionVisible((prev) => !prev)}>
+                        <Button gap={1} variant="danger" classNames={['mod-tools-danger-button']} onClick={() => setModActionVisible((prev) => !prev)}>
                             <FaGavel size={12} /> {LocalizeText('modtools.userinfo.button.mod.action')}
                         </Button>
                     </div>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -751,6 +751,40 @@ body {
     color: var(--mod-tools-text);
 }
 
+.nitro-mod-tools-user .mod-tools-action-button {
+    border: 2px solid #0e3f52 !important;
+    border-radius: 4px !important;
+    color: #fff !important;
+    background: linear-gradient(180deg, #67b6d3 0%, #418db0 48%, #2e6f8a 100%) !important;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.42),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2),
+        0 1px 0 rgba(0, 0, 0, 0.18) !important;
+    font-weight: 700;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.nitro-mod-tools-user .mod-tools-action-button:hover {
+    background: linear-gradient(180deg, #79c5df 0%, #4a9bc0 48%, #3580a0 100%) !important;
+}
+
+.nitro-mod-tools-user .mod-tools-danger-button {
+    border: 2px solid #71110c !important;
+    border-radius: 4px !important;
+    color: #fff !important;
+    background: linear-gradient(180deg, #e96f65 0%, #bd271f 48%, #8f160f 100%) !important;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.38),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.24),
+        0 1px 0 rgba(0, 0, 0, 0.2) !important;
+    font-weight: 700;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.45);
+}
+
+.nitro-mod-tools-user .mod-tools-danger-button:hover {
+    background: linear-gradient(180deg, #f07f75 0%, #cd3229 48%, #a31b14 100%) !important;
+}
+
 .nitro-mod-tools :where(.bg-white, .bg-light, .bg-muted, .bg-card-grid-item, .bg-white\/70),
 [class*="nitro-mod-tools-"] :where(.bg-white, .bg-light, .bg-muted, .bg-card-grid-item, .bg-white\/70) {
     background: var(--mod-tools-panel) !important;


### PR DESCRIPTION
﻿## What changed

- restyles the three regular user moderation actions with the classic Habbo blue gradient, dark border, inset highlight and text shadow
- applies the matching Habbo treatment to the red moderation action
- keeps blue and destructive actions visually distinct while giving the whole action grid consistent chrome
- adds a regression test for the action variants and scoped style hooks

## Why

The pale secondary buttons looked disabled and did not match the established Habbo client button language.

## Validation

- targeted Vitest passed
- `yarn typecheck`
- `yarn build`
- `git diff --check origin/Dev...HEAD`

## Scope hygiene

This PR contains only the Mod Tools user action styling and its regression test. HUD, Messenger and local catalog assets are excluded.
