### PR TITLE
fix(camera): restore fixed editor sizing

### DIFF
--- a/src/components/camera/views/editor/CameraWidgetEditorView.tsx
+++ b/src/components/camera/views/editor/CameraWidgetEditorView.tsx
@@ -214,7 +214,7 @@ export const CameraWidgetEditorView: FC<CameraWidgetEditorViewProps> = (props) =
     }, [stableTexture, selectedEffects, picture]);
 
     return (
-        <NitroCardView className="w-[600px] max-w-[95vw] h-[500px] max-h-[90vh]">
+        <NitroCardView className="w-[600px] max-w-[95vw] h-[500px] max-h-[90vh]" isResizable={false} style={{ resize: 'none' }}>
             <NitroCardHeaderView headerText={LocalizeText('camera.editor.button.text')} onCloseClick={(event) => processAction('close')} />
             <NitroCardTabsView>
                 {TABS.map((tab) => (


### PR DESCRIPTION
## Summary

- restore the fixed 600x500 camera editor contract from merged PR #357
- disable shared-card resizing and the native CSS resize handle
- repair the later Dev regression while keeping the existing source-contract test

## Validation

- `CameraWidgetEditorView.test.ts`: 1 passed
- exact one-line diff checked with `git diff --check`

## Context

A later Dev commit replaced the card opening tag and unintentionally removed the two sizing safeguards while leaving the regression test in place.
