### PR TITLE
Consume authoritative WebSocket connection state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { LoadingView } from './components/loading/LoadingView';
 import { LoginView } from './components/login/LoginView';
 import { MainView } from './components/MainView';
 import { ReconnectView } from './components/reconnect/ReconnectView';
-import { useMessageEvent, useNitroEvent } from './hooks';
+import { getConnectionFailureAction, useConnectionState, useMessageEvent } from './hooks';
 
 NitroVersion.UI_VERSION = GetUIVersion();
 
@@ -79,6 +79,7 @@ const asStringArray = (value: unknown): string[] => {
 const hasRememberLogin = (): boolean => !!GetRememberLogin();
 
 export const App: FC<{}> = (props) => {
+    const connectionState = useConnectionState();
     const [isReady, setIsReady] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
     const [homeUrl, setHomeUrl] = useState('');
@@ -116,8 +117,7 @@ export const App: FC<{}> = (props) => {
     const tickersStartedRef = useRef(false);
     const heartbeatIntervalRef = useRef<number>(null);
     const rememberRotateIntervalRef = useRef<number>(null);
-    const isReadyRef = useRef(false);
-    const reconnectInProgressRef = useRef(false);
+    const previousConnectionPhaseRef = useRef(connectionState.phase);
 
     const clearStoredCredentials = useCallback(() => {
         ClearRememberLogin();
@@ -278,31 +278,19 @@ export const App: FC<{}> = (props) => {
     }, []);
 
     useEffect(() => {
-        isReadyRef.current = isReady;
-    }, [isReady]);
-    useNitroEvent(NitroEventType.SOCKET_RECONNECTING, () => {
-        reconnectInProgressRef.current = true;
-    });
-    useNitroEvent(NitroEventType.SOCKET_REAUTHENTICATED, () => {
-        reconnectInProgressRef.current = false;
-    });
+        const previousPhase = previousConnectionPhaseRef.current;
+        const currentPhase = connectionState.phase;
+        previousConnectionPhaseRef.current = currentPhase;
 
-    useNitroEvent(NitroEventType.SOCKET_CLOSED, () => {
-        console.warn('[App] SOCKET_CLOSED fired', {
-            isReady: isReadyRef.current,
-            reconnectInProgress: reconnectInProgressRef.current
-        });
+        const action = getConnectionFailureAction(previousPhase, currentPhase, isReady);
 
-        if (!isReadyRef.current) {
-            console.warn('[App] Socket closed before authentication completed — falling back to login');
+        if (action === 'login') {
+            console.warn('[App] Connection failed before authentication completed — falling back to login');
             fallbackToLogin();
-            return;
+        } else if (action === 'expired') {
+            showSessionExpired();
         }
-
-        if (reconnectInProgressRef.current) return;
-
-        showSessionExpired();
-    });
+    }, [connectionState.phase, fallbackToLogin, isReady, showSessionExpired]);
 
     useMessageEvent<LoadGameUrlEvent>(LoadGameUrlEvent, (event) => {
         const parser = event.getParser();

--- a/src/components/reconnect/ReconnectView.tsx
+++ b/src/components/reconnect/ReconnectView.tsx
@@ -1,55 +1,10 @@
-import { NitroEventType, ReconnectEvent } from '@nitrots/nitro-renderer';
-import { FC, useCallback, useState } from 'react';
+import { FC } from 'react';
 import { Base, Column, Text } from '../../common';
-import { useNitroEvent } from '../../hooks';
+import { getReconnectPresentation, useConnectionState } from '../../hooks';
 
-export const ReconnectView: FC<{}> = (props) => {
-    const [isReconnecting, setIsReconnecting] = useState(false);
-    const [attempt, setAttempt] = useState(0);
-    const [maxAttempts, setMaxAttempts] = useState(0);
-    const [hasFailed, setHasFailed] = useState(false);
-
-    const onReconnecting = useCallback((event: ReconnectEvent) => {
-        setIsReconnecting(true);
-        setHasFailed(false);
-        setAttempt(event.attempt);
-        setMaxAttempts(event.maxAttempts);
-    }, []);
-
-    const onReconnected = useCallback(() => {
-        // Socket is open but not yet re-authenticated.
-        // Update attempt display but keep the overlay visible until
-        // re-authentication completes (SOCKET_REAUTHENTICATED).
-        setHasFailed(false);
-    }, []);
-
-    const onReauthenticated = useCallback(() => {
-        // Fully re-authenticated — dismiss the overlay so the room view
-        // (which stayed alive behind the overlay) is visible again.
-        setIsReconnecting(false);
-        setHasFailed(false);
-        setAttempt(0);
-    }, []);
-
-    const onReconnectFailed = useCallback(() => {
-        setIsReconnecting(false);
-        setHasFailed(true);
-    }, []);
-
-    useNitroEvent<ReconnectEvent>(NitroEventType.SOCKET_RECONNECTING, onReconnecting);
-    useNitroEvent(NitroEventType.SOCKET_RECONNECTED, onReconnected);
-    useNitroEvent(NitroEventType.SOCKET_REAUTHENTICATED, onReauthenticated);
-    useNitroEvent(NitroEventType.SOCKET_RECONNECT_FAILED, onReconnectFailed);
-
-    const handleReload = useCallback(() => {
-        window.location.href = window.location.origin + '/';
-    }, []);
-
-    const handleGoHome = useCallback(() => {
-        sessionStorage.removeItem('nitro.session.lastRoomId');
-        sessionStorage.removeItem('nitro.session.lastRoomPassword');
-        window.location.href = window.location.origin + '/';
-    }, []);
+export const ReconnectView: FC<{}> = () => {
+    const connectionState = useConnectionState();
+    const { isReconnecting, hasFailed, attempt, maxAttempts } = getReconnectPresentation(connectionState);
 
     if (!isReconnecting && !hasFailed) return null;
 
@@ -68,7 +23,7 @@ export const ReconnectView: FC<{}> = (props) => {
                         <Base className="w-full h-[4px] rounded-full bg-white/10 overflow-hidden mt-1">
                             <Base
                                 className="h-full bg-[#4dabf7] rounded-full transition-all duration-300"
-                                style={{ width: `${(attempt / maxAttempts) * 100}%` }}
+                                style={{ width: `${maxAttempts > 0 ? (attempt / maxAttempts) * 100 : 0}%` }}
                             />
                         </Base>
                         <Text fontSizeCustom={12} variant="white" className="text-center opacity-50">

--- a/src/hooks/events/connectionStateUi.helpers.test.ts
+++ b/src/hooks/events/connectionStateUi.helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getConnectionFailureAction, getReconnectPresentation } from './connectionStateUi.helpers';
+
+describe('connection state UI decisions', () => {
+    it('shows reconnect progress through transport and reauthentication phases', () => {
+        expect(getReconnectPresentation({ phase: 'reconnecting', reconnectAttempt: 2, maxReconnectAttempts: 7 })).toEqual({
+            isReconnecting: true,
+            hasFailed: false,
+            attempt: 2,
+            maxAttempts: 7
+        });
+        expect(getReconnectPresentation({ phase: 'reauthenticating', reconnectAttempt: 0, maxReconnectAttempts: 7 }).isReconnecting).toBe(true);
+    });
+
+    it('shows terminal failure only for the failed phase', () => {
+        expect(getReconnectPresentation({ phase: 'failed', reconnectAttempt: 7, maxReconnectAttempts: 7 }).hasFailed).toBe(true);
+        expect(getReconnectPresentation({ phase: 'connected', reconnectAttempt: 0, maxReconnectAttempts: 7 }).hasFailed).toBe(false);
+    });
+
+    it('ignores initial disconnected state and active reconnects', () => {
+        expect(getConnectionFailureAction('disconnected', 'disconnected', false)).toBe('none');
+        expect(getConnectionFailureAction('failed', 'failed', false)).toBe('none');
+        expect(getConnectionFailureAction('connected', 'reconnecting', true)).toBe('none');
+    });
+
+    it('routes real failures according to whether the hotel was ready', () => {
+        expect(getConnectionFailureAction('authenticating', 'disconnected', false)).toBe('login');
+        expect(getConnectionFailureAction('connected', 'failed', true)).toBe('expired');
+        expect(getConnectionFailureAction('authenticating', 'failed', false)).toBe('login');
+    });
+});

--- a/src/hooks/events/connectionStateUi.helpers.ts
+++ b/src/hooks/events/connectionStateUi.helpers.ts
@@ -1,0 +1,25 @@
+import { ConnectionStatePhase, IConnectionStateSnapshot } from '@nitrots/nitro-renderer';
+
+type ReconnectSnapshot = Pick<IConnectionStateSnapshot, 'phase' | 'reconnectAttempt' | 'maxReconnectAttempts'>;
+
+export type ConnectionFailureAction = 'none' | 'login' | 'expired';
+
+export const getReconnectPresentation = (snapshot: ReconnectSnapshot) => ({
+    isReconnecting: snapshot.phase === 'reconnecting' || snapshot.phase === 'reauthenticating',
+    hasFailed: snapshot.phase === 'failed',
+    attempt: snapshot.reconnectAttempt,
+    maxAttempts: snapshot.maxReconnectAttempts
+});
+
+export const getConnectionFailureAction = (
+    previousPhase: ConnectionStatePhase,
+    currentPhase: ConnectionStatePhase,
+    isReady: boolean
+): ConnectionFailureAction => {
+    const enteredDisconnected = currentPhase === 'disconnected' && previousPhase !== 'disconnected';
+    const failed = currentPhase === 'failed' && previousPhase !== 'failed';
+
+    if (!enteredDisconnected && !failed) return 'none';
+
+    return isReady ? 'expired' : 'login';
+};

--- a/src/hooks/events/index.ts
+++ b/src/hooks/events/index.ts
@@ -1,5 +1,7 @@
 export * from './useEventDispatcher';
 export * from './useExternalSnapshot';
+export * from './useConnectionState';
+export * from './connectionStateUi.helpers';
 export * from './useMessageEvent';
 export * from './useMessageEventReducer';
 export * from './useMessageEventState';

--- a/src/hooks/events/useConnectionState.test.tsx
+++ b/src/hooks/events/useConnectionState.test.tsx
@@ -1,0 +1,33 @@
+import { GetCommunication, IConnectionStateSnapshot, NitroEventType } from '@nitrots/nitro-renderer';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearMockEventDispatcher, mockEventDispatcher } from '../../nitro-renderer.mock';
+import { useConnectionState } from './useConnectionState';
+
+describe('useConnectionState', () => {
+    let snapshot: IConnectionStateSnapshot;
+
+    beforeEach(() => {
+        clearMockEventDispatcher();
+        snapshot = {
+            phase: 'disconnected',
+            reconnectAttempt: 0,
+            maxReconnectAttempts: 7,
+            authenticated: false,
+            closeCode: null,
+            closeReason: ''
+        };
+        vi.mocked(GetCommunication).mockReturnValue({ connection: { get connectionState() { return snapshot; } } } as never);
+    });
+
+    it('rereads the authoritative snapshot when the renderer notifies a change', () => {
+        const { result } = renderHook(() => useConnectionState());
+
+        snapshot = { ...snapshot, phase: 'reconnecting', reconnectAttempt: 2 };
+        act(() => mockEventDispatcher.dispatchEvent({ type: NitroEventType.CONNECTION_STATE_CHANGED }));
+
+        expect(result.current).toBe(snapshot);
+        expect(result.current.phase).toBe('reconnecting');
+        expect(result.current.reconnectAttempt).toBe(2);
+    });
+});

--- a/src/hooks/events/useConnectionState.ts
+++ b/src/hooks/events/useConnectionState.ts
@@ -1,0 +1,14 @@
+import { GetCommunication, IConnectionStateSnapshot, NitroEventType } from '@nitrots/nitro-renderer';
+import { useCallback, useState } from 'react';
+import { useNitroEvent } from './useNitroEvent';
+
+const readConnectionState = (): Readonly<IConnectionStateSnapshot> => GetCommunication().connection.connectionState;
+
+export const useConnectionState = (): Readonly<IConnectionStateSnapshot> => {
+    const [snapshot, setSnapshot] = useState(readConnectionState);
+    const refresh = useCallback(() => setSnapshot(readConnectionState()), []);
+
+    useNitroEvent(NitroEventType.CONNECTION_STATE_CHANGED, refresh);
+
+    return snapshot;
+};

--- a/src/nitro-renderer.mock.ts
+++ b/src/nitro-renderer.mock.ts
@@ -558,8 +558,18 @@ export const GetCommunication = vi.fn(() => ({
         const wrapper = _msgEventWrappers.get(event);
         if (wrapper) msgListeners.get(event.type)?.delete(wrapper);
     },
-    // Stub for SendMessageComposer which calls GetCommunication().connection.send(...)
-    connection: { send: vi.fn() }
+    // Stub for SendMessageComposer and renderer-owned connection snapshots.
+    connection: {
+        send: vi.fn(),
+        connectionState: Object.freeze({
+            phase: 'disconnected',
+            reconnectAttempt: 0,
+            maxReconnectAttempts: 7,
+            authenticated: false,
+            closeCode: null,
+            closeReason: ''
+        })
+    }
 }));
 export const GetConfiguration = vi.fn(stubManager);
 export const GetLocalizationManager = vi.fn(stubManager);


### PR DESCRIPTION
## Summary
- add one UI hook that rereads the renderer-owned connection snapshot
- derive reconnect overlay content directly from the authoritative lifecycle phase
- remove parallel reconnect flags and socket-event bookkeeping from `App`
- preserve the current reconnect overlay appearance

## Dependency
Requires renderer PR duckietm/Nitro_Render_V3#124.

## Verification
- `yarn.cmd test`: 573 tests passed
- `yarn.cmd typecheck`
- `yarn.cmd build`
- `git diff --check`