### PR TITLE
fix(ci): repair the suites the SWF overhaul left behind

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,30 @@ env:
   NITRO_JSON_MODE: 'legacy'
 
 jobs:
+  # The renderer lives in a private repo, so this workflow can only run where
+  # DUCKET_REPO_TOKEN is available. Without this gate actions/checkout fails with
+  # an opaque "Input required and not supplied: token" and turns the run red on
+  # every fork and on any repo that has not been given the secret.
+  check-access:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - name: Check for renderer access token
+        id: check
+        env:
+          DUCKET_REPO_TOKEN: ${{ secrets.DUCKET_REPO_TOKEN }}
+        run: |
+          if [ -n "$DUCKET_REPO_TOKEN" ]; then
+            echo "has-token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DUCKET_REPO_TOKEN is not set — skipping the client release build."
+          fi
+
   build-release:
+    needs: check-access
+    if: needs.check-access.outputs.has-token == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/src/components/friends/views/friends-list/FriendsListView.css
+++ b/src/components/friends/views/friends-list/FriendsListView.css
@@ -21,7 +21,9 @@
     grid-template-rows: 24px 17px minmax(0, 1fr) 41px 17px 18px;
     width: 240px;
     min-width: 240px;
-    max-width: 240px;
+    /* Fixed 240px SWF frame, but never wider than the viewport — matches the
+       max-height clamp below and the convention the other windows follow. */
+    max-width: min(240px, calc(100vw - 16px));
     height: 350px;
     min-height: 220px;
     max-height: calc(100vh - 16px);

--- a/src/components/friends/views/messenger/FriendsMessengerView.scroll.test.ts
+++ b/src/components/friends/views/messenger/FriendsMessengerView.scroll.test.ts
@@ -17,9 +17,13 @@ describe('FriendsMessengerView routing and scroll behavior', () =>
 
         expect(source).not.toContain('isLegacyStaffChat');
         expect(source).not.toContain('shouldUseLegacyStaffChat');
-        expect(source).toContain('persistentMessenger.actions.openDirectConversation(participantId, friend.name)');
-        expect(source).toContain('if(participantId === -1)');
-        expect(source).toContain('legacyStaffThread={activeThread?.participant?.id === -1 ? activeThread : null}');
+
+        // Staff Chat must not get its own branch: both it and direct chats resolve a
+        // thread and open the same window, so there is a single routing path.
+        expect(source).not.toContain('if(participantId === -1)');
+        expect(source).toContain('const thread = getMessageThread(participantId);');
+        expect(source).toContain('setActiveThreadId(thread.threadId);');
+        expect(source.match(/setActiveThreadId\(thread\.threadId\);/g)).toHaveLength(1);
     });
 
     it('keeps the Staff Chat avatar in the persistent tab bar', () =>

--- a/src/components/friends/views/messenger/FriendsMessengerView.tsx
+++ b/src/components/friends/views/messenger/FriendsMessengerView.tsx
@@ -130,15 +130,8 @@ export const FriendsMessengerView: FC<{}> = (props) => {
                     const friend = getFriend(participantId);
                     if(!friend) return;
 
-                    if(participantId === -1)
-                    {
-                        const thread = getMessageThread(participantId);
-                        if(!thread) return;
-                        setActiveThreadId(thread.threadId);
-                        setIsVisible(true);
-                        return;
-                    }
-
+                    // Staff Chat (participantId -1) and direct chats resolve the same
+                    // way — one path, so both open in the same messenger window.
                     const thread = getMessageThread(participantId);
 
                     if (!thread) return;

--- a/src/components/groups/views/GroupRoomInformationView.test.ts
+++ b/src/components/groups/views/GroupRoomInformationView.test.ts
@@ -3,9 +3,17 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('GroupRoomInformationView', () => {
-    it('matches the width of the other HUD boxes', () => {
+    it('sizes the HUD box from CSS and keeps it right-aligned in the HUD column', () => {
         const source = readFileSync(join(process.cwd(), 'src/components/groups/views/GroupRoomInformationView.tsx'), 'utf8');
+        const css = readFileSync(join(process.cwd(), 'src/css/groups/GroupView.css'), 'utf8');
 
-        expect(source).toContain("'w-full max-w-[230px]'");
+        // The SWF restyle moved sizing out of Tailwind classes and into GroupView.css.
+        expect(source).toContain('nitro-group-room-info');
+        expect(source).not.toMatch(/max-w-\[\d+px\]/);
+
+        // Right-aligned in the same HUD column as the purse (which sits at 230px);
+        // the group box is deliberately narrower at 188px.
+        expect(css).toMatch(/\.nitro-group-room-info\s*\{[^}]*margin-left:\s*auto;/s);
+        expect(css).toMatch(/\.nitro-group-room-info\s*\{[^}]*max-width:\s*188px;/s);
     });
 });

--- a/src/components/purse/PurseView.tsx
+++ b/src/components/purse/PurseView.tsx
@@ -140,6 +140,14 @@ export const PurseView: FC<{}> = (props) => {
                     <div className="nitro-purse__col nitro-purse__col--actions">
                         <button
                             type="button"
+                            className="nitro-purse__btn nitro-purse__btn--icon nitro-purse__btn--translate nitro-purse-right-button"
+                            onClick={openTranslate}
+                            title={translateLabel}
+                        >
+                            <span>{translateLabel}</span>
+                        </button>
+                        <button
+                            type="button"
                             className="nitro-purse__btn nitro-purse__btn--help nitro-purse-right-button help"
                             onClick={(event) => {
                                 event.stopPropagation();

--- a/src/components/purse/views/CurrencyView.tsx
+++ b/src/components/purse/views/CurrencyView.tsx
@@ -20,8 +20,8 @@ export const CurrencyView: FC<CurrencyViewProps> = (props) => {
     const element = useMemo(() => {
         return (
             <Flex justifyContent="end" pointer gap={1} className={`nitro-purse-button rounded allcurrencypurse nitro-purse-button currency-info currency-${type}`}>
-                <Text truncate textEnd variant="white" grow className="currency-text">
-                    {short ? LocalizeShortNumber(amount) : LocalizeFormattedNumber(amount)}
+                <Text truncate textEnd variant="white" grow className="nitro-purse-button__amount currency-text">
+                    {displayAmount}
                 </Text>
                 <LayoutCurrencyIcon type={type} />
             </Flex>

--- a/src/components/room/widgets/room-tools/RoomToolsWidgetView.test.ts
+++ b/src/components/room/widgets/room-tools/RoomToolsWidgetView.test.ts
@@ -7,29 +7,34 @@ const source = readFileSync(join(process.cwd(), 'src/components/room/widgets/roo
 const css = readFileSync(join(process.cwd(), 'src/css/room/RoomWidgets.css'), 'utf8');
 
     it('renders level controls and a collapsible side rail', () => {
-        expect(source).toContain('room-tools-zoom-level');
-        expect(source).toContain('room-tools-zoom-in');
-        expect(source).toContain('room-tools-zoom-out');
-        expect(source).toContain('nitro-room-tools-toggle');
+        expect(source).toContain('room-tools-zoom-row');
+        expect(source).toContain('room-tools-zoom-button');
+        expect(source).toContain('room-tools-collapse-toggle');
+        expect(source).toContain("LocalizeText('room.zoom.text', ['zoom_level'], [getZoomText(zoomScale)])");
     });
 
     it('keeps renderer zoom side effects outside React state updaters', () => {
-        expect(source).not.toMatch(/setZoomLevel\s*\([^)]*=>[\s\S]{0,500}setRoomInstanceRenderingCanvasScale/);
-        expect(source).toContain('stepRoomZoom(currentScale, direction)');
+        expect(source).not.toMatch(/setZoomScale\s*\([^)]*=>[\s\S]{0,500}setRoomInstanceRenderingCanvasScale/);
+        expect(source).toContain('getNextZoomScale(currentScale, direction)');
+        expect(source).toContain('GetRoomEngine().setRoomInstanceRenderingCanvasScale(roomSession.roomId, 1, nextScale)');
     });
 
     it('tracks zoom changes triggered outside the toolbar', () => {
         expect(source).toContain('RoomEngineEvent.ROOM_ZOOMED');
-        expect(source).toContain('syncZoomLevel');
+        expect(source).toContain('updateZoomScale();');
+        expect(source).toContain('}, [roomSession?.roomId]);');
     });
 
-    it('keeps the toolbar mounted while collapsing it', () => {
-        expect(source).toContain('className="flex flex-col nitro-room-tools"');
+    it('keeps the collapse handle mounted while the rail is collapsed', () => {
+        expect(source).toContain("classNames('nitro-room-tools-container', !isToolsOpen && 'is-collapsed')");
+        // The toggle is rendered before (and outside) the `isToolsOpen` branch so it
+        // stays clickable once the rail collapses — that is what reopens the toolbar.
+        expect(source.indexOf('room-tools-collapse-toggle')).toBeLessThan(source.indexOf('{isToolsOpen && ('));
         expect(source).not.toContain('initial={{ opacity: 0, x: -12 }}');
     });
 
     it('anchors the collapsed handle to the viewport edge', () => {
-        expect(css).toMatch(/&\.is-collapsed\s+\.nitro-room-tools-rail\s*\{[^}]*width:\s*0;/s);
-        expect(css).toMatch(/&\.is-collapsed\s+\.nitro-room-tools-toggle\s*\{[^}]*left:\s*0;/s);
+        expect(css).toMatch(/&\.is-collapsed\s*\{[^}]*width:\s*158px;/s);
+        expect(css).toMatch(/&\.is-collapsed\s+\.room-tools-collapse-toggle\s*\{[^}]*transform:\s*translateY\(-50%\);/s);
     });
 });

--- a/src/components/room/widgets/room-tools/RoomToolsWidgetView.tsx
+++ b/src/components/room/widgets/room-tools/RoomToolsWidgetView.tsx
@@ -6,7 +6,6 @@ import { Text } from '../../../../common';
 import { useMessageEvent, useNavigatorData, useNitroEvent, useRoom } from '../../../../hooks';
 import { classNames } from '../../../../layout';
 import { getRegisteredPlugins, INitroPlugin, subscribePlugins } from '../../../plugins/NitroPluginApi';
-import { getRoomZoomLevel, stepRoomZoom } from './roomZoom.helpers';
 
 interface RoomHistoryEntry {
     roomId: number;
@@ -172,6 +171,14 @@ export const RoomToolsWidgetView: FC<{}> = (props) => {
         setHasLikedRoom(false);
         updateZoomScale();
     }, [roomSession?.roomId]);
+
+    // The renderer can be zoomed from outside this toolbar (keyboard shortcuts,
+    // other widgets), so resync the displayed level whenever the engine reports it.
+    useNitroEvent<RoomEngineEvent>(RoomEngineEvent.ROOM_ZOOMED, (event) => {
+        if (!roomSession || event.roomId !== roomSession.roomId) return;
+
+        updateZoomScale();
+    });
 
     const tools = [
         { action: 'settings', icon: 'icon-cog', label: LocalizeText('room.settings.button.text') },

--- a/src/css/purse/PurseView.css
+++ b/src/css/purse/PurseView.css
@@ -12,7 +12,9 @@
     width: 100%;
     max-width: 230px;
     margin-left: auto;
-    overflow: hidden;
+    /* visible, not hidden: the shortened-amount tooltips in CurrencyView are
+       positioned outside the purse frame and would otherwise be clipped. */
+    overflow: visible;
     border: 0;
     border-left: 1px solid rgba(15, 15, 15, 0.78);
     border-bottom: 1px solid rgba(15, 15, 15, 0.78);

--- a/src/css/purse/PurseView.test.ts
+++ b/src/css/purse/PurseView.test.ts
@@ -12,17 +12,21 @@ describe('PurseView.css', () => {
         expect(purseBlock).toContain('overflow: visible;');
     });
 
-    it('uses the AIR6 purse height without removing the extra action', () => {
+    it('keeps the SWF purse chrome without reintroducing the legacy background hack', () => {
         const css = readFileSync(cssPath, 'utf8');
 
-        expect(css).toMatch(/\.nitro-purse\s*\{[^}]*height:\s*77px;[^}]*min-height:\s*77px;/s);
-        expect(css).toMatch(/\.nitro-purse__body\s*\{[^}]*height:\s*69px;[^}]*min-height:\s*69px;/s);
-        expect(css).toMatch(/\.nitro-purse\s*\{[^}]*border-radius:\s*8px;/s);
-        expect(css).not.toContain('.nitro-purse::before');
-        expect(css).not.toContain('ubuntu_bg_9.png');
-        expect(css).toMatch(/\.nitro-purse__btn--icon\s*\{[^}]*height:\s*15px;/s);
+        // The SWF restyle replaced the fixed AIR6 77px/69px frame with a flex body
+        // that sizes to its content, so assert the column layout rather than heights.
+        expect(css).toMatch(/\.nitro-purse__body\s*\{[^}]*display:\s*flex;/s);
         expect(css).toMatch(/\.nitro-purse__col--primary\s*\{[^}]*gap:\s*7px;/s);
         expect(css).toMatch(/\.nitro-purse__col--actions\s*\{[^}]*gap:\s*2px;/s);
-        expect(css).toMatch(/\.nitro-purse__other\s+\.nitro-purse-seasonal-currency\s*\{[^}]*border-radius:\s*8px;/s);
+
+        // Per-currency amount colours are keyed off .nitro-purse-button__amount,
+        // which CurrencyView must keep emitting alongside .currency-text.
+        expect(css).toContain('.nitro-purse .nitro-purse-button.currency--1 .nitro-purse-button__amount');
+
+        // Regression guards from the AIR6 cleanup — these must not come back.
+        expect(css).not.toContain('.nitro-purse::before');
+        expect(css).not.toContain('ubuntu_bg_9.png');
     });
 });

--- a/src/css/ui-css-ownership.test.ts
+++ b/src/css/ui-css-ownership.test.ts
@@ -63,6 +63,7 @@ describe('UI CSS ownership', () =>
         const wiredBaseView = readSource('src/components/wired/views/WiredBaseView.tsx');
         const friendsCategoryManagerView = readSource('src/components/friends/views/friends-list/FriendsCategoryManagerView.tsx');
         const friendsListView = readSource('src/components/friends/views/friends-list/FriendsListView.tsx');
+        const friendsListCss = readSource('src/components/friends/views/friends-list/FriendsListView.css');
         const friendsListRemoveConfirmationView = readSource('src/components/friends/views/friends-list/FriendsListRemoveConfirmationView.tsx');
         const friendsListRoomInviteView = readSource('src/components/friends/views/friends-list/FriendsListRoomInviteView.tsx');
         const friendsMessengerView = readSource('src/components/friends/views/messenger/FriendsMessengerView.tsx');
@@ -150,8 +151,10 @@ describe('UI CSS ownership', () =>
         expect(navigatorView).toContain('max-w-[calc(100vw-16px)]');
         expect(navigatorRoomSettingsView).toContain('max-w-[calc(100vw-16px)]');
         expect(wiredBaseView).toContain('max-h-[calc(100vh-16px)]');
-        expect(friendsListView).toContain('max-w-[calc(100vw-16px)]');
-        expect(friendsMessengerView).toContain('max-w-[calc(100vw-16px)]');
+        // The friends list and messenger were rebuilt as bespoke SWF windows, so their
+        // viewport clamp lives in CSS rather than in a Tailwind class on the view.
+        expect(friendsListCss).toContain('max-width: min(240px, calc(100vw - 16px));');
+        expect(friendsCss).toMatch(/\.swf-messenger-window\s*\{[^}]*max-width:\s*calc\(100vw - 10px\)/s);
         expect(vaultView).toContain('max-w-[calc(100vw-16px)]');
         expect(helpView).toContain('max-w-[calc(100vw-16px)]');
         expect(userSettingsView).toContain('max-w-[calc(100vw-16px)]');


### PR DESCRIPTION
## Why

CI has been red on every branch since [`2dc94c6a`](https://github.com/duckietm/Nitro-V3/commit/2dc94c6a) — *"feat: add SWF-inspired client improvements"*, 23 Jul. Last green run was `37c58ac3` at 10:35; the first red run was 11:09 the same morning.

That commit rewrote six views but left their tests pinned to the previous implementation, so **12 cases failed** on `Dev` and `main` alike.

> Note: this is unrelated to the `WiredFurniGravityMessageEvent` build break reported separately — that one was fixed by #348.

## Real regressions (fixed in source, tests unchanged)

Three failures turned out to be half-finished edits rather than test drift — in each case the supporting code was still sitting there unused:

| what | evidence |
|---|---|
| `CurrencyView` stopped shortening amounts | computed `displayAmount` (→ `"3.7k"`) but rendered a different ternary, so large amounts showed in full **and** the hover tooltip duplicated the button text. Also stopped emitting `nitro-purse-button__amount`, orphaning the three per-currency colour rules in `PurseView.css`. |
| Purse lost its Translate button | `translateLabel` / `openTranslate` still defined, never rendered. |
| Room tools stopped tracking external zoom | the `ROOM_ZOOMED` listener was deleted, leaving `RoomEngineEvent` **and** `useNitroEvent` imported but unused. Zoom level no longer updated when the room was zoomed from outside the toolbar. |

## Deliberate design changes (tests moved instead)

The purse chrome, the 188px group HUD box, and the bespoke SWF friends-list / messenger windows are intentional, so the assertions were re-pointed at the current implementation rather than forcing the old markup back.

Two small fixes fell out of this:

- **Friends list had no viewport clamp.** It's a fixed 240px SWF frame with `max-height: calc(100vh - 16px)` but an unbounded width — it would overflow on narrow screens. Now `max-width: min(240px, calc(100vw - 16px))`, matching the 36 other windows.
- **Messenger had a redundant Staff Chat branch** that was byte-identical to the code beneath it. Collapsed, so the routing genuinely is one path.

## Release workflow

`Build & Publish Client Release` checks out the private `duckethotel/ducket-render`, so without `DUCKET_REPO_TOKEN` `actions/checkout` fails with `Input required and not supplied: token`. It's now gated on the secret and skips instead of going red on forks.

## Verification

| gate | before | after |
|---|---|---|
| `vitest` | 12 failed / 666 passed | **678 passed** |
| `tsgo --noEmit` | clean | clean |
| `eslint --config eslint.hooks.config.mjs` | 0 errors | 0 errors |
| `vite build` | ok | ok |

## Left alone, worth a follow-up

`FriendsPersistentMessengerView.tsx` is now **orphaned** — nothing in the app imports it, only two test files read it as text. Its helpers and tests are still live. Deleting a component you two may intend to re-wire isn't my call, so it's untouched.