### PR TITLE
Complete the catalog admin page and offer editor

### DIFF
--- a/src/components/catalog/CatalogAdminContext.tsx
+++ b/src/components/catalog/CatalogAdminContext.tsx
@@ -5,14 +5,16 @@ import {
     CatalogAdminDeletePageComposer,
     CatalogAdminLoadOfferComposer,
     CatalogAdminLoadPageComposer,
-    CatalogAdminMoveOfferComposer,
     CatalogAdminMovePageComposer,
     CatalogAdminOfferDetailsEvent,
     CatalogAdminPageDetailsEvent,
     CatalogAdminPublishComposer,
+    CatalogAdminReorderOffersComposer,
     CatalogAdminResultEvent,
     CatalogAdminSaveOfferComposer,
-    CatalogAdminSavePageComposer
+    CatalogAdminSavePageComposer,
+    CatalogAdminSetPageEnabledComposer,
+    CatalogAdminSetPageVisibleComposer
 } from '@nitrots/nitro-renderer';
 import { createContext, FC, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ICatalogNode, IPurchasableOffer, NotificationAlertType, SendMessageComposer } from '../../api';
@@ -25,11 +27,13 @@ export interface IPageEditData {
     parentId: number;
     catalogMode: string;
     pageLayout: string;
+    iconColor: number;
     iconImage: number;
     enabled: string;
     visible: string;
     minRank: number;
     clubOnly?: string;
+    vipOnly?: string;
     orderNum: number;
     pageHeadline?: string;
     pageTeaser?: string;
@@ -38,6 +42,8 @@ export interface IPageEditData {
     pageText2?: string;
     pageTextDetails?: string;
     pageTextTeaser?: string;
+    roomId?: number;
+    includes?: string;
 }
 
 export interface IOfferEditData {
@@ -59,19 +65,47 @@ export interface IOfferEditData {
 
 export interface IEditingOfferDetails {
     offerId: number;
+    pageId: number;
+    itemIds: string;
+    catalogName: string;
+    costCredits: number;
+    costPoints: number;
+    pointsType: number;
+    amount: number;
+    clubOnly: boolean;
+    extradata: string;
+    haveOffer: boolean;
     offerIdGroup: number;
     limitedStack: number;
+    limitedSells: number;
     orderNumber: number;
+    catalogMode: string;
 }
 
 export interface IEditingPageDetails {
     pageId: number;
     caption: string;
     captionSave: string;
+    parentId: number;
+    catalogMode: string;
+    layout: string;
+    iconColor: number;
+    iconImage: number;
     minRank: number;
     orderNum: number;
     visible: boolean;
     enabled: boolean;
+    clubOnly: boolean;
+    vipOnly: boolean;
+    headline: string;
+    teaser: string;
+    special: string;
+    textOne: string;
+    textTwo: string;
+    textDetails: string;
+    textTeaser: string;
+    roomId: number;
+    includes: string;
 }
 
 export interface ICatalogAdminPendingChange {
@@ -94,6 +128,8 @@ interface ICatalogAdminContext {
     setEditingRootPage: (value: boolean) => void;
     editingPageNode: ICatalogNode | null;
     setEditingPageNode: (node: ICatalogNode | null) => void;
+    creatingPage: boolean;
+    setCreatingPage: (value: boolean) => void;
     loading: boolean;
     lastError: string | null;
     savePage: (data: IPageEditData) => void;
@@ -104,8 +140,8 @@ interface ICatalogAdminContext {
     deleteOffer: (offerId: number, summary?: string) => void;
     reorderOffers: (orders: { id: number; orderNumber: number }[], summary?: string) => void;
     reorderPage: (pageId: number, newParentId: number, newIndex: number, summary?: string) => void;
-    togglePageEnabled: (pageId: number, summary?: string) => void;
-    togglePageVisible: (pageId: number, summary?: string) => void;
+    togglePageEnabled: (pageId: number, enabled: boolean, summary?: string) => void;
+    togglePageVisible: (pageId: number, visible: boolean, summary?: string) => void;
     publishCatalog: () => void;
     hasPendingChanges: boolean;
     pendingChanges: ICatalogAdminPendingChange[];
@@ -129,6 +165,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     const [editingPageData, setEditingPageData] = useState(false);
     const [editingRootPage, setEditingRootPage] = useState(false);
     const [editingPageNode, setEditingPageNode] = useState<ICatalogNode | null>(null);
+    const [creatingPage, setCreatingPage] = useState(false);
     const [loading, setLoading] = useState(false);
     const [lastError, setLastError] = useState<string | null>(null);
     const [hasPendingChanges, setHasPendingChanges] = useState(false);
@@ -136,16 +173,18 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     const pendingActionRef = useRef<string | null>(null);
     const pendingChangeLabelRef = useRef<string | null>(null);
     const pendingChangeRecordedForBatchRef = useRef(false);
-    const pendingReorderRef = useRef<{ remaining: number } | null>(null);
     const { simpleAlert = null } = useNotification();
 
     const beginAdminAction = useCallback((action: string, summary: string) => {
+        if (pendingActionRef.current) return false;
+
         setLoading(true);
         setLastError(null);
         pendingActionRef.current = action;
         pendingChangeLabelRef.current = summary;
 
         if (action === 'reorder') pendingChangeRecordedForBatchRef.current = false;
+        return true;
     }, []);
 
     const recordPendingChange = useCallback((action: string | null, summary: string | null) => {
@@ -186,9 +225,21 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
         setEditingOfferDetails({
             offerId: parser.offerId,
+            pageId: parser.pageId,
+            itemIds: parser.itemIds,
+            catalogName: parser.catalogName,
+            costCredits: parser.costCredits,
+            costPoints: parser.costPoints,
+            pointsType: parser.pointsType,
+            amount: parser.amount,
+            clubOnly: parser.clubOnly,
+            extradata: parser.extradata,
+            haveOffer: parser.haveOffer,
             offerIdGroup: parser.offerIdGroup,
             limitedStack: parser.limitedStack,
-            orderNumber: parser.orderNumber
+            limitedSells: parser.limitedSells,
+            orderNumber: parser.orderNumber,
+            catalogMode: parser.catalogMode
         });
     });
 
@@ -199,10 +250,26 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             pageId: parser.pageId,
             caption: parser.caption,
             captionSave: parser.captionSave,
+            parentId: parser.parentId,
+            catalogMode: parser.catalogMode,
+            layout: parser.layout,
+            iconColor: parser.iconColor,
+            iconImage: parser.iconImage,
             minRank: parser.minRank,
             orderNum: parser.orderNum,
             visible: parser.visible,
-            enabled: parser.enabled
+            enabled: parser.enabled,
+            clubOnly: parser.clubOnly,
+            vipOnly: parser.vipOnly,
+            headline: parser.headline,
+            teaser: parser.teaser,
+            special: parser.special,
+            textOne: parser.textOne,
+            textTwo: parser.textTwo,
+            textDetails: parser.textDetails,
+            textTeaser: parser.textTeaser,
+            roomId: parser.roomId,
+            includes: parser.includes
         });
     });
 
@@ -229,6 +296,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     setEditingPageData(false);
                     setEditingRootPage(false);
                     setEditingPageNode(null);
+                    setCreatingPage(false);
                     e.preventDefault();
                 }
             }
@@ -243,29 +311,6 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         const parser = event.getParser();
         const action = pendingActionRef.current;
         const summary = pendingChangeLabelRef.current;
-
-        if (action === 'reorder' && pendingReorderRef.current) {
-            if (!parser.success) {
-                pendingReorderRef.current = null;
-                pendingActionRef.current = null;
-                pendingChangeLabelRef.current = null;
-                setLoading(false);
-                setLastError(parser.message || 'Operation failed');
-
-                if (simpleAlert) {
-                    simpleAlert(parser.message || 'Operation failed', NotificationAlertType.ALERT, null, null, 'Admin Error');
-                }
-
-                window.dispatchEvent(new Event('catalog-admin-refresh-current-page'));
-                return;
-            }
-
-            pendingReorderRef.current.remaining -= 1;
-
-            if (pendingReorderRef.current.remaining > 0) return;
-
-            pendingReorderRef.current = null;
-        }
 
         pendingActionRef.current = null;
         pendingChangeLabelRef.current = null;
@@ -283,6 +328,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             setEditingPageData(false);
             setEditingRootPage(false);
             setEditingPageNode(null);
+            setCreatingPage(false);
 
             if (action === 'publish') {
                 setHasPendingChanges(false);
@@ -303,7 +349,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const savePage = useCallback(
         (data: IPageEditData) => {
-            beginAdminAction('savePage', `Updated page: ${data.caption || `#${data.pageId}`}`);
+            if (!beginAdminAction('savePage', `Updated page: ${data.caption || `#${data.pageId}`}`)) return;
 
             SendMessageComposer(
                 new CatalogAdminSavePageComposer(
@@ -322,7 +368,15 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.pageTextDetails || '',
                     currentType,
                     data.catalogMode,
-                    data.pageText1 || ''
+                    data.pageText1 || '',
+                    data.iconColor,
+                    data.clubOnly === '1',
+                    data.vipOnly === '1',
+                    data.pageSpecial || '',
+                    data.pageText2 || '',
+                    data.pageTextTeaser || '',
+                    data.roomId || 0,
+                    data.includes || ''
                 )
             );
         },
@@ -331,7 +385,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const createPage = useCallback(
         (data: IPageEditData) => {
-            beginAdminAction('createPage', `Created page: ${data.caption || 'New page'}`);
+            if (!beginAdminAction('createPage', `Created page: ${data.caption || 'New page'}`)) return;
             SendMessageComposer(
                 new CatalogAdminCreatePageComposer(
                     data.caption,
@@ -344,7 +398,19 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.orderNum,
                     data.parentId,
                     currentType,
-                    data.catalogMode
+                    data.catalogMode,
+                    data.iconColor,
+                    data.clubOnly === '1',
+                    data.vipOnly === '1',
+                    data.pageHeadline || '',
+                    data.pageTeaser || '',
+                    data.pageSpecial || '',
+                    data.pageText1 || '',
+                    data.pageText2 || '',
+                    data.pageTextDetails || '',
+                    data.pageTextTeaser || '',
+                    data.roomId || 0,
+                    data.includes || ''
                 )
             );
         },
@@ -353,7 +419,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const deletePage = useCallback(
         (pageId: number, summary?: string) => {
-            beginAdminAction('deletePage', summary || `Deleted page #${pageId}`);
+            if (!beginAdminAction('deletePage', summary || `Deleted page #${pageId}`)) return;
             SendMessageComposer(new CatalogAdminDeletePageComposer(pageId, currentType));
         },
         [currentType, beginAdminAction]
@@ -361,7 +427,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const saveOffer = useCallback(
         (data: IOfferEditData) => {
-            beginAdminAction('saveOffer', `Updated offer: ${data.catalogName || `#${data.offerId}`}`);
+            if (!beginAdminAction('saveOffer', `Updated offer: ${data.catalogName || `#${data.offerId}`}`)) return;
             SendMessageComposer(
                 new CatalogAdminSaveOfferComposer(
                     data.offerId || 0,
@@ -387,7 +453,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const createOffer = useCallback(
         (data: IOfferEditData) => {
-            beginAdminAction('createOffer', `Created offer: ${data.catalogName || 'New offer'}`);
+            if (!beginAdminAction('createOffer', `Created offer: ${data.catalogName || 'New offer'}`)) return;
             SendMessageComposer(
                 new CatalogAdminCreateOfferComposer(
                     data.pageId,
@@ -412,7 +478,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     const deleteOffer = useCallback(
         (offerId: number, summary?: string) => {
-            beginAdminAction('deleteOffer', summary || `Deleted offer #${offerId}`);
+            if (!beginAdminAction('deleteOffer', summary || `Deleted offer #${offerId}`)) return;
             SendMessageComposer(new CatalogAdminDeleteOfferComposer(offerId, currentType));
         },
         [currentType, beginAdminAction]
@@ -422,42 +488,38 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         (orders: { id: number; orderNumber: number }[], summary?: string) => {
             if (!orders.length) return;
 
-            beginAdminAction('reorder', summary || 'Reordered offers');
-            pendingReorderRef.current = { remaining: orders.length };
-
-            for (const order of orders) {
-                SendMessageComposer(new CatalogAdminMoveOfferComposer(order.id, order.orderNumber, currentType));
-            }
+            if (!beginAdminAction('reorder', summary || 'Reordered offers')) return;
+            SendMessageComposer(new CatalogAdminReorderOffersComposer(orders, currentType));
         },
         [currentType, beginAdminAction]
     );
 
     const reorderPage = useCallback(
         (pageId: number, newParentId: number, newIndex: number, summary?: string) => {
-            beginAdminAction('movePage', summary || `Moved page #${pageId}`);
+            if (!beginAdminAction('movePage', summary || `Moved page #${pageId}`)) return;
             SendMessageComposer(new CatalogAdminMovePageComposer(pageId, newParentId, newIndex, currentType));
         },
         [currentType, beginAdminAction]
     );
 
     const togglePageEnabled = useCallback(
-        (pageId: number, summary?: string) => {
-            beginAdminAction('toggleEnabled', summary || `Toggled enabled state for page #${pageId}`);
-            SendMessageComposer(new CatalogAdminMovePageComposer(pageId, -1, -1, currentType));
+        (pageId: number, enabled: boolean, summary?: string) => {
+            if (!beginAdminAction('toggleEnabled', summary || `Toggled enabled state for page #${pageId}`)) return;
+            SendMessageComposer(new CatalogAdminSetPageEnabledComposer(pageId, enabled, currentType));
         },
         [currentType, beginAdminAction]
     );
 
     const togglePageVisible = useCallback(
-        (pageId: number, summary?: string) => {
-            beginAdminAction('toggleVisible', summary || `Toggled visibility for page #${pageId}`);
-            SendMessageComposer(new CatalogAdminMovePageComposer(pageId, -2, -1, currentType));
+        (pageId: number, visible: boolean, summary?: string) => {
+            if (!beginAdminAction('toggleVisible', summary || `Toggled visibility for page #${pageId}`)) return;
+            SendMessageComposer(new CatalogAdminSetPageVisibleComposer(pageId, visible, currentType));
         },
         [currentType, beginAdminAction]
     );
 
     const publishCatalog = useCallback(() => {
-        beginAdminAction('publish', 'Published catalog');
+        if (!beginAdminAction('publish', 'Published catalog')) return;
         SendMessageComposer(new CatalogAdminPublishComposer());
     }, [beginAdminAction]);
 
@@ -477,6 +539,8 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 setEditingRootPage,
                 editingPageNode,
                 setEditingPageNode,
+                creatingPage,
+                setCreatingPage,
                 loading,
                 lastError,
                 hasPendingChanges,

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useState } from 'react';
 import {
-    FaArrowsAlt,
     FaArrowDown,
+    FaArrowsAlt,
     FaArrowUp,
     FaChevronDown,
     FaChevronRight,
@@ -14,14 +14,14 @@ import {
     FaSitemap,
     FaTrash
 } from 'react-icons/fa';
-import { CatalogType, GetConfigurationValue, ICatalogNode, IPurchasableOffer, LocalizeText, ProductTypeEnum } from '../../../../api';
+import { GetConfigurationValue, ICatalogNode, IPurchasableOffer, LocalizeText, ProductTypeEnum } from '../../../../api';
 import { NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
 import { useCatalogActions, useCatalogData, useCatalogUiState } from '../../../../hooks';
 import { replaceCatalogPageOffers } from '../../../../hooks/catalog/useCatalog.helpers';
 import { useCatalogAdmin } from '../../CatalogAdminContext';
 import { parseCatalogTabLabel } from '../../useCatalogWindowWidth';
-import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
+import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 
 type CatalogAdminOffer = Parameters<NonNullable<ReturnType<typeof useCatalogAdmin>>['setEditingOffer']>[0];
 type ManagerTab = 'pages' | 'publish';
@@ -74,7 +74,7 @@ const getOfferIconUrl = (offer: IPurchasableOffer): string | null => {
 
 export const CatalogAdminManagerView: FC<{}> = () => {
     const { rootNode = null, currentPage = null } = useCatalogData();
-    const { currentType = CatalogType.NORMAL, setCurrentPage } = useCatalogUiState();
+    const { setCurrentPage } = useCatalogUiState();
     const { activateNode = null } = useCatalogActions();
     const catalogAdmin = useCatalogAdmin();
     const [activeTab, setActiveTab] = useState<ManagerTab>('pages');
@@ -204,24 +204,17 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     };
 
     const editPage = (node: ICatalogNode | null, isRoot: boolean) => {
+        catalogAdmin.setCreatingPage(false);
         catalogAdmin.setEditingPageNode(isRoot ? null : node);
         catalogAdmin.setEditingRootPage(isRoot);
         catalogAdmin.setEditingPageData(true);
     };
 
     const createCategory = (parent: ICatalogNode) => {
-        catalogAdmin.createPage({
-            caption: 'New Category',
-            captionSave: 'New Category',
-            catalogMode: currentType,
-            pageLayout: 'default_3x3',
-            iconImage: 0,
-            minRank: 1,
-            visible: '1',
-            enabled: '1',
-            orderNum: 99,
-            parentId: parent.pageId
-        });
+        catalogAdmin.setCreatingPage(true);
+        catalogAdmin.setEditingRootPage(false);
+        catalogAdmin.setEditingPageNode(parent);
+        catalogAdmin.setEditingPageData(true);
     };
 
     const deletePage = (node: ICatalogNode) => {
@@ -339,10 +332,7 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                     <button
                         className="nitro-catalog-admin-btn"
                         onClick={() =>
-                            catalogAdmin.togglePageVisible(
-                                selectedNode.pageId,
-                                `${isHidden ? 'Showed' : 'Hidden'} page: ${nodeName(selectedNode)}`
-                            )
+                            catalogAdmin.togglePageVisible(selectedNode.pageId, isHidden, `${isHidden ? 'Showed' : 'Hidden'} page: ${nodeName(selectedNode)}`)
                         }
                     >
                         {isHidden ? <FaEye /> : <FaEyeSlash />} <span>{isHidden ? 'Show' : 'Hide'}</span>
@@ -468,16 +458,16 @@ export const CatalogAdminManagerView: FC<{}> = () => {
         <div className="nitro-catalog-admin-publish">
             <div className={`nitro-catalog-admin-publish-status ${hasPendingChanges ? 'has-pending' : ''}`}>
                 {hasPendingChanges
-                    ? `${pendingChanges.length} unpublished change${pendingChanges.length === 1 ? '' : 's'}.`
-                    : 'Catalog is up to date — no pending changes.'}
+                    ? `${pendingChanges.length} change${pendingChanges.length === 1 ? '' : 's'} awaiting client refresh.`
+                    : 'Catalog is up to date — no changes waiting to be published.'}
             </div>
             <p className="nitro-catalog-admin-publish-text">
-                Publishing pushes every pending page, offer and ordering change live to all connected players. Edits are saved as drafts until you publish.
+                Changes are saved immediately. Publishing reloads the server catalog and tells connected players to refresh it.
             </p>
 
             {pendingChanges.length > 0 && (
                 <div className="nitro-catalog-admin-publish-changes">
-                    <div className="nitro-catalog-admin-publish-changes-head">Pending changes</div>
+                    <div className="nitro-catalog-admin-publish-changes-head">Changes since last publish</div>
                     <ul className="nitro-catalog-admin-publish-changes-list">
                         {[...pendingChanges].reverse().map((change) => (
                             <li key={change.id} className="nitro-catalog-admin-publish-change">

--- a/src/components/catalog/views/admin/CatalogAdminOfferEditView.test.ts
+++ b/src/components/catalog/views/admin/CatalogAdminOfferEditView.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import * as OfferEditor from './CatalogAdminOfferEditView';
+
+describe('catalog admin offer form state', () => {
+    it('uses the complete authoritative offer response including bundle quantities', () => {
+        const createFormState = (OfferEditor as any).createCatalogAdminOfferFormState;
+        const state = createFormState({
+            offerId: 99,
+            pageId: 42,
+            itemIds: '100:2;200:5',
+            catalogName: 'quantity_bundle',
+            costCredits: 25,
+            costPoints: 10,
+            pointsType: 5,
+            amount: 1,
+            clubOnly: true,
+            extradata: 'extra',
+            haveOffer: false,
+            offerIdGroup: 77,
+            limitedStack: 100,
+            limitedSells: 12,
+            orderNumber: 4,
+            catalogMode: 'NORMAL'
+        });
+
+        expect(state).toMatchObject({
+            offerId: 99,
+            pageId: 42,
+            itemIds: '100:2;200:5',
+            catalogName: 'quantity_bundle',
+            costCredits: 25,
+            costPoints: 10,
+            pointsType: 5,
+            amount: 1,
+            clubOnly: '1',
+            extradata: 'extra',
+            haveOffer: '0',
+            offerId_group: 77,
+            limitedStack: 100,
+            orderNumber: 4
+        });
+    });
+
+    it('validates bundle syntax and limited stock before sending an offer', () => {
+        const validate = (OfferEditor as any).validateCatalogAdminOfferForm;
+        const valid = {
+            pageId: 42,
+            itemIds: '100:2;200:5',
+            catalogName: 'quantity_bundle',
+            costCredits: 25,
+            costPoints: 0,
+            pointsType: 0,
+            amount: 1,
+            clubOnly: '0',
+            extradata: '',
+            haveOffer: '1',
+            offerId_group: 0,
+            limitedStack: 100,
+            orderNumber: 4
+        };
+
+        expect(validate(valid, false, 12)).toBeNull();
+        expect(validate({ ...valid, itemIds: '100:0' }, false, 12)).toMatch(/item ids/i);
+        expect(validate({ ...valid, limitedStack: 5 }, false, 12)).toMatch(/sold/i);
+        expect(validate({ ...valid, catalogName: '   ' }, false, 12)).toMatch(/name/i);
+    });
+});

--- a/src/components/catalog/views/admin/CatalogAdminOfferEditView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminOfferEditView.tsx
@@ -1,8 +1,8 @@
 import { FC, useEffect, useState } from 'react';
 import { FaCubes, FaSave, FaSpinner, FaTrash } from 'react-icons/fa';
-import { GetConfigurationValue, IPurchasableOffer, LocalizeText, ProductTypeEnum, localizeWithFallback } from '../../../../api';
-import { useCatalogData } from '../../../../hooks';
-import { IOfferEditData, useCatalogAdmin } from '../../CatalogAdminContext';
+import { CatalogType, GetConfigurationValue, IPurchasableOffer, LocalizeText, localizeWithFallback, ProductTypeEnum } from '../../../../api';
+import { useCatalogData, useCatalogUiState, usePurse } from '../../../../hooks';
+import { IEditingOfferDetails, IOfferEditData, useCatalogAdmin } from '../../CatalogAdminContext';
 import { CatalogAdminModalView } from './CatalogAdminModalView';
 import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 
@@ -30,8 +30,47 @@ const getOfferIconUrl = (offer: IPurchasableOffer | null): string | null => {
     return product.getIconUrl(offer) ?? null;
 };
 
+export const createCatalogAdminOfferFormState = (details: IEditingOfferDetails): IOfferEditData => ({
+    offerId: details.offerId,
+    pageId: details.pageId,
+    itemIds: details.itemIds,
+    catalogName: details.catalogName,
+    costCredits: details.costCredits,
+    costPoints: details.costPoints,
+    pointsType: details.pointsType,
+    amount: details.amount,
+    clubOnly: details.clubOnly ? '1' : '0',
+    extradata: details.extradata,
+    haveOffer: details.haveOffer ? '1' : '0',
+    offerId_group: details.offerIdGroup,
+    limitedStack: details.limitedStack,
+    orderNumber: details.orderNumber
+});
+
+export const validateCatalogAdminOfferForm = (data: IOfferEditData, builderCatalog: boolean, limitedSells: number): string | null => {
+    if (data.pageId <= 0) return 'Select a valid catalog page.';
+    if (!data.catalogName.trim()) return 'Offer name is required.';
+
+    const cleanItemIds = data.itemIds.replace(/\s+/g, '');
+    if (!builderCatalog && !cleanItemIds) return 'Item IDs are required.';
+    if (cleanItemIds) {
+        const entries = cleanItemIds.split(/[;,]/);
+        if (entries.some((entry) => !/^\d+(?::[1-9]\d*)?$/.test(entry) || Number(entry.split(':')[0]) <= 0)) {
+            return 'Item IDs must use the format 123 or 123:2, separated by semicolons.';
+        }
+    }
+
+    if (data.costCredits < 0 || data.costPoints < 0 || data.pointsType < 0) return 'Prices and currency type cannot be negative.';
+    if (data.amount < 1 || data.amount > 10000) return 'Quantity must be between 1 and 10,000.';
+    if (data.orderNumber < 0) return 'Order cannot be negative.';
+    if (data.limitedStack < limitedSells) return 'Limited stack cannot be lower than the number already sold.';
+    return null;
+};
+
 export const CatalogAdminOfferEditView: FC<{}> = () => {
     const { currentPage = null } = useCatalogData();
+    const { currentType } = useCatalogUiState();
+    const { purse } = usePurse();
     const catalogAdmin = useCatalogAdmin();
     const editingOffer = catalogAdmin?.editingOffer ?? null;
     const editingOfferDetails = catalogAdmin?.editingOfferDetails ?? null;
@@ -91,36 +130,54 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
 
     useEffect(() => {
         if (!editingOfferDetails) return;
+        if (!editingOffer || editingOfferDetails.offerId !== editingOffer.offerId) return;
 
-        setOfferIdGroup(editingOfferDetails.offerIdGroup);
-        setLimitedStack(editingOfferDetails.limitedStack);
-        setOrderNumber(editingOfferDetails.orderNumber);
-    }, [editingOfferDetails]);
+        const form = createCatalogAdminOfferFormState(editingOfferDetails);
+        setItemIds(form.itemIds);
+        setCatalogName(form.catalogName);
+        setCostCredits(form.costCredits);
+        setCostPoints(form.costPoints);
+        setPointsType(form.pointsType);
+        setAmount(form.amount);
+        setClubOnly(form.clubOnly);
+        setExtradata(form.extradata);
+        setHaveOffer(form.haveOffer);
+        setOfferIdGroup(form.offerId_group);
+        setLimitedStack(form.limitedStack);
+        setOrderNumber(form.orderNumber);
+    }, [editingOffer, editingOfferDetails]);
 
     if (!editingOffer) return null;
 
+    const detailsReady = isNew || editingOfferDetails?.offerId === editingOffer.offerId;
+    const limitedSells = isNew ? 0 : editingOfferDetails?.limitedSells || 0;
+    const formData: IOfferEditData = {
+        offerId: isNew ? undefined : editingOffer.offerId,
+        pageId: isNew ? currentPage?.pageId || 0 : editingOfferDetails?.pageId || 0,
+        itemIds,
+        catalogName,
+        costCredits,
+        costPoints,
+        pointsType,
+        amount,
+        clubOnly,
+        extradata,
+        haveOffer,
+        offerId_group: offerId,
+        limitedStack,
+        orderNumber
+    };
+    const validationError = detailsReady ? validateCatalogAdminOfferForm(formData, currentType === CatalogType.BUILDER, limitedSells) : null;
+    const currencyTypes = Array.from(new Set([0, 5, 101, pointsType, ...Array.from(purse?.activityPoints?.keys?.() || [])]))
+        .filter((type) => type >= 0)
+        .sort((left, right) => left - right);
+
     const handleSave = async () => {
-        if (!saveOffer || !createOffer) return;
+        if (!saveOffer || !createOffer || !detailsReady) return;
+        if (validationError) return;
 
-        const data: IOfferEditData = {
-            offerId: isNew ? undefined : editingOffer.offerId,
-            pageId: currentPage?.pageId || 0,
-            itemIds,
-            catalogName,
-            costCredits,
-            costPoints,
-            pointsType,
-            amount,
-            clubOnly,
-            extradata,
-            haveOffer,
-            offerId_group: offerId,
-            limitedStack,
-            orderNumber
-        };
-
-        if (isNew) createOffer(data);
-        else saveOffer(data);
+        if (isNew) createOffer(formData);
+        else saveOffer(formData);
     };
 
     const handleDelete = () => {
@@ -131,7 +188,8 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
 
     const inputClass = 'nitro-catalog-admin-input';
     const previewIconUrl = isNew ? null : getOfferIconUrl(editingOffer);
-    const previewName = catalogName || editingOffer.localizationName || (isNew ? localizeWithFallback('catalog.admin.offer.new', 'New offer') : `#${editingOffer.offerId}`);
+    const previewName =
+        catalogName || editingOffer.localizationName || (isNew ? localizeWithFallback('catalog.admin.offer.new', 'New offer') : `#${editingOffer.offerId}`);
     const previewFallbackIcon = isNew ? null : editingOffer.product?.getIconUrl(editingOffer);
 
     return (
@@ -151,7 +209,8 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                         draggable={false}
                                         src={previewIconUrl}
                                         onError={(event) => {
-                                            if (previewFallbackIcon && event.currentTarget.src !== previewFallbackIcon) event.currentTarget.src = previewFallbackIcon;
+                                            if (previewFallbackIcon && event.currentTarget.src !== previewFallbackIcon)
+                                                event.currentTarget.src = previewFallbackIcon;
                                             else event.currentTarget.style.visibility = 'hidden';
                                         }}
                                     />
@@ -164,7 +223,9 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                     {previewName}
                                 </span>
                                 <span className="nitro-catalog-admin-offer-preview-sub">
-                                    {isNew ? localizeWithFallback('catalog.admin.offer.new', 'New offer') : `${localizeWithFallback('catalog.admin.offer.id', 'Offer ID')} #${editingOffer.offerId}`}
+                                    {isNew
+                                        ? localizeWithFallback('catalog.admin.offer.new', 'New offer')
+                                        : `${localizeWithFallback('catalog.admin.offer.id', 'Offer ID')} #${editingOffer.offerId}`}
                                     {amount > 1 ? ` · x${amount}` : ''}
                                 </span>
                                 <span className="nitro-catalog-admin-offer-preview-price">
@@ -188,7 +249,9 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                             </div>
                             <div className="nitro-catalog-admin-form-grid is-3col">
                                 <div className="nitro-catalog-admin-form-field is-span-3">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.offer.item.ids', 'Item IDs')}</label>
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.offer.item.ids', 'Item IDs')}
+                                    </label>
                                     <input
                                         className={inputClass}
                                         placeholder={localizeWithFallback('catalog.admin.offer.item.ids.placeholder', '1234 or 100;200')}
@@ -199,15 +262,32 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.quantity')}</label>
-                                    <input className={inputClass} min={1} type="number" value={amount} onChange={(e) => setAmount(parseInt(e.target.value) || 1)} />
+                                    <input
+                                        className={inputClass}
+                                        min={1}
+                                        type="number"
+                                        value={amount}
+                                        onChange={(e) => setAmount(parseInt(e.target.value) || 1)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.order')}</label>
-                                    <input className={inputClass} min={0} type="number" value={orderNumber} onChange={(e) => setOrderNumber(parseInt(e.target.value) || 0)} />
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={orderNumber}
+                                        onChange={(e) => setOrderNumber(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.offer.id', 'Offer ID')}</label>
-                                    <input className={inputClass} type="number" value={offerId} onChange={(e) => setOfferIdGroup(parseInt(e.target.value) || -1)} />
+                                    <input
+                                        className={inputClass}
+                                        type="number"
+                                        value={offerId}
+                                        onChange={(e) => setOfferIdGroup(parseInt(e.target.value) || -1)}
+                                    />
                                 </div>
                             </div>
                         </section>
@@ -217,18 +297,32 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                             <div className="nitro-catalog-admin-form-grid is-3col">
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.credits')}</label>
-                                    <input className={inputClass} min={0} type="number" value={costCredits} onChange={(e) => setCostCredits(parseInt(e.target.value) || 0)} />
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={costCredits}
+                                        onChange={(e) => setCostCredits(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.points')}</label>
-                                    <input className={inputClass} min={0} type="number" value={costPoints} onChange={(e) => setCostPoints(parseInt(e.target.value) || 0)} />
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={costPoints}
+                                        onChange={(e) => setCostPoints(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.points.type')}</label>
                                     <select className={inputClass} value={pointsType} onChange={(e) => setPointsType(parseInt(e.target.value))}>
-                                        <option value={0}>{localizeWithFallback('catalog.admin.currency.duckets', 'Duckets')}</option>
-                                        <option value={5}>{localizeWithFallback('catalog.admin.currency.diamonds', 'Diamonds')}</option>
-                                        <option value={101}>{localizeWithFallback('catalog.admin.currency.seasonal', 'Seasonal')}</option>
+                                        {currencyTypes.map((type) => (
+                                            <option key={type} value={type}>
+                                                {localizeWithFallback(`purse.seasonal.currency.${type}`, `Currency ${type}`)} ({type})
+                                            </option>
+                                        ))}
                                     </select>
                                 </div>
                             </div>
@@ -245,9 +339,25 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                     </select>
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.offer.limited.stack', 'Limited stack')}</label>
-                                    <input className={inputClass} min={0} type="number" value={limitedStack} onChange={(e) => setLimitedStack(parseInt(e.target.value) || 0)} />
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.offer.limited.stack', 'Limited stack')}
+                                    </label>
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={limitedStack}
+                                        onChange={(e) => setLimitedStack(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
+                                {!isNew && (
+                                    <div className="nitro-catalog-admin-form-field">
+                                        <label className="nitro-catalog-admin-label is-field">
+                                            {localizeWithFallback('catalog.admin.offer.limited.sold', 'Already sold')}
+                                        </label>
+                                        <input className={inputClass} readOnly type="number" value={limitedSells} />
+                                    </div>
+                                )}
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.extradata')}</label>
                                     <input
@@ -260,13 +370,19 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                 </div>
                             </div>
                             <label className="nitro-catalog-admin-form-toggle">
-                                <input checked={haveOffer === '1'} id="haveOffer" type="checkbox" onChange={(e) => setHaveOffer(e.target.checked ? '1' : '0')} />
+                                <input
+                                    checked={haveOffer === '1'}
+                                    id="haveOffer"
+                                    type="checkbox"
+                                    onChange={(e) => setHaveOffer(e.target.checked ? '1' : '0')}
+                                />
                                 <span>{LocalizeText('catalog.admin.offer.have.offer')}</span>
                             </label>
                         </section>
                     </div>
 
                     <div className="nitro-catalog-admin-form-actions">
+                        {validationError && <span className="nitro-catalog-admin-translate-error">{validationError}</span>}
                         {!isNew ? (
                             <button className="nitro-catalog-admin-button is-danger" onClick={handleDelete}>
                                 <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
@@ -274,7 +390,7 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                         ) : (
                             <div />
                         )}
-                        <button className="nitro-catalog-admin-button is-primary" disabled={loading} onClick={handleSave}>
+                        <button className="nitro-catalog-admin-button is-primary" disabled={loading || !detailsReady || !!validationError} onClick={handleSave}>
                             {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
                             {isNew ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
                         </button>

--- a/src/components/catalog/views/admin/CatalogAdminPageEditView.test.ts
+++ b/src/components/catalog/views/admin/CatalogAdminPageEditView.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import * as PageEditor from './CatalogAdminPageEditView';
+
+describe('catalog admin page form state', () => {
+    it('uses the authoritative database values returned for the selected page', () => {
+        const createFormState = (PageEditor as any).createCatalogAdminPageFormState;
+        const state = createFormState({
+            pageId: 42,
+            caption: 'Guild shop',
+            captionSave: 'guild_shop',
+            parentId: 7,
+            catalogMode: 'BOTH',
+            layout: 'guild_furni',
+            iconColor: 3,
+            iconImage: 145,
+            minRank: 5,
+            orderNum: 9,
+            visible: true,
+            enabled: false,
+            clubOnly: true,
+            vipOnly: false,
+            headline: 'headline',
+            teaser: 'teaser',
+            special: 'special',
+            textOne: 'text one',
+            textTwo: 'text two',
+            textDetails: 'details',
+            textTeaser: 'teaser text',
+            roomId: 123,
+            includes: '1;2;3'
+        });
+
+        expect(state).toMatchObject({
+            caption: 'Guild shop',
+            captionSave: 'guild_shop',
+            parentId: 7,
+            catalogMode: 'BOTH',
+            pageLayout: 'guild_furni',
+            iconColor: 3,
+            iconImage: 145,
+            minRank: 5,
+            orderNum: 9,
+            visible: '1',
+            enabled: '0',
+            clubOnly: '1',
+            vipOnly: '0',
+            pageHeadline: 'headline',
+            pageTeaser: 'teaser',
+            pageSpecial: 'special',
+            pageText1: 'text one',
+            pageText2: 'text two',
+            pageTextDetails: 'details',
+            pageTextTeaser: 'teaser text',
+            roomId: 123,
+            includes: '1;2;3'
+        });
+    });
+
+    it('creates a new-page form without writing a placeholder page first', () => {
+        const createNewFormState = (PageEditor as any).createCatalogAdminNewPageFormState;
+
+        expect(createNewFormState(7, 'NORMAL')).toMatchObject({
+            pageId: undefined,
+            caption: '',
+            captionSave: '',
+            parentId: 7,
+            catalogMode: 'NORMAL',
+            pageLayout: 'default_3x3',
+            iconImage: 0,
+            minRank: 1,
+            orderNum: 0,
+            visible: '1',
+            enabled: '1'
+        });
+    });
+
+    it('validates required page fields and included page ids', () => {
+        const validate = (PageEditor as any).validateCatalogAdminPageForm;
+        const valid = (PageEditor as any).createCatalogAdminNewPageFormState(7, 'NORMAL');
+
+        expect(validate({ ...valid, caption: 'New page', includes: '1;2,3' })).toBeNull();
+        expect(validate(valid)).toMatch(/caption/i);
+        expect(validate({ ...valid, caption: 'New page', includes: '1;abc' })).toMatch(/included/i);
+        expect(validate({ ...valid, caption: 'New page', minRank: 0 })).toMatch(/rank/i);
+    });
+});

--- a/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
@@ -2,23 +2,26 @@ import { FC, useEffect, useState } from 'react';
 import { FaLanguage, FaSave, FaSpinner, FaTrash } from 'react-icons/fa';
 import { CatalogType, LocalizeText, localizeWithFallback } from '../../../../api';
 import { useCatalogData, useCatalogUiState, useTranslationActions, useTranslationState } from '../../../../hooks';
-import { IPageEditData, useCatalogAdmin } from '../../CatalogAdminContext';
+import { IEditingPageDetails, IPageEditData, useCatalogAdmin } from '../../CatalogAdminContext';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
 import { CatalogAdminModalView } from './CatalogAdminModalView';
 
 const LAYOUT_OPTIONS = [
     'default_3x3',
-    'frontpage4',
+    'club_buy',
+    'club_gift',
+    'frontpage',
     'pets',
     'pets2',
     'pets3',
     'spaces_new',
+    'spaces',
     'soundmachine',
     'trophies',
     'roomads',
-    'guild_frontpage',
+    'guilds',
     'guild_forum',
-    'guild_custom_furni',
+    'guild_furni',
     'vip_buy',
     'builders_club_frontpage',
     'builders_club_addons',
@@ -29,11 +32,27 @@ const LAYOUT_OPTIONS = [
     'recycler_info',
     'recycler_prizes',
     'info_loyalty',
+    'info_duckets',
+    'info_rentables',
+    'info_pets',
+    'loyalty_vip_buy',
     'badge_display',
     'bots',
     'single_bundle',
-    'color_grouping',
-    'recent_purchases'
+    'sold_ltd_items',
+    'plasto',
+    'default_3x3_color_grouping',
+    'recent_purchases',
+    'room_bundle',
+    'petcustomization',
+    'frontpage_featured',
+    'root',
+    'monkey',
+    'niko',
+    'mad_money',
+    'custom_prefix',
+    'productpage1',
+    'collectibles'
 ];
 
 const MODE_OPTIONS = [
@@ -41,6 +60,63 @@ const MODE_OPTIONS = [
     { value: 'BUILDER', label: 'Builder' },
     { value: 'BOTH', label: 'Both' }
 ];
+
+export const createCatalogAdminPageFormState = (details: IEditingPageDetails): IPageEditData => ({
+    pageId: details.pageId,
+    caption: details.caption,
+    captionSave: details.captionSave,
+    parentId: details.parentId,
+    catalogMode: details.catalogMode,
+    pageLayout: details.layout,
+    iconColor: details.iconColor,
+    iconImage: details.iconImage,
+    minRank: details.minRank,
+    orderNum: details.orderNum,
+    visible: details.visible ? '1' : '0',
+    enabled: details.enabled ? '1' : '0',
+    clubOnly: details.clubOnly ? '1' : '0',
+    vipOnly: details.vipOnly ? '1' : '0',
+    pageHeadline: details.headline,
+    pageTeaser: details.teaser,
+    pageSpecial: details.special,
+    pageText1: details.textOne,
+    pageText2: details.textTwo,
+    pageTextDetails: details.textDetails,
+    pageTextTeaser: details.textTeaser,
+    roomId: details.roomId,
+    includes: details.includes
+});
+
+export const createCatalogAdminNewPageFormState = (parentId: number, catalogMode: string): IPageEditData => ({
+    pageId: undefined,
+    caption: '',
+    captionSave: '',
+    parentId,
+    catalogMode,
+    pageLayout: 'default_3x3',
+    iconColor: 1,
+    iconImage: 0,
+    minRank: 1,
+    orderNum: 0,
+    visible: '1',
+    enabled: '1'
+});
+
+export const validateCatalogAdminPageForm = (data: IPageEditData): string | null => {
+    if (!data.caption.trim()) return 'Page caption is required.';
+    if (!LAYOUT_OPTIONS.includes(data.pageLayout)) return 'Select a valid page layout.';
+    if (data.minRank < 1) return 'Minimum rank must be at least 1.';
+    if (data.iconImage < 0 || data.iconColor < 0) return 'Icon values cannot be negative.';
+    if (data.orderNum < 0) return 'Order cannot be negative.';
+    if (data.parentId < -1) return 'Parent page ID is invalid.';
+    if ((data.roomId || 0) < 0) return 'Room ID cannot be negative.';
+
+    const includes = (data.includes || '').replace(/\s+/g, '');
+    if (includes && includes.split(/[;,]/).some((id) => !/^[1-9]\d*$/.test(id))) {
+        return 'Included page IDs must be positive numbers separated by semicolons.';
+    }
+    return null;
+};
 
 export const CatalogAdminPageEditView: FC<{}> = () => {
     const { currentPage = null, rootNode = null } = useCatalogData();
@@ -50,6 +126,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const editingRootPage = catalogAdmin?.editingRootPage ?? false;
     const editingPageNode = catalogAdmin?.editingPageNode ?? null;
     const editingPageDetails = catalogAdmin?.editingPageDetails ?? null;
+    const creatingPage = catalogAdmin?.creatingPage ?? false;
     const requestPageDetails = catalogAdmin?.requestPageDetails;
     const loading = catalogAdmin?.loading ?? false;
 
@@ -57,13 +134,24 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const [captionSave, setCaptionSave] = useState('');
     const [catalogMode, setCatalogMode] = useState<string>('NORMAL');
     const [pageLayout, setPageLayout] = useState('default_3x3');
+    const [iconColor, setIconColor] = useState(1);
     const [iconImage, setIconImage] = useState(0);
     const [minRank, setMinRank] = useState(1);
     const [visible, setVisible] = useState('1');
     const [enabled, setEnabled] = useState('1');
     const [orderNum, setOrderNum] = useState(0);
     const [parentId, setParentId] = useState(-1);
+    const [clubOnly, setClubOnly] = useState('0');
+    const [vipOnly, setVipOnly] = useState('0');
+    const [pageHeadline, setPageHeadline] = useState('');
+    const [pageTeaser, setPageTeaser] = useState('');
+    const [pageSpecial, setPageSpecial] = useState('');
     const [pageText1, setPageText1] = useState('');
+    const [pageText2, setPageText2] = useState('');
+    const [pageTextDetails, setPageTextDetails] = useState('');
+    const [pageTextTeaser, setPageTextTeaser] = useState('');
+    const [roomId, setRoomId] = useState(0);
+    const [includes, setIncludes] = useState('');
     const [showTranslate, setShowTranslate] = useState(false);
     const [translateTargetLanguage, setTranslateTargetLanguage] = useState('en');
     const [isTranslating, setIsTranslating] = useState(false);
@@ -79,10 +167,42 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
         catalogAdmin?.setEditingPageData(false);
         catalogAdmin?.setEditingRootPage(false);
         catalogAdmin?.setEditingPageNode(null);
+        catalogAdmin?.setCreatingPage(false);
     };
 
     useEffect(() => {
         if (!editingPageData || !targetNode) return;
+
+        if (creatingPage) {
+            const mode = currentType === CatalogType.BUILDER ? 'BUILDER' : 'NORMAL';
+            const form = createCatalogAdminNewPageFormState(targetNode.pageId, mode);
+            setCaption(form.caption);
+            setCaptionSave(form.captionSave);
+            setCatalogMode(form.catalogMode);
+            setPageLayout(form.pageLayout);
+            setIconColor(form.iconColor);
+            setIconImage(form.iconImage);
+            setMinRank(form.minRank);
+            setOrderNum(form.orderNum);
+            setParentId(form.parentId);
+            setVisible(form.visible);
+            setEnabled(form.enabled);
+            setClubOnly(form.clubOnly || '0');
+            setVipOnly(form.vipOnly || '0');
+            setPageHeadline('');
+            setPageTeaser('');
+            setPageSpecial('');
+            setPageText1('');
+            setPageText2('');
+            setPageTextDetails('');
+            setPageTextTeaser('');
+            setRoomId(0);
+            setIncludes('');
+            setShowTranslate(false);
+            setIsTranslating(false);
+            setTranslateError(null);
+            return;
+        }
 
         setCaption('');
         setCaptionSave('');
@@ -91,13 +211,11 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
         setEnabled('1');
 
         setCatalogMode(currentType === CatalogType.BUILDER ? 'BUILDER' : 'NORMAL');
-        setPageLayout(currentPage?.layoutCode || 'default_3x3');
+        setPageLayout('default_3x3');
         setIconImage(targetNode.iconId ?? 0);
         setVisible(targetNode.isVisible ? '1' : '0');
 
-        const matchesLoadedPage = currentPage && targetPageId === currentPage.pageId;
-        const existingText1 = matchesLoadedPage && currentPage.localization ? currentPage.localization.getText(0) : '';
-        setPageText1(existingText1 || '');
+        setPageText1('');
         setShowTranslate(false);
         setIsTranslating(false);
         setTranslateError(null);
@@ -105,44 +223,75 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
         setParentId(typeof wireParentId === 'number' && wireParentId !== -1 ? wireParentId : targetNode.parent ? targetNode.parent.pageId : -1);
 
         if (targetPageId != null && targetPageId >= 0) requestPageDetails?.(targetPageId);
-    }, [editingPageData, targetNode, currentPage, currentType, targetPageId, requestPageDetails]);
+    }, [editingPageData, creatingPage, targetNode, currentPage, currentType, targetPageId, requestPageDetails]);
 
     useEffect(() => {
         if (!editingPageDetails) return;
         if (targetPageId != null && editingPageDetails.pageId !== targetPageId) return;
 
-        setCaption(editingPageDetails.caption);
-        setCaptionSave(editingPageDetails.captionSave);
-        setMinRank(editingPageDetails.minRank);
-        setOrderNum(editingPageDetails.orderNum);
-        setVisible(editingPageDetails.visible ? '1' : '0');
-        setEnabled(editingPageDetails.enabled ? '1' : '0');
+        const form = createCatalogAdminPageFormState(editingPageDetails);
+        setCaption(form.caption);
+        setCaptionSave(form.captionSave);
+        setCatalogMode(form.catalogMode);
+        setPageLayout(form.pageLayout);
+        setIconColor(form.iconColor);
+        setIconImage(form.iconImage);
+        setMinRank(form.minRank);
+        setOrderNum(form.orderNum);
+        setParentId(form.parentId);
+        setVisible(form.visible);
+        setEnabled(form.enabled);
+        setClubOnly(form.clubOnly || '0');
+        setVipOnly(form.vipOnly || '0');
+        setPageHeadline(form.pageHeadline || '');
+        setPageTeaser(form.pageTeaser || '');
+        setPageSpecial(form.pageSpecial || '');
+        setPageText1(form.pageText1 || '');
+        setPageText2(form.pageText2 || '');
+        setPageTextDetails(form.pageTextDetails || '');
+        setPageTextTeaser(form.pageTextTeaser || '');
+        setRoomId(form.roomId || 0);
+        setIncludes(form.includes || '');
     }, [editingPageDetails, targetPageId]);
 
     if (!editingPageData || !targetNode) return null;
 
     const inputClass = 'nitro-catalog-admin-input';
     const previewName = caption || editingPageDetails?.caption || localizeWithFallback('catalog.admin.page.untitled', 'Untitled page');
+    const detailsReady = creatingPage || editingPageDetails?.pageId === targetPageId;
+    const formData: IPageEditData = {
+        pageId: creatingPage ? undefined : targetPageId,
+        caption,
+        captionSave,
+        catalogMode,
+        pageLayout,
+        iconColor,
+        iconImage,
+        minRank,
+        visible,
+        enabled,
+        orderNum,
+        parentId,
+        clubOnly,
+        vipOnly,
+        pageHeadline,
+        pageTeaser,
+        pageSpecial,
+        pageText1,
+        pageText2,
+        pageTextDetails,
+        pageTextTeaser,
+        roomId,
+        includes
+    };
+    const validationError = detailsReady ? validateCatalogAdminPageForm(formData) : null;
 
     const handleSave = async () => {
-        if (!catalogAdmin?.savePage) return;
+        if (!catalogAdmin?.savePage || !catalogAdmin.createPage || !detailsReady) return;
+        if (validationError) return;
 
-        const data: IPageEditData = {
-            pageId: targetPageId,
-            caption,
-            captionSave,
-            catalogMode,
-            pageLayout,
-            iconImage,
-            minRank,
-            visible,
-            enabled,
-            orderNum,
-            parentId,
-            pageText1
-        };
-
-        catalogAdmin.savePage(data);
+        if (creatingPage) catalogAdmin.createPage(formData);
+        else catalogAdmin.savePage(formData);
     };
 
     const openTranslate = () => {
@@ -178,7 +327,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     };
 
     const handleDelete = async () => {
-        if (!catalogAdmin?.deletePage || isRoot) return;
+        if (!catalogAdmin?.deletePage || isRoot || creatingPage) return;
         if (!confirm(LocalizeText('catalog.admin.delete.page.confirm', ['name'], [editingPageDetails?.caption ?? '']))) return;
 
         catalogAdmin.deletePage(targetPageId);
@@ -187,7 +336,13 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
 
     return (
         <CatalogAdminModalView
-            title={isRoot ? LocalizeText('catalog.admin.edit.root') : localizeWithFallback('catalog.admin.edit.page', 'Edit page')}
+            title={
+                creatingPage
+                    ? localizeWithFallback('catalog.admin.create.page', 'Create page')
+                    : isRoot
+                      ? LocalizeText('catalog.admin.edit.root')
+                      : localizeWithFallback('catalog.admin.edit.page', 'Edit page')
+            }
             widthClassName="w-[540px]"
             onClose={closeForm}
         >
@@ -195,9 +350,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                 <div className="nitro-catalog-admin-form-sheet">
                     <div className="nitro-catalog-admin-form-scroll">
                         <div className="nitro-catalog-admin-form-hero">
-                            <span className="nitro-catalog-admin-page-preview-icon">
-                                {iconImage > 0 ? <CatalogIconView icon={iconImage} /> : null}
-                            </span>
+                            <span className="nitro-catalog-admin-page-preview-icon">{iconImage > 0 ? <CatalogIconView icon={iconImage} /> : null}</span>
                             <div className="nitro-catalog-admin-page-preview-info">
                                 <span className="nitro-catalog-admin-page-preview-name" title={previewName}>
                                     {previewName}
@@ -212,7 +365,9 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                             <div className="nitro-catalog-admin-section-title">{localizeWithFallback('catalog.admin.page.section.identity', 'Identity')}</div>
                             <div className="nitro-catalog-admin-form-grid is-2col">
                                 <div className="nitro-catalog-admin-form-field is-span-2">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.page.caption', 'Caption')}</label>
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.caption', 'Caption')}
+                                    </label>
                                     <input className={inputClass} value={caption} onChange={(e) => setCaption(e.target.value)} />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field is-span-2">
@@ -222,12 +377,40 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                     <input className={inputClass} value={captionSave} onChange={(e) => setCaptionSave(e.target.value)} />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.page.min.rank', 'Min rank')}</label>
-                                    <input className={inputClass} min={1} type="number" value={minRank} onChange={(e) => setMinRank(parseInt(e.target.value) || 1)} />
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.min.rank', 'Min rank')}
+                                    </label>
+                                    <input
+                                        className={inputClass}
+                                        min={1}
+                                        type="number"
+                                        value={minRank}
+                                        onChange={(e) => setMinRank(parseInt(e.target.value) || 1)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.page.icon.image', 'Icon image')}</label>
-                                    <input className={inputClass} min={0} type="number" value={iconImage} onChange={(e) => setIconImage(parseInt(e.target.value) || 0)} />
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.icon.image', 'Icon image')}
+                                    </label>
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={iconImage}
+                                        onChange={(e) => setIconImage(parseInt(e.target.value) || 0)}
+                                    />
+                                </div>
+                                <div className="nitro-catalog-admin-form-field">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.icon.color', 'Icon color')}
+                                    </label>
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={iconColor}
+                                        onChange={(e) => setIconColor(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
                             </div>
                         </section>
@@ -257,10 +440,18 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.order')}</label>
-                                    <input className={inputClass} min={0} type="number" value={orderNum} onChange={(e) => setOrderNum(parseInt(e.target.value) || 0)} />
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={orderNum}
+                                        onChange={(e) => setOrderNum(parseInt(e.target.value) || 0)}
+                                    />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.page.parent.id', 'Parent ID')}</label>
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.parent.id', 'Parent ID')}
+                                    </label>
                                     <input
                                         className={inputClass}
                                         disabled={isRoot}
@@ -270,7 +461,9 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                     />
                                 </div>
                                 <div className="nitro-catalog-admin-form-field is-span-2">
-                                    <label className="nitro-catalog-admin-label is-field">{localizeWithFallback('catalog.admin.page.visibility', 'Visibility')}</label>
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.visibility', 'Visibility')}
+                                    </label>
                                     <div className="nitro-catalog-admin-form-toggles">
                                         <label className="nitro-catalog-admin-form-toggle">
                                             <input checked={visible === '1'} type="checkbox" onChange={(e) => setVisible(e.target.checked ? '1' : '0')} />
@@ -280,21 +473,63 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                             <input checked={enabled === '1'} type="checkbox" onChange={(e) => setEnabled(e.target.checked ? '1' : '0')} />
                                             {LocalizeText('catalog.admin.enabled')}
                                         </label>
+                                        <label className="nitro-catalog-admin-form-toggle">
+                                            <input checked={clubOnly === '1'} type="checkbox" onChange={(e) => setClubOnly(e.target.checked ? '1' : '0')} />
+                                            {localizeWithFallback('catalog.admin.page.club.only', 'HC only')}
+                                        </label>
+                                        <label className="nitro-catalog-admin-form-toggle">
+                                            <input checked={vipOnly === '1'} type="checkbox" onChange={(e) => setVipOnly(e.target.checked ? '1' : '0')} />
+                                            {localizeWithFallback('catalog.admin.page.vip.only', 'VIP only')}
+                                        </label>
                                     </div>
+                                </div>
+                                <div className="nitro-catalog-admin-form-field">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.room.id', 'Room ID')}
+                                    </label>
+                                    <input
+                                        className={inputClass}
+                                        min={0}
+                                        type="number"
+                                        value={roomId}
+                                        onChange={(e) => setRoomId(parseInt(e.target.value) || 0)}
+                                    />
+                                </div>
+                                <div className="nitro-catalog-admin-form-field">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.includes', 'Included page IDs')}
+                                    </label>
+                                    <input className={inputClass} placeholder="1;2;3" value={includes} onChange={(e) => setIncludes(e.target.value)} />
                                 </div>
                             </div>
                         </section>
 
                         <section className="nitro-catalog-admin-form-section">
                             <div className="nitro-catalog-admin-section-title">{localizeWithFallback('catalog.admin.page.section.content', 'Content')}</div>
+                            <div className="nitro-catalog-admin-form-grid is-2col">
+                                <div className="nitro-catalog-admin-form-field">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.headline', 'Headline image')}
+                                    </label>
+                                    <input className={inputClass} value={pageHeadline} onChange={(e) => setPageHeadline(e.target.value)} />
+                                </div>
+                                <div className="nitro-catalog-admin-form-field">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.teaser', 'Teaser image')}
+                                    </label>
+                                    <input className={inputClass} value={pageTeaser} onChange={(e) => setPageTeaser(e.target.value)} />
+                                </div>
+                                <div className="nitro-catalog-admin-form-field is-span-2">
+                                    <label className="nitro-catalog-admin-label is-field">
+                                        {localizeWithFallback('catalog.admin.page.special', 'Special image')}
+                                    </label>
+                                    <input className={inputClass} value={pageSpecial} onChange={(e) => setPageSpecial(e.target.value)} />
+                                </div>
+                            </div>
                             <div className="nitro-catalog-admin-form-field">
                                 <div className="flex items-center justify-between gap-2">
                                     <label className="nitro-catalog-admin-label is-field">
                                         {localizeWithFallback('catalog.admin.page.text.1', 'Page text')}
-                                        <span className="nitro-catalog-admin-form-field-hint">
-                                            {' '}
-                                            {localizeWithFallback('catalog.admin.page.text.keep.current', '(leave blank to keep current)')}
-                                        </span>
                                     </label>
                                     <button
                                         className="nitro-catalog-admin-button is-ghost is-compact"
@@ -316,7 +551,9 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                             onChange={(e) => setTranslateTargetLanguage(e.target.value)}
                                         >
                                             {languagesLoading && !supportedLanguages.length && (
-                                                <option value="">{localizeWithFallback('catalog.admin.translate.loading.languages', 'Loading languages...')}</option>
+                                                <option value="">
+                                                    {localizeWithFallback('catalog.admin.translate.loading.languages', 'Loading languages...')}
+                                                </option>
                                             )}
                                             {supportedLanguages.map((lang) => (
                                                 <option key={lang.code} value={lang.code}>
@@ -330,7 +567,11 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                             type="button"
                                             onClick={runTranslate}
                                         >
-                                            {isTranslating ? <FaSpinner className="text-[8px] animate-spin" /> : localizeWithFallback('catalog.admin.translate.apply', 'Apply')}
+                                            {isTranslating ? (
+                                                <FaSpinner className="text-[8px] animate-spin" />
+                                            ) : (
+                                                localizeWithFallback('catalog.admin.translate.apply', 'Apply')
+                                            )}
                                         </button>
                                         <button
                                             className="nitro-catalog-admin-button is-muted"
@@ -348,19 +589,47 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                 {translateError && <span className="nitro-catalog-admin-translate-error">{translateError}</span>}
                                 <textarea className={`${inputClass} min-h-[80px] resize-y`} value={pageText1} onChange={(e) => setPageText1(e.target.value)} />
                             </div>
+                            <div className="nitro-catalog-admin-form-field">
+                                <label className="nitro-catalog-admin-label is-field">
+                                    {localizeWithFallback('catalog.admin.page.text.2', 'Secondary text')}
+                                </label>
+                                <textarea className={`${inputClass} min-h-[70px] resize-y`} value={pageText2} onChange={(e) => setPageText2(e.target.value)} />
+                            </div>
+                            <div className="nitro-catalog-admin-form-field">
+                                <label className="nitro-catalog-admin-label is-field">
+                                    {localizeWithFallback('catalog.admin.page.text.details', 'Details text')}
+                                </label>
+                                <textarea
+                                    className={`${inputClass} min-h-[70px] resize-y`}
+                                    value={pageTextDetails}
+                                    onChange={(e) => setPageTextDetails(e.target.value)}
+                                />
+                            </div>
+                            <div className="nitro-catalog-admin-form-field">
+                                <label className="nitro-catalog-admin-label is-field">
+                                    {localizeWithFallback('catalog.admin.page.text.teaser', 'Teaser text')}
+                                </label>
+                                <textarea
+                                    className={`${inputClass} min-h-[70px] resize-y`}
+                                    value={pageTextTeaser}
+                                    onChange={(e) => setPageTextTeaser(e.target.value)}
+                                />
+                            </div>
                         </section>
                     </div>
 
                     <div className="nitro-catalog-admin-form-actions">
-                        {!isRoot ? (
+                        {validationError && <span className="nitro-catalog-admin-translate-error">{validationError}</span>}
+                        {!isRoot && !creatingPage ? (
                             <button className="nitro-catalog-admin-button is-danger" onClick={handleDelete}>
                                 <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
                             </button>
                         ) : (
                             <div />
                         )}
-                        <button className="nitro-catalog-admin-button is-primary" disabled={loading} onClick={handleSave}>
-                            {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />} {LocalizeText('catalog.admin.save')}
+                        <button className="nitro-catalog-admin-button is-primary" disabled={loading || !detailsReady || !!validationError} onClick={handleSave}>
+                            {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
+                            {creatingPage ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
                         </button>
                     </div>
                 </div>

--- a/src/components/catalog/views/navigation/CatalogNavigationItemView.tsx
+++ b/src/components/catalog/views/navigation/CatalogNavigationItemView.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useRef, useState } from 'react';
 import { FaArrowsAlt, FaCaretDown, FaCaretUp, FaPlus, FaTrash } from 'react-icons/fa';
-import { CatalogType, ICatalogNode, LocalizeText } from '../../../../api';
-import { useCatalogActions, useCatalogUiState } from '../../../../hooks';
+import { ICatalogNode, LocalizeText } from '../../../../api';
+import { useCatalogActions } from '../../../../hooks';
 import { useCatalogAdmin } from '../../CatalogAdminContext';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
 import { CatalogNavigationSetView } from './CatalogNavigationSetView';
@@ -14,7 +14,6 @@ export interface CatalogNavigationItemViewProps {
 export const CatalogNavigationItemView: FC<CatalogNavigationItemViewProps> = (props) => {
     const { node = null, child = false } = props;
     const { activateNode = null } = useCatalogActions();
-    const { currentType = CatalogType.NORMAL } = useCatalogUiState();
     const catalogAdmin = useCatalogAdmin();
     const adminMode = catalogAdmin?.adminMode ?? false;
     const [isDragOver, setIsDragOver] = useState(false);
@@ -101,18 +100,10 @@ export const CatalogNavigationItemView: FC<CatalogNavigationItemViewProps> = (pr
                             title={LocalizeText('catalog.admin.create.subpage')}
                             onClick={(e) => {
                                 e.stopPropagation();
-                                catalogAdmin.createPage({
-                                    caption: 'New Page',
-                                    captionSave: 'New Page',
-                                    catalogMode: currentType,
-                                    pageLayout: 'default_3x3',
-                                    iconImage: 0,
-                                    minRank: 1,
-                                    visible: '1',
-                                    enabled: '1',
-                                    orderNum: 0,
-                                    parentId: node.pageId
-                                });
+                                catalogAdmin.setCreatingPage(true);
+                                catalogAdmin.setEditingRootPage(false);
+                                catalogAdmin.setEditingPageNode(node);
+                                catalogAdmin.setEditingPageData(true);
                             }}
                         />
                         <FaTrash


### PR DESCRIPTION
## Summary
- replace placeholder page creation with a complete validated editor form
- expose the full page model, layouts, modes, ranks, content, room, includes, and state controls
- expose complete offer pricing, bundle quantities, currencies, order, and limited-edition state
- serialize admin actions to avoid result acknowledgement mismatches
- use dedicated visibility/enabled packets and atomic offer reordering
- clarify that saves are immediate and publish refreshes the live catalog

## Testing
- `yarn test` (775 tests)
- `yarn typecheck`
- targeted Biome checks
- `yarn build` in JSONC mode

## Companions
- Renderer: https://github.com/duckietm/Nitro_Render_V3/pull/157
- Emulator: https://github.com/duckietm/Polaris-Emulator/pull/554