### PR TITLE
fix: restore crisp avatar heads across friends and messenger

### DIFF
--- a/src/components/friends/views/friends-list/FriendsListView.avatar-cascade.test.ts
+++ b/src/components/friends/views/friends-list/FriendsListView.avatar-cascade.test.ts
@@ -1,0 +1,47 @@
+/* @vitest-environment jsdom */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import postcss from 'postcss';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/components/friends/views/friends-list/FriendsListView.css'), 'utf8');
+
+beforeAll(async () => {
+    const result = await postcss().process(source, { from: undefined });
+    const relevantRules: string[] = [];
+
+    result.root.walkRules((rule) => {
+        if (rule.selector.includes('.hfl-friend-avatar')) relevantRules.push(rule.toString());
+    });
+
+    const style = document.createElement('style');
+
+    style.textContent = relevantRules.join('\n');
+    document.head.appendChild(style);
+});
+
+describe('Friends list compact avatar cascade', () => {
+    it('keeps the cropped friend head at its smooth 20px output size', () => {
+        const container = document.createElement('div');
+        const avatar = document.createElement('div');
+
+        container.className = 'hfl-friend-avatar';
+        avatar.className = 'avatar-image compact-head';
+        avatar.style.backgroundSize = '20px 20px';
+        avatar.style.backgroundPosition = 'center';
+        avatar.style.imageRendering = 'auto';
+        container.appendChild(avatar);
+        document.body.appendChild(container);
+
+        const computed = getComputedStyle(avatar);
+
+        expect(computed.top).toBe('0px');
+        expect(computed.left).toBe('0px');
+        expect(computed.width).toBe('20px');
+        expect(computed.height).toBe('20px');
+        expect(computed.backgroundSize).toBe('20px 20px');
+        expect(computed.backgroundPosition).toBe('center center');
+        expect(computed.imageRendering).toBe('auto');
+    });
+});

--- a/src/components/friends/views/friends-list/FriendsListView.css
+++ b/src/components/friends/views/friends-list/FriendsListView.css
@@ -293,16 +293,19 @@
     image-rendering: pixelated !important;
 }
 
-.hfl-friend-avatar .avatar-image {
-    inset: auto !important;
-    top: -1px !important;
-    left: -2px !important;
-    width: 22px !important;
-    height: 22px !important;
+.hfl-friend-avatar .avatar-image.compact-head {
+    inset: 0 !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 20px !important;
+    height: 20px !important;
     border: 0 !important;
     border-radius: 0 !important;
     background-color: transparent !important;
+    background-position: center !important;
+    background-size: 20px 20px !important;
     box-shadow: none !important;
+    image-rendering: auto !important;
 }
 
 .hfl-friend-profile,

--- a/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemAvatar.test.tsx
+++ b/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemAvatar.test.tsx
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+
+import { GetAvatarRenderManager } from '@nitrots/nitro-renderer';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessengerFriend } from '../../../../../api';
+import { useFriends } from '../../../../../hooks';
+import { FriendsListGroupItemView } from './FriendsListGroupItemView';
+
+vi.mock('../../../../../hooks', () => ({
+    useFriends: vi.fn()
+}));
+
+vi.mock('../../../../../common/layout/avatarImageCrop', () => ({
+    cropTransparentImageUrl: vi.fn(async () => 'data:image/png;base64,cropped')
+}));
+
+describe('Friends list avatar head', () => {
+    beforeEach(() => {
+        vi.mocked(GetAvatarRenderManager).mockReturnValue({
+            createAvatarImage: () => ({
+                setDirection: vi.fn(),
+                processAsImageUrl: () => 'data:image/png;base64,raw',
+                isPlaceholder: () => false,
+                dispose: vi.fn()
+            })
+        } as unknown as ReturnType<typeof GetAvatarRenderManager>);
+        vi.mocked(useFriends).mockReturnValue({
+            followFriend: vi.fn(),
+            updateRelationship: vi.fn()
+        } as unknown as ReturnType<typeof useFriends>);
+    });
+
+    afterEach(cleanup);
+
+    it('renders the friend head as a smooth 20px compact thumbnail', () => {
+        const friend = new MessengerFriend();
+
+        friend.id = 42;
+        friend.name = 'tester1';
+        friend.figure = 'hd-180-1.ch-210-66.lg-270-82.sh-290-80';
+        friend.gender = 0;
+        friend.online = true;
+
+        const { container } = render(<FriendsListGroupItemView friend={friend} selected={false} selectFriend={vi.fn()} />);
+        const avatar = container.querySelector<HTMLElement>('.hfl-friend-avatar .avatar-image');
+
+        expect(avatar).not.toBeNull();
+        expect(avatar).toHaveClass('compact-head');
+        expect(avatar).toHaveStyle({
+            backgroundSize: '20px 20px',
+            backgroundPosition: 'center',
+            imageRendering: 'auto'
+        });
+    });
+});

--- a/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
+++ b/src/components/friends/views/friends-list/friends-list-group/FriendsListGroupItemView.tsx
@@ -44,7 +44,15 @@ export const FriendsListGroupItemView: FC<{ friend: MessengerFriend; selected: b
     return (
         <div className={`hfl-friend ${friend.online ? 'online' : 'offline'}${selected ? ' selected' : ''}`} role="button" tabIndex={0} onClick={() => selectFriend(friend.id)} onKeyDown={(event) => event.key === 'Enter' && selectFriend(friend.id)}>
             <div className="hfl-friend-avatar">
-                    <LayoutAvatarImageView figure={resolveAvatarFigure(friend.figure, friend.gender)} gender={resolveAvatarGender(friend.gender)} headOnly direction={2} />
+                <LayoutAvatarImageView
+                    figure={resolveAvatarFigure(friend.figure, friend.gender)}
+                    gender={resolveAvatarGender(friend.gender)}
+                    headOnly
+                    compactHead
+                    compactHeadSize={20}
+                    compactHeadPadding={0}
+                    direction={2}
+                />
             </div>
             <span className="hfl-friend-profile" onClick={stop}><UserProfileIconView userId={friend.id} /></span>
             <span className="hfl-friend-name">{friend.name}</span>

--- a/src/components/friends/views/messenger/FriendsMessengerAvatarHeads.test.tsx
+++ b/src/components/friends/views/messenger/FriendsMessengerAvatarHeads.test.tsx
@@ -1,0 +1,121 @@
+/* @vitest-environment jsdom */
+
+import { AddLinkEventTracker, GetAvatarRenderManager, GetSessionDataManager } from '@nitrots/nitro-renderer';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessengerFriend, MessengerThread } from '../../../../api';
+import { useFriends, useHelp, useMessenger, useTranslation } from '../../../../hooks';
+import { FriendsMessengerView } from './FriendsMessengerView';
+import { FriendsMessengerThreadGroup } from './messenger-thread/FriendsMessengerThreadGroup';
+
+vi.mock('../../../../hooks', () => ({
+    useFriends: vi.fn(),
+    useHelp: vi.fn(),
+    useMessenger: vi.fn(),
+    useTranslation: vi.fn()
+}));
+
+vi.mock('../../../../common/layout/avatarImageCrop', () => ({
+    cropTransparentImageUrl: vi.fn(async () => 'data:image/png;base64,cropped')
+}));
+
+const figure = 'hd-180-1.ch-210-66.lg-270-82.sh-290-80';
+
+const makeFriend = () => {
+    const friend = new MessengerFriend();
+
+    friend.id = 42;
+    friend.name = 'Lorenzo';
+    friend.gender = 0;
+    friend.figure = figure;
+    friend.online = true;
+
+    return friend;
+};
+
+const makeThread = (friend: MessengerFriend) => {
+    const thread = new MessengerThread(friend);
+
+    thread.addMessage(friend.id, 'Ciao');
+
+    return thread;
+};
+
+describe('Messenger avatar heads', () => {
+    const friend = makeFriend();
+
+    beforeEach(() => {
+        vi.mocked(AddLinkEventTracker).mockClear();
+        vi.mocked(GetAvatarRenderManager).mockReturnValue({
+            createAvatarImage: () => ({
+                setDirection: vi.fn(),
+                processAsImageUrl: () => 'data:image/png;base64,raw',
+                isPlaceholder: () => false,
+                dispose: vi.fn()
+            })
+        } as unknown as ReturnType<typeof GetAvatarRenderManager>);
+        vi.mocked(GetSessionDataManager).mockReturnValue({
+            userId: 7,
+            userName: 'Simoleo',
+            figure
+        } as ReturnType<typeof GetSessionDataManager>);
+        vi.mocked(useFriends).mockReturnValue({ getFriend: () => friend } as unknown as ReturnType<typeof useFriends>);
+        vi.mocked(useHelp).mockReturnValue({ report: vi.fn() } as unknown as ReturnType<typeof useHelp>);
+        vi.mocked(useTranslation).mockReturnValue({
+            settings: { enabled: false },
+            translateOutgoing: vi.fn()
+        } as unknown as ReturnType<typeof useTranslation>);
+    });
+
+    afterEach(cleanup);
+
+    it('uses a tightly cropped head in each conversation tab', () => {
+        const thread = makeThread(friend);
+
+        vi.mocked(useMessenger).mockReturnValue({
+            visibleThreads: [thread],
+            activeThread: null,
+            getMessageThread: () => thread,
+            sendMessage: vi.fn(),
+            setActiveThreadId: vi.fn(),
+            closeThread: vi.fn(),
+            typingUserIds: [],
+            sendTypingStatus: vi.fn()
+        } as unknown as ReturnType<typeof useMessenger>);
+
+        render(<FriendsMessengerView />);
+
+        const tracker = vi.mocked(AddLinkEventTracker).mock.calls[0][0];
+
+        act(() => tracker.linkReceived('friends-messenger/open'));
+
+        const avatar = document.querySelector<HTMLElement>('.messenger-avatar-tab .avatar-image');
+
+        expect(avatar).not.toBeNull();
+        expect(avatar).toHaveClass('compact-head');
+        expect(avatar).toHaveStyle({ backgroundSize: '35px 35px', backgroundPosition: 'center' });
+    });
+
+    it('uses a tightly cropped head beside incoming messages', () => {
+        const thread = makeThread(friend);
+        const { container } = render(<FriendsMessengerThreadGroup thread={thread} group={thread.groups[0]} />);
+        const avatar = container.querySelector<HTMLElement>('.message-avatar .avatar-image');
+
+        expect(avatar).not.toBeNull();
+        expect(avatar).toHaveClass('compact-head');
+        expect(avatar).toHaveStyle({ backgroundSize: '40px 40px', backgroundPosition: 'center' });
+    });
+
+    it('uses the same tightly cropped head beside sent messages', () => {
+        const thread = new MessengerThread(friend);
+
+        thread.addMessage(7, 'Ciao Lorenzo');
+
+        const { container } = render(<FriendsMessengerThreadGroup thread={thread} group={thread.groups[0]} />);
+        const avatar = container.querySelector<HTMLElement>('.messenger-message-row.own .message-avatar .avatar-image');
+
+        expect(avatar).not.toBeNull();
+        expect(avatar).toHaveClass('compact-head');
+        expect(avatar).toHaveStyle({ backgroundSize: '40px 40px', backgroundPosition: 'center' });
+    });
+});

--- a/src/components/friends/views/messenger/FriendsMessengerView.tsx
+++ b/src/components/friends/views/messenger/FriendsMessengerView.tsx
@@ -206,7 +206,14 @@ export const FriendsMessengerView: FC<{}> = (props) => {
                                     className={'messenger-avatar-tab' + (activeThread === thread ? ' active' : '') + (thread.unread ? ' unread' : '')}
                                     onClick={(event) => setActiveThreadId(thread.threadId)}
                                 >
-                                    <LayoutAvatarImageView figure={figure} headOnly={true} direction={isStaff ? 3 : 2} />
+                                    <LayoutAvatarImageView
+                                        figure={figure}
+                                        headOnly={true}
+                                        compactHead={true}
+                                        compactHeadSize={35}
+                                        compactHeadPadding={0}
+                                        direction={isStaff ? 3 : 2}
+                                    />
                                 </button>
                             );
                         })}

--- a/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadGroup.tsx
+++ b/src/components/friends/views/messenger/messenger-thread/FriendsMessengerThreadGroup.tsx
@@ -88,7 +88,7 @@ export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: M
     };
 
     return <div className={`messenger-message-row${own ? ' own' : ''}`}>
-        {!own && <div className="message-avatar"><LayoutAvatarImageView direction={2} figure={figure} headOnly /></div>}
+        {!own && <div className="message-avatar"><LayoutAvatarImageView direction={2} figure={figure} headOnly compactHead compactHeadSize={40} compactHeadPadding={0} /></div>}
         <div className="messenger-message-body">
             <div className="messenger-message-name">{name}:</div>
             <div className="messenger-message-bubble">
@@ -98,6 +98,6 @@ export const FriendsMessengerThreadGroup: FC<{ thread: MessengerThread; group: M
             </div>
             <div className="messenger-message-time">{group.chats[0].date.toLocaleTimeString()}</div>
         </div>
-        {own && <div className="message-avatar"><LayoutAvatarImageView direction={4} figure={figure} headOnly /></div>}
+        {own && <div className="message-avatar"><LayoutAvatarImageView direction={4} figure={figure} headOnly compactHead compactHeadSize={40} compactHeadPadding={0} /></div>}
     </div>;
 };

--- a/src/css/friends/FriendsView.css
+++ b/src/css/friends/FriendsView.css
@@ -2309,14 +2309,15 @@ button.swf-friends-section-header {
     box-shadow: inset 1px 1px 0 #fff !important;
 }
 
-.swf-messenger-window .messenger-avatar-tab .avatar-image {
-    top: 7px !important;
-    left: 7px !important;
-    width: 20px !important;
-    height: 20px !important;
-    background-size: 52px auto !important;
-    background-position: 51% 40% !important;
+.swf-messenger-window .messenger-avatar-tab .avatar-image.compact-head {
+    top: 0 !important;
+    left: 0 !important;
+    width: 35px !important;
+    height: 35px !important;
+    background-size: 35px 35px !important;
+    background-position: center !important;
     transform: none !important;
+    image-rendering: auto !important;
 }
 
 .swf-messenger-window .messenger-thread-header {
@@ -3011,13 +3012,14 @@ button.swf-friends-section-header {
     overflow: hidden;
 }
 
-.swf-messenger-window .message-avatar .avatar-image {
+.swf-messenger-window .message-avatar .avatar-image.compact-head {
     inset: 0 !important;
     width: 40px !important;
     height: 40px !important;
-    background-size: auto !important;
-    background-position: -25px -38px !important;
+    background-size: 40px 40px !important;
+    background-position: center !important;
     transform: none !important;
+    image-rendering: auto !important;
 }
 
 .swf-messenger-window .chat-messages {

--- a/src/css/friends/FriendsView.messenger-avatar-cascade.test.ts
+++ b/src/css/friends/FriendsView.messenger-avatar-cascade.test.ts
@@ -1,0 +1,60 @@
+/* @vitest-environment jsdom */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import postcss from 'postcss';
+import postcssNested from 'postcss-nested';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/css/friends/FriendsView.css'), 'utf8');
+
+beforeAll(async () => {
+    const result = await postcss([postcssNested]).process(source, { from: undefined });
+    const relevantRules: string[] = [];
+
+    result.root.walkRules((rule) => {
+        if (rule.selector.includes('.swf-messenger-window')) relevantRules.push(rule.toString());
+    });
+
+    const style = document.createElement('style');
+
+    style.textContent = relevantRules.join('\n');
+    document.head.appendChild(style);
+});
+
+const computedAvatarStyle = (containerClass: string, size: number) => {
+    const messenger = document.createElement('div');
+    const container = document.createElement('div');
+    const avatar = document.createElement('div');
+
+    messenger.className = 'swf-messenger-window';
+    container.className = containerClass;
+    avatar.className = 'avatar-image compact-head';
+    avatar.style.backgroundSize = `${size}px ${size}px`;
+    avatar.style.backgroundPosition = 'center';
+    container.appendChild(avatar);
+    messenger.appendChild(container);
+    document.body.appendChild(messenger);
+
+    return getComputedStyle(avatar);
+};
+
+describe('SWF messenger compact avatar cascade', () => {
+    it('keeps conversation-tab heads centered at their cropped size', () => {
+        const style = computedAvatarStyle('messenger-avatar-tab', 35);
+
+        expect(style.width).toBe('35px');
+        expect(style.height).toBe('35px');
+        expect(style.backgroundSize).toBe('35px 35px');
+        expect(style.backgroundPosition).toBe('center center');
+    });
+
+    it('keeps message heads centered at their cropped size', () => {
+        const style = computedAvatarStyle('message-avatar', 40);
+
+        expect(style.width).toBe('40px');
+        expect(style.height).toBe('40px');
+        expect(style.backgroundSize).toBe('40px 40px');
+        expect(style.backgroundPosition).toBe('center center');
+    });
+});


### PR DESCRIPTION
## What changed

- restored tightly cropped avatar heads in messenger conversation tabs
- restored cropped heads beside incoming and sent messages
- rendered friend-list heads as smooth 20x20 compact thumbnails
- replaced fragile fixed CSS offsets and pixelated rescaling with centered size-specific rules
- added component and real CSS-cascade regression tests for messenger and friend-list avatars

## Root cause

The SWF UI overhaul stopped using the existing compact-head raster crop in the messenger and introduced fixed background offsets. The friend list also kept scaling a large head image to 65px inside a 20px row while forcing `image-rendering: pixelated`, which produced the visibly grainy face.

## User impact

Avatar faces remain correctly framed in messenger tabs and messages, while friend-list faces are now generated directly at their final 20x20 display size without the grainy intermediate scaling.

## Validation

- `npm test`: 100 files, 729 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run verify:jsonc`
- targeted Biome lint/check on changed TypeScript and test files
- `git diff --check`
