### PR TITLE
fix(friend-bar): prevent staff chat close artifact

### DIFF
--- a/src/css/friends/FriendsView.css
+++ b/src/css/friends/FriendsView.css
@@ -2617,18 +2617,10 @@ button.swf-friends-section-header {
 }
 
 .friend-bar .friend-bar-friend:not(.is-selected) .friend-bar-actions {
-    bottom: 0;
-    left: 0;
-    box-sizing: border-box;
-    width: 262px;
-    min-height: 70px;
-    padding: 7px 39px 7px 42px;
-    border: 2px solid #111;
-    border-top-color: #9ac35d;
-    border-radius: 4px 4px 0 0;
-    background: #1c1c1a;
-    box-shadow: inset 0 1px rgba(255, 255, 255, 0.16), 1px -1px 0 rgba(0, 0, 0, 0.5);
-    transform: none;
+    /* AnimatePresence retains the panel briefly while it exits, after the
+       parent has already lost is-selected. Keep that stale closing frame from
+       picking up an unrelated, oversized legacy skin. */
+    display: none;
 }
 
 .friend-bar .friend-bar-friend .friend-bar-actions-name {

--- a/src/css/friends/FriendsView.messenger-visuals.test.ts
+++ b/src/css/friends/FriendsView.messenger-visuals.test.ts
@@ -29,4 +29,13 @@ describe('Messenger and Friend List visual CSS', () =>
     {
         expect(css).toMatch(/\.friends-list-group-assign\s*\{[^}]*position:\s*relative;/s);
     });
+
+    it('hides an exiting friend-bar panel as soon as its tab is deselected', () =>
+    {
+        const closingPanelRule = css.match(/\.friend-bar\s+\.friend-bar-friend:not\(\.is-selected\)\s+\.friend-bar-actions\s*\{([^}]*)\}/s);
+
+        expect(closingPanelRule?.[1]).toMatch(/display:\s*none;/);
+        expect(closingPanelRule?.[1]).not.toMatch(/width:\s*262px;/);
+        expect(closingPanelRule?.[1]).not.toMatch(/border-top-color:\s*#9ac35d;/);
+    });
 });


### PR DESCRIPTION
## Summary

- hide the exiting friend-bar action panel as soon as its tab loses the selected state
- remove the oversized legacy closing-frame skin that produced the green line
- add a regression assertion for the deselected exit state

## Root cause

`AnimatePresence` keeps the action panel mounted for its 120 ms exit animation after the parent immediately loses `is-selected`. During that interval, a legacy `:not(.is-selected)` rule expanded the retained panel to 262 px and painted a green top border, creating the line above Staff Chat.

## User impact

Closing Staff Chat or another selected friend-bar tab no longer flashes or stretches a green line across the toolbar.

## Validation

- browser reproduction before fix: retained panel measured 262 x 70 px with a 2 px green top border
- browser verification after fix: retained closing node computes to `display: none` and 0 x 0 px
- `npm test` — 87 files, 671 tests passed
- `./node_modules/.bin/tsgo --noEmit`
- targeted Biome lint
- `npm run build`
- `git diff --check`