### PR TITLE
fix(camera): keep editor fixed size

### DIFF
--- a/src/components/camera/views/editor/CameraWidgetEditorView.test.ts
+++ b/src/components/camera/views/editor/CameraWidgetEditorView.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('CameraWidgetEditorView layout', () => {
+    it('keeps the fixed-size editor non-resizable', () => {
+        const source = readFileSync(join(process.cwd(), 'src/components/camera/views/editor/CameraWidgetEditorView.tsx'), 'utf8');
+
+        expect(source).toContain('isResizable={false}');
+        expect(source).toContain("style={{ resize: 'none' }}");
+    });
+});

--- a/src/components/camera/views/editor/CameraWidgetEditorView.tsx
+++ b/src/components/camera/views/editor/CameraWidgetEditorView.tsx
@@ -204,7 +204,7 @@ export const CameraWidgetEditorView: FC<CameraWidgetEditorViewProps> = (props) =
     }, [stableTexture, selectedEffects]);
 
     return (
-        <NitroCardView className="w-[600px] h-[500px]">
+        <NitroCardView className="w-[600px] h-[500px]" isResizable={false} style={{ resize: 'none' }}>
             <NitroCardHeaderView headerText={LocalizeText('camera.editor.button.text')} onCloseClick={(event) => processAction('close')} />
             <NitroCardTabsView>
                 {TABS.map((tab) => (


### PR DESCRIPTION
## Summary

- disable resizing for the fixed 600 x 500 camera editor
- enforce `resize: none` inline so the shared card skin cannot re-enable the resize handle
- add a focused source contract test for the fixed-size behavior

## Root cause

The shared `NitroCardView` is resizable by default, while the camera editor uses a fixed three-column effects grid and fixed 325 x 325 preview. PR #331 changed clipping to horizontal scrolling, but did not make that fixed layout responsive. Resizing the card therefore caused effects, frames, spacing, and controls to stop fitting their intended composition.

## User impact

The camera editor now stays at its designed dimensions, so effects and frames remain aligned instead of drifting when the card is manually resized.

## Validation

- focused camera editor test: passed
- Biome check for both changed files: passed
- full Vitest run: 674 tests passed; one housekeeping source scan timed out under parallel load, then passed all 5 tests when rerun alone
- `git diff --check`: passed

## Existing Dev CI issue

The current `Dev` baseline already fails typecheck/build in the SnowWar integration due to missing renderer exports and a renderer syntax error. This is unrelated to the camera editor change: https://github.com/duckietm/Nitro-V3/actions/runs/30457385738