### PR TITLE
Match group windows to SWF layout

### DIFF
--- a/src/api/groups/GetGroupMembers.ts
+++ b/src/api/groups/GetGroupMembers.ts
@@ -1,6 +1,6 @@
 import { CreateLinkEvent } from '@nitrots/nitro-renderer';
 
 export function GetGroupMembers(groupId: number, levelId?: number): void {
-    if (!levelId) CreateLinkEvent(`group-members/${groupId}`);
+    if (levelId === undefined || levelId === null) CreateLinkEvent(`group-members/${groupId}/0`);
     else CreateLinkEvent(`group-members/${groupId}/${levelId}`);
 }

--- a/src/components/groups/views/GroupInformationStandaloneView.tsx
+++ b/src/components/groups/views/GroupInformationStandaloneView.tsx
@@ -17,7 +17,7 @@ export const GroupInformationStandaloneView: FC<{}> = (props) => {
     if (!groupInformation) return null;
 
     return (
-        <NitroCardView className="nitro-groups-window nitro-group-information-standalone" theme="primary-slim">
+        <NitroCardView className="nitro-groups-window nitro-group-information-standalone" theme="primary-slim" isResizable={false}>
             <NitroCardHeaderView headerText={LocalizeText('group.window.title')} onCloseClick={(event) => setGroupInformation(null)} />
             <NitroCardContentView className="nitro-groups-content">
                 <GroupInformationView groupInformation={groupInformation} onClose={() => setGroupInformation(null)} />

--- a/src/components/groups/views/GroupInformationView.tsx
+++ b/src/components/groups/views/GroupInformationView.tsx
@@ -82,7 +82,7 @@ export const GroupInformationView: FC<GroupInformationViewProps> = (props) => {
     const handleAction = (action: string) => {
         switch (action) {
             case 'members':
-                GetGroupMembers(groupInformation.id);
+                GetGroupMembers(groupInformation.id, 0);
                 break;
             case 'members_pending':
                 GetGroupMembers(groupInformation.id, 2);
@@ -114,16 +114,40 @@ export const GroupInformationView: FC<GroupInformationViewProps> = (props) => {
                     <LayoutBadgeImageView badgeCode={groupInformation.badge} isGroup={true} scale={2.1} />
                 </div>
                 <div className="nitro-extended-profile-group-info__meta">
-                    <Text pointer small bold underline onClick={() => handleAction('members')}>
+                    <span
+                        className="nitro-extended-profile-group-info__member-link"
+                        role="button"
+                        tabIndex={0}
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={(event) => { event.stopPropagation(); handleAction('members'); }}
+                        onKeyDown={(event) => {
+                            if (event.key !== 'Enter' && event.key !== ' ') return;
+                            event.preventDefault();
+                            event.stopPropagation();
+                            handleAction('members');
+                        }}
+                    >
                         {LocalizeText('group.membercount', ['totalMembers'], [groupInformation.membersCount.toString()])}
-                    </Text>
+                    </span>
                     {groupInformation.pendingRequestsCount > 0 && (
-                        <Text pointer small underline onClick={() => handleAction('members_pending')}>
+                        <span
+                            className="nitro-extended-profile-group-info__member-link"
+                            role="button"
+                            tabIndex={0}
+                            onMouseDown={(event) => event.stopPropagation()}
+                            onClick={(event) => { event.stopPropagation(); handleAction('members_pending'); }}
+                            onKeyDown={(event) => {
+                                if (event.key !== 'Enter' && event.key !== ' ') return;
+                                event.preventDefault();
+                                event.stopPropagation();
+                                handleAction('members_pending');
+                            }}
+                        >
                             {LocalizeText('group.pendingmembercount', ['amount'], [groupInformation.pendingRequestsCount.toString()])}
-                        </Text>
+                        </span>
                     )}
                 </div>
-                <div className="nitro-extended-profile-group-info__role">{getRoleIcon()}</div>
+                <div className="nitro-extended-profile-group-info__role" aria-hidden="true">{getRoleIcon()}</div>
             </div>
             <div className="nitro-extended-profile-group-info__content">
                 <div className="nitro-extended-profile-group-info__header-copy">

--- a/src/components/groups/views/GroupMembersView.tsx
+++ b/src/components/groups/views/GroupMembersView.tsx
@@ -146,7 +146,7 @@ export const GroupMembersView: FC<{}> = (props) => {
                 if (parts.length < 2) return;
 
                 const groupId = parseInt(parts[1]) || -1;
-                const levelId = parseInt(parts[2]) || 3;
+                const levelId = Number.isInteger(parseInt(parts[2])) ? parseInt(parts[2]) : 0;
 
                 setGroupId(groupId);
                 setLevelId(levelId);
@@ -173,7 +173,6 @@ export const GroupMembersView: FC<{}> = (props) => {
     useEffect(() => {
         if (groupId === -1) return;
 
-        setLevelId(-1);
         setMembersData(null);
         setTotalPages(0);
         setSearchQuery('');
@@ -183,17 +182,17 @@ export const GroupMembersView: FC<{}> = (props) => {
     if (groupId === -1 || !membersData) return null;
 
     return (
-        <NitroCardView className="nitro-groups-window nitro-group-members w-[400px] max-h-[380px]" theme="primary-slim">
+        <NitroCardView className="nitro-groups-window nitro-group-members" theme="primary-slim" isResizable={false}>
             <NitroCardHeaderView
                 headerText={LocalizeText('group.members.title', ['groupName'], [membersData ? membersData.groupTitle : ''])}
                 onCloseClick={(event) => setGroupId(-1)}
             />
             <NitroCardContentView className="nitro-groups-content" overflow="hidden">
                 <div className="nitro-group-members-search flex gap-2">
-                    <Flex center className="group-badge">
+                    <Flex center className="group-badge nitro-group-members-search__badge">
                         <LayoutBadgeImageView badgeCode={membersData.badge} className="mx-auto block" isGroup={true} />
                     </Flex>
-                    <Column fullWidth gap={1}>
+                    <Column fullWidth gap={1} className="nitro-group-members-search__controls">
                         <input
                             className="nitro-groups-input min-h-[calc(1.5em+.5rem+2px)] px-[.5rem] py-[.25rem] text-[.7875rem] rounded-[.2rem] w-full"
                             placeholder={LocalizeText('group.members.searchinfo')}
@@ -211,21 +210,29 @@ export const GroupMembersView: FC<{}> = (props) => {
                 <Grid className="nitro-group-members-list-grid" columnCount={2} overflow="auto">
                     {membersData.result.map((member, index) => {
                         return (
-                            <Flex key={index} alignItems="center" className="nitro-group-member-row p-2 bg-white rounded h-[50px] max-h-[50px]" gap={2} overflow="hidden">
-                                <div className="cursor-pointer relative overflow-hidden w-[40px] h-[50px]" onClick={() => GetUserProfile(member.id)}>
-                                    <LayoutAvatarImageView className="absolute -left-[25px] -top-[20px]" direction={2} figure={member.figure} headOnly={true} />
+                            <Flex key={index} alignItems="center" className="nitro-group-member-row" gap={0} overflow="hidden">
+                                <div className="nitro-group-member-row__avatar cursor-pointer" onClick={() => GetUserProfile(member.id)}>
+                                    <LayoutAvatarImageView
+                                        className="nitro-group-member-row__head"
+                                        direction={2}
+                                        figure={member.figure}
+                                        headOnly={true}
+                                        compactHead
+                                        compactHeadSize={40}
+                                        compactHeadPadding={0}
+                                    />
                                 </div>
-                                <Column grow gap={1}>
-                                    <Text bold pointer small onClick={(event) => GetUserProfile(member.id)}>
+                                <Column className="nitro-group-member-row__copy" grow gap={0}>
+                                    <Text bold pointer small className="nitro-group-member-row__name" onClick={(event) => GetUserProfile(member.id)}>
                                         {member.name}
                                     </Text>
                                     {member.rank !== GroupRank.REQUESTED && (
-                                        <Text italics small variant="muted">
+                                        <Text italics small variant="muted" className="nitro-group-member-row__since">
                                             {LocalizeText('group.members.since', ['date'], [member.joinedAt])}
                                         </Text>
                                     )}
                                 </Column>
-                                <div className="flex flex-col gap-1">
+                                <div className="nitro-group-member-row__actions">
                                     {member.rank !== GroupRank.REQUESTED && (
                                         <div className="flex items-center justify-center">
                                             <div
@@ -261,17 +268,29 @@ export const GroupMembersView: FC<{}> = (props) => {
                         );
                     })}
                 </Grid>
-                <Flex alignItems="center" gap={1} justifyContent="between" className="nitro-groups-footer">
+                <Flex alignItems="center" gap={1} justifyContent="between" className="nitro-groups-footer nitro-group-members-footer">
                     <Button className="nitro-groups-button nitro-groups-button--pager" disabled={pageId <= 0} onClick={(event) => setPageId((prevValue) => Math.max(0, prevValue - 1))}>
                         <FaChevronLeft className="fa-icon" />
                     </Button>
-                    <Text small>
-                        {LocalizeText(
-                            'group.members.pageinfo',
-                            ['amount', 'page', 'totalPages'],
-                            [membersData.totalMembersCount.toString(), (membersData.pageIndex + 1).toString(), totalPages.toString()]
-                        )}
-                    </Text>
+                    <div className="nitro-group-members-footer__page">
+                        <Text small className="nitro-group-members-footer__label">
+                            {membersData.totalMembersCount} Habbo Membri. Pagina
+                        </Text>
+                        <input
+                            className="nitro-group-members-footer__input"
+                            type="number"
+                            min={1}
+                            max={Math.max(1, totalPages)}
+                            value={membersData.pageIndex + 1}
+                            onChange={(event) => {
+                                const value = Math.min(Math.max(parseInt(event.target.value) || 1, 1), Math.max(1, totalPages));
+                                setPageId(value - 1);
+                            }}
+                        />
+                        <Text small className="nitro-group-members-footer__total">
+                            / {Math.max(1, totalPages)}
+                        </Text>
+                    </div>
                     <Button
                         className="nitro-groups-button nitro-groups-button--pager"
                         disabled={totalPages === 0 || pageId >= totalPages - 1}

--- a/src/css/groups/GroupView.css
+++ b/src/css/groups/GroupView.css
@@ -116,45 +116,436 @@
     border-image-source: var(--habbo-skin-shiny-pressed) !important;
 }
 
+.nitro-group-information-standalone {
+    width: 365px !important;
+    height: 267px !important;
+    resize: none !important;
+}
+
+.nitro-group-information-standalone .nitro-card-content-shell,
+.nitro-group-information-standalone .nitro-groups-content {
+    width: 365px !important;
+    height: 234px !important;
+    padding: 0 !important;
+    overflow: visible !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info {
+    position: relative;
+    display: block !important;
+    width: 343px !important;
+    height: 212px !important;
+    min-height: 0 !important;
+    max-height: 212px !important;
+    box-sizing: border-box !important;
+    margin: 10px 11px 0 !important;
+    padding: 0 !important;
+    border: 1px solid #77776f !important;
+    border-radius: 5px !important;
+    background: #cccccc !important;
+    color: #000000;
+    font-size: 12px;
+    overflow: hidden !important;
+    clip-path: inset(0 round 5px);
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__badge-column {
+    position: absolute;
+    left: 14px !important;
+    top: 16px !important;
+    width: 105px !important;
+    height: 134px !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__badge-wrap {
+    position: absolute;
+    left: 0 !important;
+    top: 0 !important;
+    width: 80px !important;
+    height: 80px !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__badge-wrap .group-badge {
+    flex: 0 0 auto;
+    min-width: 80px;
+    min-height: 80px;
+    background-size: auto !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    image-rendering: pixelated;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__badge-wrap img {
+    width: auto;
+    height: auto;
+    image-rendering: pixelated;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__meta {
+    position: absolute;
+    left: 0 !important;
+    top: 85px !important;
+    width: 82px !important;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__member-link {
+    display: block;
+    width: 82px !important;
+    height: 17px;
+    padding: 0 !important;
+    border: 0 !important;
+    border-image: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    color: #000000 !important;
+    font-weight: 700;
+    font-size: 12px;
+    text-align: center;
+    text-decoration: underline;
+    line-height: 17px;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__role {
+    display: block !important;
+    position: absolute !important;
+    left: 30px !important;
+    top: 118px !important;
+    width: 20px !important;
+    height: 20px !important;
+    z-index: 2;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__content {
+    position: absolute;
+    left: 116px !important;
+    top: 11px !important;
+    width: 196px !important;
+    height: 190px !important;
+    display: block;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy {
+    position: absolute;
+    left: 0 !important;
+    top: 0 !important;
+    width: 196px !important;
+    height: 47px !important;
+    display: block;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy > .flex {
+    display: block !important;
+    width: 196px !important;
+    height: 16px !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy > .flex > .flex {
+    display: none !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy .text-bold,
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy b,
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy .fw-bold {
+    display: block !important;
+    width: 196px !important;
+    height: 16px !important;
+    color: #111111 !important;
+    font-size: 12px !important;
+    font-weight: 700 !important;
+    line-height: 16px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__header-copy > .text {
+    display: block !important;
+    position: absolute !important;
+    left: 0 !important;
+    top: 16px !important;
+    width: 196px !important;
+    height: 15px !important;
+    color: #111111 !important;
+    font-size: 11px !important;
+    line-height: 15px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__description {
+    position: absolute;
+    left: 0;
+    top: 32px !important;
+    width: 194px !important;
+    height: 31px !important;
+    padding: 0;
+    color: #000000 !important;
+    font-size: 12px !important;
+    line-height: 15px !important;
+    overflow: hidden !important;
+    word-break: normal;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__links {
+    position: absolute;
+    left: 0;
+    top: 84px !important;
+    width: 190px !important;
+    height: 58px !important;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__links .text,
+.nitro-group-information-standalone .nitro-extended-profile-group-info__links span {
+    color: #000000 !important;
+    font-size: 12px;
+    line-height: 16px;
+    text-decoration: underline;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__button {
+    position: absolute;
+    left: -2px !important;
+    top: 168px !important;
+    width: 160px !important;
+    height: 29px !important;
+    min-height: 29px !important;
+    box-sizing: border-box !important;
+    border: 2px solid #111111 !important;
+    border-image: none !important;
+    border-radius: 3px !important;
+    background: linear-gradient(180deg, #ffffff 0%, #f4f4f2 48%, #d5d5d1 100%) !important;
+    color: #111111 !important;
+    text-shadow: none !important;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.95),
+        inset 0 -1px 0 #a6a6a0 !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__button:hover {
+    background: linear-gradient(180deg, #ffffff 0%, #fafaf8 48%, #e0e0dc 100%) !important;
+}
+
+.nitro-group-information-standalone .nitro-extended-profile-group-info__button .text-white,
+.nitro-group-information-standalone .nitro-extended-profile-group-info__button span {
+    color: #111111 !important;
+    text-shadow: none !important;
+}
+
+.nitro-group-members {
+    width: 332px;
+    height: 431px;
+    resize: none !important;
+}
+
+.nitro-group-members .nitro-card-content-shell,
+.nitro-group-members .nitro-groups-content {
+    position: relative;
+    width: 332px;
+    height: 398px;
+    padding: 0 !important;
+    overflow: hidden !important;
+    background: #eeeee7 !important;
+}
+
 .nitro-group-members-search {
-    padding: 6px;
-    border: 1px solid #b4b4ad;
-    border-radius: 6px;
-    background: #f7f7f2;
+    position: absolute;
+    left: 6px;
+    top: 0;
+    width: 320px;
+    height: 77px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+
+.nitro-group-members-search__badge {
+    position: absolute;
+    left: 17px;
+    top: 22px;
+    width: 39px;
+    height: 39px;
+    min-width: 39px;
+    min-height: 39px;
+    background-size: auto !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    image-rendering: pixelated;
+}
+
+.nitro-group-members-search .flex-column,
+.nitro-group-members-search .d-flex.flex-column,
+.nitro-group-members-search > .column {
+    position: absolute;
+    left: 78px;
+    top: 14px;
+    width: 230px;
+    height: 59px;
+    gap: 9px !important;
+}
+
+.nitro-group-members-search input {
+    width: 214px !important;
+    height: 25px !important;
+    min-height: 25px !important;
+    padding: 2px 6px !important;
+    font-size: 13px !important;
+}
+
+.nitro-group-members-search select {
+    width: 230px !important;
+    height: 25px !important;
+    min-height: 25px !important;
+    padding: 2px 6px !important;
+    font-size: 13px !important;
 }
 
 .nitro-group-members-list-grid {
-    padding: 4px;
-    border: 1px solid #b4b4ad;
-    border-radius: 6px;
-    background: #d7d7d0;
+    position: absolute;
+    left: 4px;
+    top: 82px;
+    width: 324px;
+    height: 277px;
+    display: grid !important;
+    grid-template-columns: repeat(2, 164px) !important;
+    grid-auto-rows: 35px;
+    gap: 0 0 !important;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
 }
 
 .nitro-group-member-row {
-    border: 1px solid #b4b4ad !important;
-    border-radius: 5px !important;
-    background: #f2f2ed !important;
-    box-shadow: inset 0 1px 0 #ffffff;
-    color: #111111;
+    position: relative;
+    width: 164px !important;
+    height: 35px !important;
+    min-height: 35px !important;
+    max-height: 35px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    color: #000000;
 }
 
 .nitro-group-member-row:hover {
-    background: #ffffff !important;
+    background: rgba(255, 255, 255, .35) !important;
 }
 
-.nitro-group-information-standalone {
-    width: 360px;
+.nitro-group-member-row__avatar {
+    position: absolute;
+    left: -3px;
+    top: 0;
+    width: 33px;
+    height: 34px;
+    overflow: hidden;
 }
 
-.nitro-extended-profile-group-info {
-    background: #d6d6d1;
-    border: 1px solid #7b7b75;
-    border-radius: 7px;
-    color: #111111;
+.nitro-group-member-row__head {
+    position: absolute;
+    left: 50%;
+    top: -12px;
+    width: auto !important;
+    height: auto !important;
+    transform: translateX(-50%);
+    image-rendering: pixelated;
 }
 
-.nitro-extended-profile-group-info__button {
-    min-height: 26px;
+.nitro-group-member-row__copy {
+    position: absolute;
+    left: 33px;
+    top: 1px;
+    width: 94px;
+    height: 31px;
+    overflow: hidden;
+}
+
+.nitro-group-member-row__name {
+    display: block;
+    width: 77px;
+    height: 16px;
+    color: #000000 !important;
+    font-size: 11px !important;
+    font-weight: 700 !important;
+    line-height: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nitro-group-member-row__since {
+    display: block;
+    position: absolute;
+    left: 17px;
+    top: 14px;
+    width: 61px;
+    height: 15px;
+    color: #666666 !important;
+    font-size: 10px !important;
+    font-style: italic;
+    line-height: 15px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nitro-group-member-row__actions {
+    position: absolute;
+    right: 1px;
+    top: 1px;
+    width: 34px;
+    height: 18px;
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+    align-items: center;
+}
+
+.nitro-group-member-row__actions .nitro-icon,
+.nitro-group-member-row__actions .nitro-friends-spritesheet {
+    margin: 0 !important;
+    flex: 0 0 auto;
+}
+
+.nitro-group-members .nitro-groups-footer {
+    position: absolute;
+    left: 4px;
+    top: 363px;
+    width: 324px;
+    height: 25px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+.nitro-group-members .nitro-groups-button--pager {
+    width: 50px !important;
+    height: 25px !important;
+    min-height: 25px !important;
+    padding: 0 !important;
+}
+
+.nitro-group-members .nitro-groups-footer .text {
+    width: 178px;
+    text-align: center;
+    color: rgba(0, 0, 0, .7) !important;
+    font-size: 12px;
 }
 
 .nitro-group-room-info {
@@ -499,4 +890,275 @@
 
 .nitro-group-room-info__button .text-white {
     color: #111111 !important;
+}
+
+/* SWF guild_members_window/member_entry layout */
+.nitro-group-members {
+    width: 351px !important;
+    height: 431px !important;
+    resize: none !important;
+}
+
+.nitro-group-members .nitro-card-header,
+.nitro-group-members .nitro-card-header-shell {
+    height: 32px !important;
+}
+
+.nitro-group-members .nitro-card-header-text {
+    font-size: 13px !important;
+    font-weight: 700 !important;
+    line-height: 30px !important;
+    text-align: center !important;
+}
+
+.nitro-group-members .nitro-card-content-shell,
+.nitro-group-members .nitro-groups-content {
+    position: relative !important;
+    width: 351px !important;
+    height: 398px !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    background: #eeeee7 !important;
+}
+
+.nitro-group-members-search {
+    position: absolute !important;
+    left: 7px !important;
+    top: 9px !important;
+    width: 337px !important;
+    height: 70px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+}
+
+.nitro-group-members-search__badge {
+    position: absolute !important;
+    left: 19px !important;
+    top: 8px !important;
+    width: 39px !important;
+    height: 39px !important;
+    min-width: 39px !important;
+    min-height: 39px !important;
+}
+
+.nitro-group-members-search__controls,
+.nitro-group-members-search .flex-column,
+.nitro-group-members-search .d-flex.flex-column,
+.nitro-group-members-search > .column {
+    position: absolute !important;
+    left: 80px !important;
+    top: 5px !important;
+    width: 244px !important;
+    height: 56px !important;
+    gap: 8px !important;
+    display: flex !important;
+    flex-direction: column !important;
+}
+
+.nitro-group-members-search input {
+    position: relative !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 216px !important;
+    height: 25px !important;
+    min-height: 25px !important;
+    padding: 2px 5px !important;
+    border: 1px solid #000000 !important;
+    border-radius: 0 !important;
+    background: #ffffff !important;
+    box-shadow: none !important;
+    color: #222222 !important;
+    font-size: 13px !important;
+}
+
+.nitro-group-members-search select {
+    position: relative !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 244px !important;
+    height: 25px !important;
+    min-height: 25px !important;
+    padding: 2px 23px 2px 5px !important;
+    border: 1px solid #000000 !important;
+    border-radius: 0 !important;
+    background-color: #ffffff !important;
+    box-shadow: none !important;
+    color: #222222 !important;
+    font-size: 13px !important;
+}
+
+.nitro-group-members-list-grid {
+    position: absolute !important;
+    left: 6px !important;
+    top: 82px !important;
+    width: 339px !important;
+    height: 272px !important;
+    display: grid !important;
+    grid-template-columns: 169px 169px !important;
+    grid-auto-rows: 39px !important;
+    gap: 0 1px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+}
+
+.nitro-group-member-row {
+    position: relative !important;
+    width: 168px !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    max-height: 36px !important;
+    margin: 0 0 3px 0 !important;
+    padding: 0 !important;
+    border: 1px solid #77776f !important;
+    border-radius: 5px !important;
+    background: #f5f5f0 !important;
+    box-shadow: inset 0 1px 0 #ffffff !important;
+    overflow: hidden !important;
+}
+
+.nitro-group-member-row:hover {
+    background: #ffffff !important;
+}
+
+.nitro-group-member-row__avatar {
+    position: absolute !important;
+    left: -5px !important;
+    top: -5px !important;
+    width: 43px !important;
+    height: 45px !important;
+    overflow: hidden !important;
+}
+
+.nitro-group-member-row__head {
+    position: absolute !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 40px !important;
+    height: 40px !important;
+    transform: none !important;
+    image-rendering: pixelated !important;
+}
+
+.nitro-group-member-row__copy {
+    position: absolute !important;
+    left: 38px !important;
+    top: 1px !important;
+    width: 96px !important;
+    height: 32px !important;
+    overflow: hidden !important;
+}
+
+.nitro-group-member-row__name {
+    display: block !important;
+    width: 93px !important;
+    height: 16px !important;
+    color: #111111 !important;
+    font-size: 11px !important;
+    font-weight: 700 !important;
+    line-height: 16px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+}
+
+.nitro-group-member-row__since {
+    display: block !important;
+    position: absolute !important;
+    left: 11px !important;
+    top: 15px !important;
+    width: 85px !important;
+    height: 14px !important;
+    color: #6a6a65 !important;
+    font-size: 10px !important;
+    font-style: italic !important;
+    line-height: 14px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: clip !important;
+}
+
+.nitro-group-member-row__actions {
+    position: absolute !important;
+    right: 3px !important;
+    top: 17px !important;
+    width: 28px !important;
+    height: 16px !important;
+    display: flex !important;
+    justify-content: flex-end !important;
+    align-items: center !important;
+    gap: 1px !important;
+}
+
+.nitro-group-member-row__actions .nitro-icon,
+.nitro-group-member-row__actions .nitro-friends-spritesheet {
+    margin: 0 !important;
+    flex: 0 0 auto !important;
+}
+
+.nitro-group-members-footer {
+    position: absolute !important;
+    left: 8px !important;
+    top: 360px !important;
+    width: 335px !important;
+    height: 31px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+}
+
+.nitro-group-members-footer .nitro-groups-button--pager {
+    width: 51px !important;
+    height: 29px !important;
+    min-height: 29px !important;
+    padding: 0 !important;
+}
+
+.nitro-group-members-footer .nitro-groups-button--pager:first-child {
+    visibility: hidden;
+}
+
+.nitro-group-members-footer__page {
+    position: absolute;
+    left: 73px;
+    top: 4px;
+    width: 204px;
+    height: 23px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    color: #5d5d58;
+}
+
+.nitro-group-members-footer__label,
+.nitro-group-members-footer__total {
+    color: #5d5d58 !important;
+    font-size: 12px !important;
+    line-height: 20px !important;
+    white-space: nowrap !important;
+}
+
+.nitro-group-members-footer__input {
+    width: 22px !important;
+    height: 22px !important;
+    min-height: 22px !important;
+    padding: 0 !important;
+    border: 1px solid #000000 !important;
+    border-radius: 0 !important;
+    background: #ffffff !important;
+    color: #111111 !important;
+    text-align: center !important;
+    font-size: 12px !important;
+    box-shadow: none !important;
+    appearance: textfield !important;
+}
+
+.nitro-group-members-footer__input::-webkit-outer-spin-button,
+.nitro-group-members-footer__input::-webkit-inner-spin-button {
+    appearance: none;
+    margin: 0;
 }


### PR DESCRIPTION
## Summary
- Match group info and member windows to the SWF-style layout
- Open group members from the member count text and keep member windows non-resizable
- Adjust group member list sizing, heads, pagination, and standalone group card styling

## Validation
- yarn typecheck