### PR TITLE
feat(wired): add opacity editor and room controller

### DIFF
--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -111,4 +111,5 @@ export class WiredActionLayoutCode {
     public static CONTRACT_REWARD: number = 111;
     public static CONTRACT_TRADE: number = 112;
     public static CUSTOM_CONTRACT: number = 113;
+    public static CHANGE_OPACITY: number = 114;
 }

--- a/src/components/wired-tools/WiredCreatorTools.constants.ts
+++ b/src/components/wired-tools/WiredCreatorTools.constants.ts
@@ -91,7 +91,9 @@ export const VARIABLES_ELEMENTS: VariablesElementButton[] = [
     { key: 'context', label: 'Context', icon: contextInspectionIcon }
 ];
 
-export const EDITABLE_FURNI_VARIABLES: string[] = ['@position_x', '@position_y', '@rotation', '@altitude', '@state', '@wallitem_offset'];
+export const EDITABLE_FURNI_VARIABLES: string[] = ['@position_x', '@position_y', '@rotation', '@altitude', '@state', '@gravity', '@wallitem_offset'];
+export const WIRED_FURNI_RUNTIME_ACTION_READ = 0;
+export const WIRED_FURNI_RUNTIME_ACTION_WRITE = 1;
 export const EDITABLE_USER_VARIABLES: string[] = ['@position_x', '@position_y', '@direction'];
 
 const createVariableDefinition = (
@@ -125,6 +127,7 @@ export const VARIABLE_DEFINITIONS: Record<VariablesElementType, VariableDefiniti
         createVariableDefinition('@position_y', 'Furni', 'Always', true),
         createVariableDefinition('@rotation', 'Furni', 'Always', true),
         createVariableDefinition('@altitude', 'Furni', 'Always', true),
+        createVariableDefinition('@gravity', 'Furni', 'Conditional', true),
         createVariableDefinition('@is_invisible', 'Furni', 'Conditional'),
         createVariableDefinition('@wallitem_offset', 'Furni', 'Conditional', true),
         createVariableDefinition('@type', 'Furni'),

--- a/src/components/wired-tools/WiredCreatorToolsView.tsx
+++ b/src/components/wired-tools/WiredCreatorToolsView.tsx
@@ -28,6 +28,8 @@ import {
     Vector3d,
     WiredMonitorDataEvent,
     WiredMonitorRequestComposer,
+    WiredFurniRuntimeStateEvent,
+    WiredFurniRuntimeStateRequestComposer,
     WiredUserInspectMoveComposer
 } from '@nitrots/nitro-renderer';
 import { FC, KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -70,6 +72,8 @@ import {
     VARIABLES_ELEMENTS,
     WEEKDAY_NAMES,
     WIRED_CLOCK_REFRESH_MS,
+    WIRED_FURNI_RUNTIME_ACTION_READ,
+    WIRED_FURNI_RUNTIME_ACTION_WRITE,
     WIRED_FREEZE_EFFECT_IDS,
     WIRED_INSPECTION_REFRESH_MS,
     WIRED_MONITOR_ACTION_CLEAR_LOGS,
@@ -130,6 +134,12 @@ export const WiredCreatorToolsView: FC<{}> = () => {
     const setSelectedFurni = useWiredCreatorToolsUiStore((s) => s.setSelectedFurni);
     const selectedFurniLiveState = useWiredCreatorToolsUiStore((s) => s.selectedFurniLiveState);
     const setSelectedFurniLiveState = useWiredCreatorToolsUiStore((s) => s.setSelectedFurniLiveState);
+    const [selectedFurniRuntimeState, setSelectedFurniRuntimeState] = useState<{
+        itemId: number;
+        key: string;
+        value: number;
+        supported: boolean;
+    }>(null);
     const selectedUser = useWiredCreatorToolsUiStore((s) => s.selectedUser);
     const setSelectedUser = useWiredCreatorToolsUiStore((s) => s.setSelectedUser);
     const selectedUserLiveState = useWiredCreatorToolsUiStore((s) => s.selectedUserLiveState);
@@ -659,6 +669,19 @@ export const WiredCreatorToolsView: FC<{}> = () => {
             heavyDelayedThresholdPercent: Number(parser.heavyDelayedThresholdPercent ?? 0),
             logs: [...(parser.logs ?? [])],
             history: [...(parser.history ?? [])]
+        });
+    });
+
+    useMessageEvent<WiredFurniRuntimeStateEvent>(WiredFurniRuntimeStateEvent, (event) => {
+        const parser = event.getParser();
+
+        if (parser.key !== '@gravity' || parser.itemId !== selectedFurni?.objectId) return;
+
+        setSelectedFurniRuntimeState({
+            itemId: parser.itemId,
+            key: parser.key,
+            value: parser.value,
+            supported: parser.supported
         });
     });
 
@@ -1246,6 +1269,11 @@ export const WiredCreatorToolsView: FC<{}> = () => {
             { key: '@position_y', value: String(liveState?.positionY ?? 0), editable: canEditInspection },
             { key: '@rotation', value: String(liveState?.rotation ?? 0), editable: canEditInspection },
             { key: '@altitude', value: String(liveState?.altitude ?? 0), editable: canEditInspection },
+            ...(selectedFurni.category === RoomObjectCategory.FLOOR &&
+            selectedFurniRuntimeState?.itemId === selectedFurni.objectId &&
+            selectedFurniRuntimeState.supported
+                ? [{ key: '@gravity', value: String(selectedFurniRuntimeState.value), editable: canEditInspection }]
+                : []),
             { key: '@is_invisible', value: '0' },
             ...(wallItemOffset ? [{ key: '@wallitem_offset', value: wallItemOffset, editable: canEditInspection }] : []),
             {
@@ -1267,7 +1295,8 @@ export const WiredCreatorToolsView: FC<{}> = () => {
         wallItemOffset,
         canEditInspection,
         selectedFurniCustomVariableDefinitions,
-        selectedFurniAssignmentMap
+        selectedFurniAssignmentMap,
+        selectedFurniRuntimeState
     ]);
     const canEditSelectedUser = useMemo(() => {
         return !!selectedUser && !!roomSession && roomSettings.canModify;
@@ -2672,6 +2701,23 @@ export const WiredCreatorToolsView: FC<{}> = () => {
             return;
         }
 
+        if (editingVariable === '@gravity') {
+            const parsed = parseInt(editingValue.trim(), 10);
+            if (!selectedFurni || !roomSession || (parsed !== 0 && parsed !== 1)) {
+                cancelVariableEdit();
+                return;
+            }
+            if (selectedFurniRuntimeState?.itemId === selectedFurni.objectId && selectedFurniRuntimeState.value === parsed) {
+                cancelVariableEdit();
+                return;
+            }
+
+            SendMessageComposer(new WiredFurniRuntimeStateRequestComposer(selectedFurni.objectId, WIRED_FURNI_RUNTIME_ACTION_WRITE, '@gravity', parsed));
+            setEditingVariable(null);
+            setEditingValue('');
+            return;
+        }
+
         if (!editingVariable || !selectedFurni || !selectedRoomObject || !roomSession) return;
 
         const currentLiveState = selectedFurniLiveState ?? getFurniLiveState(selectedFurni.objectId, selectedFurni.category);
@@ -3057,6 +3103,14 @@ export const WiredCreatorToolsView: FC<{}> = () => {
 
         setSelectedFurniLiveState(getFurniLiveState(selectedFurni.objectId, selectedFurni.category));
     }, [inspectionType, selectedFurni?.objectId, selectedFurni?.category]);
+
+    useEffect(() => {
+        setSelectedFurniRuntimeState(null);
+        if (!isVisible || inspectionType !== 'furni' || !roomSettings.canInspect || !selectedFurni || selectedFurni.category !== RoomObjectCategory.FLOOR)
+            return;
+
+        SendMessageComposer(new WiredFurniRuntimeStateRequestComposer(selectedFurni.objectId, WIRED_FURNI_RUNTIME_ACTION_READ, '@gravity', 0));
+    }, [isVisible, inspectionType, roomSettings.canInspect, selectedFurni?.objectId, selectedFurni?.category]);
 
     useEffect(() => {
         if (inspectionType !== 'user' || !selectedUser) {

--- a/src/components/wired/views/WiredVariablePickerData.test.ts
+++ b/src/components/wired/views/WiredVariablePickerData.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildWiredVariablePickerEntries, flattenWiredVariablePickerEntries } from './WiredVariablePickerData';
+
+describe('Wired variable picker internal furniture variables', () => {
+    it('offers gravity as both a reference and destination without changing custom variables', () => {
+        const references = flattenWiredVariablePickerEntries(buildWiredVariablePickerEntries('furni', 'change-reference', []));
+        const destinations = flattenWiredVariablePickerEntries(buildWiredVariablePickerEntries('furni', 'change-destination', []));
+
+        expect(references.find((entry) => entry.label === '@gravity')?.selectable).toBe(true);
+        expect(destinations.find((entry) => entry.label === '@gravity')?.selectable).toBe(true);
+    });
+});

--- a/src/components/wired/views/WiredVariablePickerData.ts
+++ b/src/components/wired/views/WiredVariablePickerData.ts
@@ -73,6 +73,7 @@ const INTERNAL_VARIABLES: Record<'user' | 'furni' | 'global' | 'context', IInter
         createInternalMeta('@position_y', true, true),
         createInternalMeta('@rotation', true, true),
         createInternalMeta('@altitude', true, true),
+        createInternalMeta('@gravity', true, true),
         createInternalMeta('@is_invisible', false, true),
         createInternalMeta('@type', false, true),
         createInternalMeta('@is_stackable', false, true),

--- a/src/components/wired/views/actions/WiredActionChangeOpacityState.test.ts
+++ b/src/components/wired/views/actions/WiredActionChangeOpacityState.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+    normalizeWiredActionChangeOpacity,
+    serializeWiredActionChangeOpacity,
+    WIRED_OPACITY_DEFAULT_DURATION,
+    WIRED_OPACITY_EASING_INSTANT,
+    WIRED_OPACITY_MAXIMUM,
+    WIRED_OPACITY_SELECTED_FURNI_SOURCE,
+    WIRED_OPACITY_TRIGGER_USER_SOURCE,
+    WIRED_OPACITY_VISIBILITY_SOURCE_USERS
+} from './WiredActionChangeOpacityState';
+
+describe('WiredActionChangeOpacityState', () => {
+    it('uses conservative defaults for a legacy empty payload', () => {
+        expect(normalizeWiredActionChangeOpacity()).toEqual({
+            visibility: WIRED_OPACITY_VISIBILITY_SOURCE_USERS,
+            opacity: WIRED_OPACITY_MAXIMUM,
+            easing: WIRED_OPACITY_EASING_INSTANT,
+            duration: WIRED_OPACITY_DEFAULT_DURATION,
+            furniSource: WIRED_OPACITY_SELECTED_FURNI_SOURCE,
+            userSource: WIRED_OPACITY_TRIGGER_USER_SOURCE,
+            clickThrough: false
+        });
+    });
+
+    it('clamps malformed numeric input and rejects unsupported sources', () => {
+        expect(normalizeWiredActionChangeOpacity([99, -12, 90, 44, 999, -8, 7])).toEqual({
+            visibility: WIRED_OPACITY_VISIBILITY_SOURCE_USERS,
+            opacity: 0,
+            easing: 4,
+            duration: 10,
+            furniSource: WIRED_OPACITY_SELECTED_FURNI_SOURCE,
+            userSource: WIRED_OPACITY_TRIGGER_USER_SOURCE,
+            clickThrough: false
+        });
+    });
+
+    it('preserves every valid server parameter in wire order', () => {
+        expect(normalizeWiredActionChangeOpacity([1, 35, 3, 7, 200, 201, 1])).toEqual({
+            visibility: 1,
+            opacity: 35,
+            easing: 3,
+            duration: 7,
+            furniSource: 200,
+            userSource: 201,
+            clickThrough: true
+        });
+    });
+
+    it('normalizes state again when serializing the seven-value payload', () => {
+        expect(
+            serializeWiredActionChangeOpacity({
+                visibility: 1,
+                opacity: 51.8,
+                easing: 2,
+                duration: Number.NaN,
+                furniSource: 100,
+                userSource: 0,
+                clickThrough: true
+            })
+        ).toEqual([1, 52, 2, WIRED_OPACITY_DEFAULT_DURATION, 100, 0, 1]);
+    });
+
+    it('keeps duration 0 as the server-default transition and floors negatives to it', () => {
+        expect(normalizeWiredActionChangeOpacity([0, 100, 2, 0, 100, 0, 0]).duration).toBe(WIRED_OPACITY_DEFAULT_DURATION);
+        expect(normalizeWiredActionChangeOpacity([0, 100, 2, -3, 100, 0, 0]).duration).toBe(WIRED_OPACITY_DEFAULT_DURATION);
+        expect(normalizeWiredActionChangeOpacity([0, 100, 2, 7, 100, 0, 0]).duration).toBe(7);
+    });
+});

--- a/src/components/wired/views/actions/WiredActionChangeOpacityState.ts
+++ b/src/components/wired/views/actions/WiredActionChangeOpacityState.ts
@@ -1,0 +1,71 @@
+import { FURNI_SOURCES, USER_SOURCES } from '../WiredSourcesSelector';
+
+export const WIRED_OPACITY_VISIBILITY_SOURCE_USERS = 0;
+export const WIRED_OPACITY_VISIBILITY_EVERYONE = 1;
+export const WIRED_OPACITY_EASING_INSTANT = 0;
+export const WIRED_OPACITY_MINIMUM = 0;
+export const WIRED_OPACITY_MAXIMUM = 100;
+export const WIRED_OPACITY_MINIMUM_DURATION = 1;
+export const WIRED_OPACITY_MAXIMUM_DURATION = 10;
+// 0 = server default transition (400 ms); explicit 1-10 s still supported.
+export const WIRED_OPACITY_DEFAULT_DURATION = 0;
+export const WIRED_OPACITY_SELECTED_FURNI_SOURCE = 100;
+export const WIRED_OPACITY_TRIGGER_USER_SOURCE = 0;
+
+export interface WiredActionChangeOpacityState {
+    visibility: number;
+    opacity: number;
+    easing: number;
+    duration: number;
+    furniSource: number;
+    userSource: number;
+    clickThrough: boolean;
+}
+
+const clampInteger = (value: number, minimum: number, maximum: number) => {
+    const normalized = Number.isFinite(value) ? Math.round(value) : minimum;
+
+    return Math.min(maximum, Math.max(minimum, normalized));
+};
+
+const hasSource = (options: { value: number }[], value: number) => options.some((option) => option.value === value);
+
+const normalizeDuration = (value: number) => {
+    const normalized = Number.isFinite(value) ? Math.round(value) : WIRED_OPACITY_DEFAULT_DURATION;
+
+    if (normalized <= WIRED_OPACITY_DEFAULT_DURATION) return WIRED_OPACITY_DEFAULT_DURATION;
+
+    return Math.min(WIRED_OPACITY_MAXIMUM_DURATION, Math.max(WIRED_OPACITY_MINIMUM_DURATION, normalized));
+};
+
+export const normalizeWiredActionChangeOpacity = (intData: readonly number[] = []): WiredActionChangeOpacityState => ({
+    visibility: intData[0] === WIRED_OPACITY_VISIBILITY_EVERYONE ? WIRED_OPACITY_VISIBILITY_EVERYONE : WIRED_OPACITY_VISIBILITY_SOURCE_USERS,
+    opacity: clampInteger(intData[1] ?? WIRED_OPACITY_MAXIMUM, WIRED_OPACITY_MINIMUM, WIRED_OPACITY_MAXIMUM),
+    easing: clampInteger(intData[2] ?? WIRED_OPACITY_EASING_INSTANT, 0, 4),
+    duration: normalizeDuration(intData[3] ?? WIRED_OPACITY_DEFAULT_DURATION),
+    furniSource: hasSource(FURNI_SOURCES, intData[4]) ? intData[4] : WIRED_OPACITY_SELECTED_FURNI_SOURCE,
+    userSource: hasSource(USER_SOURCES, intData[5]) ? intData[5] : WIRED_OPACITY_TRIGGER_USER_SOURCE,
+    clickThrough: intData[6] === 1
+});
+
+export const serializeWiredActionChangeOpacity = (state: WiredActionChangeOpacityState) => {
+    const normalized = normalizeWiredActionChangeOpacity([
+        state.visibility,
+        state.opacity,
+        state.easing,
+        state.duration,
+        state.furniSource,
+        state.userSource,
+        state.clickThrough ? 1 : 0
+    ]);
+
+    return [
+        normalized.visibility,
+        normalized.opacity,
+        normalized.easing,
+        normalized.duration,
+        normalized.furniSource,
+        normalized.userSource,
+        normalized.clickThrough ? 1 : 0
+    ];
+};

--- a/src/components/wired/views/actions/WiredActionChangeOpacityView.tsx
+++ b/src/components/wired/views/actions/WiredActionChangeOpacityView.tsx
@@ -1,0 +1,140 @@
+import { FC, useEffect, useState } from 'react';
+import { localizeWithFallback, WiredFurniType } from '../../../../api';
+import { Slider, Text } from '../../../../common';
+import { useWired } from '../../../../hooks';
+import { WiredSourcesSelector } from '../WiredSourcesSelector';
+import { WiredActionBaseView } from './WiredActionBaseView';
+import {
+    normalizeWiredActionChangeOpacity,
+    serializeWiredActionChangeOpacity,
+    WIRED_OPACITY_DEFAULT_DURATION,
+    WIRED_OPACITY_EASING_INSTANT,
+    WIRED_OPACITY_MAXIMUM,
+    WIRED_OPACITY_MAXIMUM_DURATION,
+    WIRED_OPACITY_MINIMUM,
+    WIRED_OPACITY_SELECTED_FURNI_SOURCE,
+    WIRED_OPACITY_VISIBILITY_EVERYONE,
+    WIRED_OPACITY_VISIBILITY_SOURCE_USERS,
+    WiredActionChangeOpacityState
+} from './WiredActionChangeOpacityState';
+
+const EASING_OPTIONS = [
+    { value: WIRED_OPACITY_EASING_INSTANT, label: 'Instant' },
+    { value: 1, label: 'Linear' },
+    { value: 2, label: 'Ease in' },
+    { value: 3, label: 'Ease out' },
+    { value: 4, label: 'Ease in-out' }
+];
+
+export const WiredActionChangeOpacityView: FC<{}> = () => {
+    const { trigger = null, setFurniIds = null, setIntParams = null } = useWired();
+    const [state, setState] = useState<WiredActionChangeOpacityState>(() => normalizeWiredActionChangeOpacity(trigger?.intData));
+
+    useEffect(() => {
+        setState(normalizeWiredActionChangeOpacity(trigger?.intData));
+    }, [trigger]);
+
+    const update = (patch: Partial<WiredActionChangeOpacityState>) => setState((current) => ({ ...current, ...patch }));
+    const save = () => {
+        setIntParams(serializeWiredActionChangeOpacity(state));
+        if (state.furniSource !== WIRED_OPACITY_SELECTED_FURNI_SOURCE) setFurniIds?.([]);
+    };
+
+    return (
+        <WiredActionBaseView
+            hasSpecialInput={true}
+            requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_BY_ID_BY_TYPE_OR_FROM_CONTEXT}
+            save={save}
+            footer={
+                <WiredSourcesSelector
+                    showFurni={true}
+                    showUsers={state.visibility === WIRED_OPACITY_VISIBILITY_SOURCE_USERS}
+                    furniSource={state.furniSource}
+                    userSource={state.userSource}
+                    onChangeFurni={(furniSource) => update({ furniSource })}
+                    onChangeUsers={(userSource) => update({ userSource })}
+                />
+            }
+        >
+            <div className="flex flex-col gap-2">
+                <Text bold>{localizeWithFallback('wiredfurni.params.opacity.visibility_selection.title', 'Who should see this opacity change?')}</Text>
+                <label className="flex items-center gap-1">
+                    <input
+                        checked={state.visibility === WIRED_OPACITY_VISIBILITY_SOURCE_USERS}
+                        className="form-check-input"
+                        name="wiredOpacityVisibility"
+                        type="radio"
+                        onChange={() => update({ visibility: WIRED_OPACITY_VISIBILITY_SOURCE_USERS })}
+                    />
+                    <Text>{localizeWithFallback('wiredfurni.params.show_message.visibility_selection.0', 'Only the selected users')}</Text>
+                </label>
+                <label className="flex items-center gap-1">
+                    <input
+                        checked={state.visibility === WIRED_OPACITY_VISIBILITY_EVERYONE}
+                        className="form-check-input"
+                        name="wiredOpacityVisibility"
+                        type="radio"
+                        onChange={() => update({ visibility: WIRED_OPACITY_VISIBILITY_EVERYONE })}
+                    />
+                    <Text>{localizeWithFallback('wiredfurni.params.show_message.visibility_selection.1', 'Everyone in the room')}</Text>
+                </label>
+            </div>
+
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center justify-between gap-2">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.opacity.visibility_amount', 'Opacity')}</Text>
+                    <input
+                        aria-label="Opacity percentage"
+                        className="form-control form-control-sm max-w-[80px]"
+                        max={WIRED_OPACITY_MAXIMUM}
+                        min={WIRED_OPACITY_MINIMUM}
+                        type="number"
+                        value={state.opacity}
+                        onChange={(event) => update({ opacity: Number(event.target.value) })}
+                    />
+                </div>
+                <Slider
+                    max={WIRED_OPACITY_MAXIMUM}
+                    min={WIRED_OPACITY_MINIMUM}
+                    step={1}
+                    value={state.opacity}
+                    onChange={(opacity) => update({ opacity: opacity as number })}
+                />
+                <label className="flex items-center gap-1">
+                    <input
+                        checked={state.clickThrough}
+                        className="form-check-input"
+                        type="checkbox"
+                        onChange={(event) => update({ clickThrough: event.target.checked })}
+                    />
+                    <Text>{localizeWithFallback('wiredfurni.params.opacity.clickthrough', 'Allow clicks to pass through transparent furni')}</Text>
+                </label>
+            </div>
+
+            <div className="flex flex-col gap-1">
+                <Text bold>{localizeWithFallback('wiredfurni.params.easing_function', 'Transition')}</Text>
+                <select className="form-select form-select-sm" value={state.easing} onChange={(event) => update({ easing: Number(event.target.value) })}>
+                    {EASING_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+                {state.easing !== WIRED_OPACITY_EASING_INSTANT && (
+                    <label className="flex items-center justify-between gap-2">
+                        <Text>{localizeWithFallback('wiredfurni.params.variables.duration', 'Duration (seconds, 0 = default)')}</Text>
+                        <input
+                            aria-label="Transition duration in seconds, 0 uses the default transition"
+                            className="form-control form-control-sm max-w-[80px]"
+                            max={WIRED_OPACITY_MAXIMUM_DURATION}
+                            min={WIRED_OPACITY_DEFAULT_DURATION}
+                            type="number"
+                            value={state.duration}
+                            onChange={(event) => update({ duration: Number(event.target.value) })}
+                        />
+                    </label>
+                )}
+            </div>
+        </WiredActionBaseView>
+    );
+};

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -66,6 +66,7 @@ import { WiredActionBotTalkView } from './WiredActionBotTalkView';
 import { WiredActionBotTeleportView } from './WiredActionBotTeleportView';
 import { WiredActionCallAnotherStackView } from './WiredActionCallAnotherStackView';
 import { WiredActionCancelTransactionView } from './WiredActionCancelTransactionView';
+import { WiredActionChangeOpacityView } from './WiredActionChangeOpacityView';
 import { WiredActionChangeVariableValueView } from './WiredActionChangeVariableValueView';
 import { WiredActionChaseView } from './WiredActionChaseView';
 import { WiredActionChatView } from './WiredActionChatView';
@@ -332,6 +333,8 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredContractTradeView />;
         case WiredActionLayoutCode.CUSTOM_CONTRACT:
             return <WiredCustomContractView />;
+        case WiredActionLayoutCode.CHANGE_OPACITY:
+            return <WiredActionChangeOpacityView />;
     }
 
     return null;

--- a/src/hooks/rooms/WiredFurniOpacityController.test.ts
+++ b/src/hooks/rooms/WiredFurniOpacityController.test.ts
@@ -1,0 +1,183 @@
+import { RoomObjectCategory, RoomObjectVariable } from '@nitrots/nitro-renderer';
+import { describe, expect, it } from 'vitest';
+import {
+    clampWiredOpacity,
+    WiredFurniOpacityController,
+    WiredOpacityFrameScheduler,
+    WiredOpacityObject,
+    WiredOpacityObjectModel,
+    WiredOpacityObjectSource,
+    wiredOpacityEasing
+} from './WiredFurniOpacityController';
+
+class TestModel implements WiredOpacityObjectModel
+{
+    readonly values = new Map<string, unknown>();
+
+    getValue<T>(key: string): T
+    {
+        return this.values.get(key) as T;
+    }
+
+    setValue<T>(key: string, value: T): void
+    {
+        this.values.set(key, value);
+    }
+}
+
+class TestObjects implements WiredOpacityObjectSource
+{
+    readonly values = new Map<string, WiredOpacityObject>();
+
+    key(roomId: number, itemId: number, category: number): string
+    {
+        return `${roomId}:${category}:${itemId}`;
+    }
+
+    add(roomId: number, itemId: number, category: number): TestModel
+    {
+        const model = new TestModel();
+        this.values.set(this.key(roomId, itemId, category), { model });
+        return model;
+    }
+
+    getObject(roomId: number, itemId: number, category: number): WiredOpacityObject
+    {
+        return this.values.get(this.key(roomId, itemId, category));
+    }
+}
+
+class TestFrames implements WiredOpacityFrameScheduler
+{
+    currentTime = 1000;
+    nextHandle = 1;
+    requested = new Map<number, (time: number) => void>();
+    cancelled: number[] = [];
+
+    now(): number
+    {
+        return this.currentTime;
+    }
+
+    request(callback: (time: number) => void): number
+    {
+        const handle = this.nextHandle++;
+        this.requested.set(handle, callback);
+        return handle;
+    }
+
+    cancel(handle: number): void
+    {
+        this.cancelled.push(handle);
+        this.requested.delete(handle);
+    }
+
+    run(time: number): void
+    {
+        const entry = this.requested.entries().next().value as [ number, (time: number) => void ];
+        expect(entry).toBeTruthy();
+        this.requested.delete(entry[0]);
+        this.currentTime = time;
+        entry[1](time);
+    }
+}
+
+const update = (itemId: number, opacity: number, durationMs = 0, easing = 0, wallItem = false) => ({
+    itemId,
+    wallItem,
+    opacity,
+    clickThrough: true,
+    easing,
+    durationMs
+});
+
+describe('WiredFurniOpacityController', () =>
+{
+    it('owns one animation frame for every active object and lands exactly on target', () =>
+    {
+        const objects = new TestObjects();
+        const frames = new TestFrames();
+        const first = objects.add(7, 1, RoomObjectCategory.FLOOR);
+        const second = objects.add(7, 2, RoomObjectCategory.FLOOR);
+        const controller = new WiredFurniOpacityController(objects, frames);
+        controller.setRoom(7);
+
+        controller.apply(7, [ update(1, 20, 1000, 1), update(2, 60, 1000, 1) ]);
+
+        expect(frames.requested.size).toBe(1);
+        expect(controller.pendingAnimationCount()).toBe(2);
+        frames.run(1500);
+        expect(first.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBeCloseTo(0.6);
+        expect(second.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBeCloseTo(0.8);
+        expect(frames.requested.size).toBe(1);
+        frames.run(2000);
+        expect(first.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBe(0.2);
+        expect(second.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBe(0.6);
+        expect(controller.pendingAnimationCount()).toBe(0);
+        expect(frames.requested.size).toBe(0);
+    });
+
+    it('replacement starts from the rendered value rather than the stale original target', () =>
+    {
+        const objects = new TestObjects();
+        const frames = new TestFrames();
+        const model = objects.add(8, 3, RoomObjectCategory.FLOOR);
+        const controller = new WiredFurniOpacityController(objects, frames);
+        controller.setRoom(8);
+        controller.apply(8, [ update(3, 0, 1000, 1) ]);
+        frames.run(1500);
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBeCloseTo(0.5);
+
+        controller.apply(8, [ update(3, 100, 1000, 1) ]);
+        frames.run(2000);
+
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBeCloseTo(0.75);
+        expect(controller.pendingAnimationCount()).toBe(1);
+    });
+
+    it('retains a missing-object target and applies final state when the object appears', () =>
+    {
+        const objects = new TestObjects();
+        const frames = new TestFrames();
+        const controller = new WiredFurniOpacityController(objects, frames);
+        controller.setRoom(9);
+        controller.apply(9, [ update(4, 35, 500, 2, true) ]);
+
+        expect(frames.requested.size).toBe(0);
+        const model = objects.add(9, 4, RoomObjectCategory.WALL);
+        controller.objectAdded(9, 4, RoomObjectCategory.WALL);
+
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBe(0.35);
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_CLICK_THROUGH)).toBe(1);
+    });
+
+    it('cancels and restores room state on removal, room switch and disposal', () =>
+    {
+        const objects = new TestObjects();
+        const frames = new TestFrames();
+        const model = objects.add(10, 5, RoomObjectCategory.FLOOR);
+        const controller = new WiredFurniOpacityController(objects, frames);
+        controller.setRoom(10);
+        controller.apply(10, [ update(5, 10, 1000, 1) ]);
+        controller.objectRemoved(10, 5, RoomObjectCategory.FLOOR);
+        expect(controller.pendingAnimationCount()).toBe(0);
+        expect(frames.cancelled).toHaveLength(1);
+
+        controller.apply(10, [ update(5, 25) ]);
+        controller.setRoom(11);
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY)).toBe(1);
+        expect(model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_CLICK_THROUGH)).toBe(0);
+        controller.dispose();
+    });
+
+    it('clamps inputs and freezes the documented easing curves', () =>
+    {
+        expect(clampWiredOpacity(Number.NaN)).toBe(100);
+        expect(clampWiredOpacity(-1)).toBe(0);
+        expect(clampWiredOpacity(101)).toBe(100);
+        expect(wiredOpacityEasing(0.5, 1)).toBe(0.5);
+        expect(wiredOpacityEasing(0.5, 2)).toBe(0.125);
+        expect(wiredOpacityEasing(0.5, 3)).toBe(0.875);
+        expect(wiredOpacityEasing(0.5, 4)).toBe(0.5);
+    });
+});

--- a/src/hooks/rooms/WiredFurniOpacityController.ts
+++ b/src/hooks/rooms/WiredFurniOpacityController.ts
@@ -1,0 +1,237 @@
+import { RoomObjectCategory, RoomObjectVariable, WiredFurniOpacityUpdate } from '@nitrots/nitro-renderer';
+
+export interface WiredOpacityObjectModel {
+    getValue<T>(key: string): T;
+    setValue<T>(key: string, value: T): void;
+}
+
+export interface WiredOpacityObject {
+    model?: WiredOpacityObjectModel;
+}
+
+export interface WiredOpacityObjectSource {
+    getObject(roomId: number, itemId: number, category: number): WiredOpacityObject;
+}
+
+export interface WiredOpacityFrameScheduler {
+    now(): number;
+    request(callback: (time: number) => void): number;
+    cancel(handle: number): void;
+}
+
+interface TargetState {
+    itemId: number;
+    category: number;
+    opacity: number;
+    clickThrough: boolean;
+}
+
+interface AnimationState extends TargetState {
+    startOpacity: number;
+    startedAt: number;
+    durationMs: number;
+    easing: number;
+}
+
+const MAXIMUM_UPDATES = 1000;
+
+const stateKey = (category: number, itemId: number) => `${category}:${itemId}`;
+
+export const clampWiredOpacity = (value: number): number => {
+    if (!Number.isFinite(value)) return 100;
+
+    return Math.max(0, Math.min(100, value));
+};
+
+export const wiredOpacityEasing = (progress: number, easing: number): number => {
+    const normalized = Math.max(0, Math.min(1, progress));
+
+    switch (easing) {
+        case 2:
+            return normalized * normalized * normalized;
+        case 3:
+            return 1 - Math.pow(1 - normalized, 3);
+        case 4:
+            return normalized < 0.5 ? 4 * normalized * normalized * normalized : 1 - Math.pow(-2 * normalized + 2, 3) / 2;
+        case 1:
+        default:
+            return normalized;
+    }
+};
+
+/** One bounded animation owner for every wired-opacity object in the active room. */
+export class WiredFurniOpacityController {
+    private activeRoomId = 0;
+    private readonly targets = new Map<string, TargetState>();
+    private readonly animations = new Map<string, AnimationState>();
+    private frameHandle: number = null;
+
+    constructor(
+        private readonly objects: WiredOpacityObjectSource,
+        private readonly frames: WiredOpacityFrameScheduler
+    ) {}
+
+    public setRoom(roomId: number): void {
+        const normalized = Math.max(0, roomId || 0);
+
+        if (normalized === this.activeRoomId) return;
+
+        this.clear(true);
+        this.activeRoomId = normalized;
+    }
+
+    public apply(roomId: number, updates: readonly WiredFurniOpacityUpdate[]): void {
+        if (roomId <= 0 || roomId !== this.activeRoomId || !updates?.length) return;
+
+        const deduplicated = new Map<string, WiredFurniOpacityUpdate>();
+
+        for (const update of updates.slice(0, MAXIMUM_UPDATES)) {
+            if (!update || update.itemId <= 0) continue;
+
+            const category = update.wallItem ? RoomObjectCategory.WALL : RoomObjectCategory.FLOOR;
+            deduplicated.set(stateKey(category, update.itemId), update);
+        }
+
+        for (const [key, update] of [...deduplicated.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+            this.applyOne(key, update);
+        }
+
+        this.scheduleFrame();
+    }
+
+    public objectAdded(roomId: number, itemId: number, category: number): void {
+        if (roomId !== this.activeRoomId) return;
+
+        const target = this.targets.get(stateKey(category, itemId));
+
+        if (!target) return;
+
+        this.animations.delete(stateKey(category, itemId));
+        this.applyModel(target, target.opacity);
+    }
+
+    public objectRemoved(roomId: number, itemId: number, category: number): void {
+        if (roomId !== this.activeRoomId) return;
+
+        const key = stateKey(category, itemId);
+        this.targets.delete(key);
+        this.animations.delete(key);
+        this.cancelFrameWhenIdle();
+    }
+
+    public dispose(): void {
+        this.clear(true);
+        this.activeRoomId = 0;
+    }
+
+    public pendingAnimationCount(): number {
+        return this.animations.size;
+    }
+
+    private applyOne(key: string, update: WiredFurniOpacityUpdate): void {
+        const target: TargetState = {
+            itemId: update.itemId,
+            category: update.wallItem ? RoomObjectCategory.WALL : RoomObjectCategory.FLOOR,
+            opacity: clampWiredOpacity(update.opacity),
+            clickThrough: update.clickThrough === true
+        };
+        this.targets.set(key, target);
+        this.animations.delete(key);
+
+        const model = this.model(target);
+
+        if (!model) return;
+
+        model.setValue(RoomObjectVariable.FURNITURE_WIRED_CLICK_THROUGH, target.clickThrough ? 1 : 0);
+        const current = model.getValue<number>(RoomObjectVariable.FURNITURE_WIRED_OPACITY);
+        const startOpacity = Number.isFinite(current) ? clampWiredOpacity(current * 100) : 100;
+        const durationMs = Math.max(0, Math.min(10000, update.durationMs));
+        const easing = Math.max(0, Math.min(4, update.easing));
+
+        if (easing === 0 || durationMs === 0 || startOpacity === target.opacity) {
+            this.setOpacity(model, target.opacity);
+            return;
+        }
+
+        this.animations.set(key, {
+            ...target,
+            startOpacity,
+            startedAt: this.frames.now(),
+            durationMs,
+            easing
+        });
+    }
+
+    private scheduleFrame(): void {
+        if (this.frameHandle !== null || !this.animations.size) return;
+
+        this.frameHandle = this.frames.request((time) => this.onFrame(time));
+    }
+
+    private onFrame(time: number): void {
+        this.frameHandle = null;
+
+        for (const [key, animation] of this.animations) {
+            const model = this.model(animation);
+
+            if (!model) {
+                this.animations.delete(key);
+                continue;
+            }
+
+            const progress = Math.max(0, Math.min(1, (time - animation.startedAt) / animation.durationMs));
+            const eased = wiredOpacityEasing(progress, animation.easing);
+            const opacity = animation.startOpacity + (animation.opacity - animation.startOpacity) * eased;
+            this.setOpacity(model, progress >= 1 ? animation.opacity : opacity);
+
+            if (progress >= 1) this.animations.delete(key);
+        }
+
+        this.scheduleFrame();
+    }
+
+    private model(target: TargetState): WiredOpacityObjectModel {
+        return this.objects.getObject(this.activeRoomId, target.itemId, target.category)?.model ?? null;
+    }
+
+    private applyModel(target: TargetState, opacity: number): void {
+        const model = this.model(target);
+
+        if (!model) return;
+
+        model.setValue(RoomObjectVariable.FURNITURE_WIRED_CLICK_THROUGH, target.clickThrough ? 1 : 0);
+        this.setOpacity(model, opacity);
+    }
+
+    private setOpacity(model: WiredOpacityObjectModel, opacity: number): void {
+        model.setValue(RoomObjectVariable.FURNITURE_WIRED_OPACITY, clampWiredOpacity(opacity) / 100);
+    }
+
+    private clear(resetModels: boolean): void {
+        if (this.frameHandle !== null) {
+            this.frames.cancel(this.frameHandle);
+            this.frameHandle = null;
+        }
+
+        if (resetModels) {
+            for (const target of this.targets.values()) {
+                const model = this.model(target);
+
+                if (!model) continue;
+
+                model.setValue(RoomObjectVariable.FURNITURE_WIRED_OPACITY, 1);
+                model.setValue(RoomObjectVariable.FURNITURE_WIRED_CLICK_THROUGH, 0);
+            }
+        }
+
+        this.animations.clear();
+        this.targets.clear();
+    }
+
+    private cancelFrameWhenIdle(): void {
+        if (this.animations.size || this.frameHandle === null) return;
+
+        this.frames.cancel(this.frameHandle);
+        this.frameHandle = null;
+    }
+}

--- a/src/hooks/rooms/useRoom.ts
+++ b/src/hooks/rooms/useRoom.ts
@@ -34,6 +34,7 @@ import {
     StartRoomSession
 } from '../../api';
 import { useMessageEvent, useNitroEvent, useUiEvent } from '../events';
+import { useWiredFurniOpacity } from './useWiredFurniOpacity';
 
 const getViewportSize = () => {
     const viewport = window.visualViewport;
@@ -50,6 +51,8 @@ const useRoomState = () => {
     const [roomBackground, setRoomBackground] = useState<NitroSprite>(null);
     const [roomFilter, setRoomFilter] = useState<NitroAdjustmentFilter>(null);
     const [originalRoomBackgroundColor, setOriginalRoomBackgroundColor] = useState(0);
+
+    useWiredFurniOpacity(roomSession?.roomId ?? 0);
 
     const updateRoomBackgroundColor = (hue: number, saturation: number, lightness: number, original: boolean = false) => {
         if (!roomBackground) return;

--- a/src/hooks/rooms/useWiredFurniOpacity.ts
+++ b/src/hooks/rooms/useWiredFurniOpacity.ts
@@ -1,0 +1,53 @@
+import { GetRoomEngine, RoomEngineObjectEvent, RoomObjectCategory, WiredFeatureCapabilitiesComposer, WiredFurniOpacityEvent } from '@nitrots/nitro-renderer';
+import { useEffect, useRef } from 'react';
+import { SendMessageComposer } from '../../api';
+import { useMessageEvent, useNitroEvent } from '../events';
+import { WiredFurniOpacityController } from './WiredFurniOpacityController';
+
+const WIRED_FEATURE_PROTOCOL_VERSION = 1;
+const WIRED_FEATURE_OPACITY = 1;
+
+export const useWiredFurniOpacity = (roomId: number): void => {
+    const controllerRef = useRef<WiredFurniOpacityController>(null);
+
+    if (!controllerRef.current) {
+        controllerRef.current = new WiredFurniOpacityController(
+            {
+                getObject: (activeRoomId, itemId, category) => GetRoomEngine().getRoomObject(activeRoomId, itemId, category)
+            },
+            {
+                now: () => performance.now(),
+                request: (callback) => requestAnimationFrame(callback),
+                cancel: (handle) => cancelAnimationFrame(handle)
+            }
+        );
+    }
+
+    useMessageEvent<WiredFurniOpacityEvent>(WiredFurniOpacityEvent, (event) => {
+        const parser = event.getParser();
+
+        if (!parser) return;
+
+        controllerRef.current.apply(parser.roomId, parser.updates);
+    });
+
+    useNitroEvent<RoomEngineObjectEvent>([RoomEngineObjectEvent.ADDED, RoomEngineObjectEvent.REMOVED], (event) => {
+        if (event.category !== RoomObjectCategory.FLOOR && event.category !== RoomObjectCategory.WALL) return;
+
+        if (event.type === RoomEngineObjectEvent.ADDED) {
+            controllerRef.current.objectAdded(event.roomId, event.objectId, event.category);
+        } else {
+            controllerRef.current.objectRemoved(event.roomId, event.objectId, event.category);
+        }
+    });
+
+    useEffect(() => {
+        controllerRef.current.setRoom(roomId);
+
+        if (roomId > 0) {
+            SendMessageComposer(new WiredFeatureCapabilitiesComposer(WIRED_FEATURE_PROTOCOL_VERSION, WIRED_FEATURE_OPACITY));
+        }
+    }, [roomId]);
+
+    useEffect(() => () => controllerRef.current.dispose(), []);
+};


### PR DESCRIPTION
## What

- Adds the Change Furniture Opacity WIRED editor.
- Adds variable-picker support for opacity values.
- Connects room entry/exit to the opacity protocol.
- Applies snapshots and live updates through one room controller.
- Adds focused state/controller tests.

Pairs with Polaris Emulator #516 and duckietm/Nitro_Render_V3#138. Supersedes the opacity part of #338; its messenger work is separate.
