### PR TITLE
fix(hooks): satisfy rules-of-hooks on habbicon views

### DIFF
--- a/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
+++ b/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
@@ -11,6 +11,18 @@ export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: b
     const { followFriend = null, updateRelationship = null } = useFriends();
     const relationshipMenuRef = useRef<HTMLDivElement>(null);
 
+    useEffect(() => {
+        if (!isRelationshipOpen) return;
+
+        const close = (event: globalThis.MouseEvent) => {
+            if (!relationshipMenuRef.current?.contains(event.target as Node)) setIsRelationshipOpen(false);
+        };
+
+        window.addEventListener('mousedown', close);
+
+        return () => window.removeEventListener('mousedown', close);
+    }, [isRelationshipOpen]);
+
     if (!friend) return null;
 
     const stop = (event: MouseEvent<HTMLElement>) => event.stopPropagation();
@@ -28,18 +40,6 @@ export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: b
         updateRelationship(friend, type);
         setIsRelationshipOpen(false);
     };
-
-    useEffect(() => {
-        if (!isRelationshipOpen) return;
-
-        const close = (event: globalThis.MouseEvent) => {
-            if (!relationshipMenuRef.current?.contains(event.target as Node)) setIsRelationshipOpen(false);
-        };
-
-        window.addEventListener('mousedown', close);
-
-        return () => window.removeEventListener('mousedown', close);
-    }, [isRelationshipOpen]);
 
     return (
         <div className={`hfl-friend ${friend.online ? 'online' : 'offline'}${selected ? ' selected' : ''}`} role="button" tabIndex={0} onClick={() => selectFriend(friend.id)} onKeyDown={(event) => event.key === 'Enter' && selectFriend(friend.id)}>

--- a/src/components/room/widgets/chat-input/ChatInputHabbiconSelectorView.tsx
+++ b/src/components/room/widgets/chat-input/ChatInputHabbiconSelectorView.tsx
@@ -176,7 +176,7 @@ export const ChatInputHabbiconSelectorView: FC = () => {
 
     if(!enabled || !baseUrl) return null;
 
-    const useHabbicon = async (habbiconId: number) => {
+    const applyHabbicon = async (habbiconId: number) => {
         await HabbiconAssetManager.getInstance().preload();
         SendMessageComposer(new UseHabbiconComposer(habbiconId));
         const nextRecent = [habbiconId, ...recentHabbiconIds.filter(id => id !== habbiconId)].slice(0, RECENT_HABBICONS_LIMIT);
@@ -226,7 +226,7 @@ export const ChatInputHabbiconSelectorView: FC = () => {
                                                     className="habbicon-selector-item"
                                                     title={formatHabbiconTitle(entry.name, entry.id)}
                                                     type="button"
-                                                    onClick={() => void useHabbicon(entry.id)}
+                                                    onClick={() => void applyHabbicon(entry.id)}
                                                 >
                                                     <span
                                                         style={{
@@ -279,7 +279,7 @@ export const ChatInputHabbiconSelectorView: FC = () => {
                                     <h3>{section.title}</h3>
                                     <div className="habbicon-book-grid">
                                         {section.entries.map(entry => (
-                                            <button key={entry.id} type="button" onClick={() => void useHabbicon(entry.id)}>
+                                            <button key={entry.id} type="button" onClick={() => void applyHabbicon(entry.id)}>
                                                 <span
                                                     style={{
                                                         width: entry.width,


### PR DESCRIPTION
Fixes two pre-existing `react-hooks/rules-of-hooks` violations already on `Dev` that fail the ESLint hook-order gate (so every open client PR currently fails CI through no fault of its own).

- **FriendsListGroupItemView**: the click-outside `useEffect` sat after an early `if (!friend) return null` guard, so it was called conditionally. Hoisted it above the guard.
- **ChatInputHabbiconSelectorView**: a local async action handler was named `useHabbicon`, so the linter treated it as a hook when called inside `onClick`. Renamed to `applyHabbicon`.

No behavior change. Both files are unrelated to the wired feature/revert PRs — this just unblocks the gate. Recommend merging first so the other client PRs go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)