### PR TITLE
fix(toolbar): restore fortune wheel entry

### DIFF
--- a/src/components/toolbar/ToolbarView.config.test.ts
+++ b/src/components/toolbar/ToolbarView.config.test.ts
@@ -11,12 +11,15 @@ describe('Toolbar feature config', () => {
 
         expect(config['buildersclub.enabled']).toBe(true);
         expect(config['toolbar.buildersclub.enabled']).toBe(true);
+        expect(config['toolbar.fortunewheel.enabled']).toBe(true);
         expect(source).toContain(
             "GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true))"
         );
+        expect(source).toContain("GetConfigurationValue<boolean>('toolbar.fortunewheel.enabled', true)");
         expect(source.match(/buildersClubEnabled\s*&&/g)).toHaveLength(2);
+        expect(source.match(/fortuneWheelEnabled\s*&&/g)).toHaveLength(2);
         expect(source.match(/icon=\"buildersclub\"/g)).toHaveLength(2);
+        expect(source.match(/icon=\"fortune-wheel\"/g)).toHaveLength(2);
         expect(source).not.toContain('rare-values/toggle');
-        expect(source).not.toContain('fortune-wheel/toggle');
     });
 });

--- a/src/components/toolbar/ToolbarView.tsx
+++ b/src/components/toolbar/ToolbarView.tsx
@@ -44,6 +44,7 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
     const { unreadCount: mentionsUnread = 0 } = useMentionsSnapshot();
     const mentionsEnabled = useMemo(() => GetConfigurationValue<boolean>('mentions_ui.enabled', true), []);
     const buildersClubEnabled = useMemo(() => GetConfigurationValue<boolean>('buildersclub.enabled', GetConfigurationValue<boolean>('toolbar.buildersclub.enabled', true)), []);
+    const fortuneWheelEnabled = useMemo(() => GetConfigurationValue<boolean>('toolbar.fortunewheel.enabled', true), []);
     const { openMonitor, showToolbarButton } = useWiredTools();
     const { enabled: soundboardEnabled, reset: resetSoundboard } = useSoundboard();
     const isMod = useHasPermission('acc_supporttool');
@@ -263,6 +264,10 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
                             <LayoutItemCountView count={ getFullCount } className="absolute -right-1 top-0" /> }
                     </motion.div>
                     { !leftCollapsed && (<>
+                    { fortuneWheelEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="fortune-wheel" onClick={ () => CreateLinkEvent('fortune-wheel/toggle') } className="tb-icon" />
+                        </motion.div> }
                     { (isInRoom && showToolbarButton) &&
                         <motion.div variants={ itemVariants }>
                             <ToolbarItemView icon="wired-tools" onClick={ openMonitor } className="tb-icon" />
@@ -392,6 +397,10 @@ export const ToolbarView: FC<{ isInRoom: boolean }> = props =>
                         { (getFullCount > 0) &&
                             <LayoutItemCountView count={ getFullCount } className="absolute -right-1 top-0" /> }
                     </motion.div>
+                    { fortuneWheelEnabled &&
+                        <motion.div variants={ itemVariants }>
+                            <ToolbarItemView icon="fortune-wheel" onClick={ () => CreateLinkEvent('fortune-wheel/toggle') } className="tb-icon" />
+                        </motion.div> }
                 </motion.div>
                 <motion.div
                     variants={ containerVariants }


### PR DESCRIPTION
## What changed

- restore the Fortune Wheel toolbar button in desktop and mobile layouts
- keep the button gated by `toolbar.fortunewheel.enabled`
- restore regression assertions for the config lookup and both rendered toolbar entries

## Why

The SWF-inspired toolbar overhaul removed the only normal `fortune-wheel/toggle` entry point while leaving the configuration key, wheel UI, protocol, and emulator implementation intact. As a result, enabling the documented setting could not make the wheel visible.

## User impact

Hotels with `toolbar.fortunewheel.enabled` set to `true` once again show the Fortune Wheel toolbar icon. Setting it to `false` continues to hide the icon.
