### PR TITLE
fix(navigator): overlay group badges on room thumbnails

### DIFF
--- a/src/components/navigator/views/search/NavigatorSearchResultItemBadgeOverlay.test.ts
+++ b/src/components/navigator/views/search/NavigatorSearchResultItemBadgeOverlay.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const badgeOverlayClasses = 'absolute! bottom-0 left-1/2 z-10 mb-1 -translate-x-1/2';
+const searchViewPath = 'src/components/navigator/views/search';
+
+describe('navigator room group badge overlay', () => {
+    it.each(['NavigatorSearchResultItemView.tsx', 'NavigatorSearchResultItemInfoView.tsx'])('keeps the badge over the bottom center in %s', (fileName) => {
+        const source = readFileSync(join(process.cwd(), searchViewPath, fileName), 'utf8');
+
+        expect(source).toContain(`className="${badgeOverlayClasses}"`);
+        expect(source).not.toContain('className="absolute top-0 inset-s-0 m-1"');
+    });
+});

--- a/src/components/navigator/views/search/NavigatorSearchResultItemInfoView.tsx
+++ b/src/components/navigator/views/search/NavigatorSearchResultItemInfoView.tsx
@@ -119,7 +119,11 @@ export const NavigatorSearchResultItemInfoView: FC<NavigatorSearchResultItemInfo
                                 roomId={roomData.roomId}
                             >
                                 {roomData.habboGroupId > 0 && (
-                                    <LayoutBadgeImageView badgeCode={roomData.groupBadgeCode} className="absolute top-0 inset-s-0 m-1" isGroup={true} />
+                                    <LayoutBadgeImageView
+                                        badgeCode={roomData.groupBadgeCode}
+                                        className="absolute! bottom-0 left-1/2 z-10 mb-1 -translate-x-1/2"
+                                        isGroup={true}
+                                    />
                                 )}
                                 {roomData.doorMode !== RoomDataParser.OPEN_STATE && (
                                     <i

--- a/src/components/navigator/views/search/NavigatorSearchResultItemView.tsx
+++ b/src/components/navigator/views/search/NavigatorSearchResultItemView.tsx
@@ -123,7 +123,11 @@ export const NavigatorSearchResultItemView: FC<NavigatorSearchResultItemViewProp
                     roomId={roomData.roomId}
                 >
                     {roomData.habboGroupId > 0 && (
-                        <LayoutBadgeImageView badgeCode={roomData.groupBadgeCode} className="absolute top-0 inset-s-0 m-1" isGroup={true} />
+                        <LayoutBadgeImageView
+                            badgeCode={roomData.groupBadgeCode}
+                            className="absolute! bottom-0 left-1/2 z-10 mb-1 -translate-x-1/2"
+                            isGroup={true}
+                        />
                     )}
                     <Flex
                         center


### PR DESCRIPTION
## What changed

- force navigator group badges out of the thumbnail flex flow
- position badges over the bottom center of room thumbnails
- apply the same layout in the room result card and its info popover
- add a focused regression contract for both render paths

## Why

`LayoutBadgeImageView` includes a default `relative` positioning utility. The navigator previously added a non-important `absolute` utility, which could lose in the generated Tailwind cascade. The badge then remained in the flex layout and reduced the space available to the 110px room image, visibly cropping the thumbnail.

The explicit important absolute positioning keeps the badge out of flow and layers it over the image at the requested bottom-center position.
