### PR TITLE
feat(catalog): add Catalog Studio command center

### DIFF
--- a/src/components/catalog/CatalogAdminContext.test.tsx
+++ b/src/components/catalog/CatalogAdminContext.test.tsx
@@ -1,0 +1,164 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CatalogAdminProvider, useCatalogAdmin } from './CatalogAdminContext';
+
+const mocks = vi.hoisted(() => ({
+    acquireLock: vi.fn(),
+    refresh: vi.fn(),
+    sendMessage: vi.fn(),
+    useCatalogStudio: vi.fn()
+}));
+
+vi.mock('../../api', () => ({
+    NotificationAlertType: { ALERT: 'alert' },
+    SendMessageComposer: mocks.sendMessage
+}));
+
+vi.mock('../../hooks', () => ({
+    useCatalogUiState: () => ({ currentType: 'NORMAL' }),
+    useMessageEvent: vi.fn(),
+    useNotification: () => ({ simpleAlert: null })
+}));
+
+vi.mock('./admin/studio/useCatalogStudio', () => ({
+    useCatalogStudio: mocks.useCatalogStudio
+}));
+
+type PageMutationAction = 'delete' | 'move' | 'toggleEnabled' | 'toggleVisible';
+
+const Probe = ({ action }: { action: PageMutationAction }) => {
+    const admin = useCatalogAdmin();
+
+    const mutate = () => {
+        switch (action) {
+            case 'delete':
+                admin.deletePage(42, 'Deleted page');
+                break;
+            case 'move':
+                admin.reorderPage(42, 7, 1, 'Moved page');
+                break;
+            case 'toggleEnabled':
+                admin.togglePageEnabled(42, false, 'Disabled page');
+                break;
+            case 'toggleVisible':
+                admin.togglePageVisible(42, false, 'Hidden page');
+                break;
+        }
+    };
+
+    return <button onClick={mutate}>{action}</button>;
+};
+
+const session = {
+    activeVersionId: 11,
+    draftVersionId: 12,
+    revision: 3,
+    activeUpdatedAt: '',
+    draftCreatedAt: '',
+    pendingCount: 0,
+    actors: [],
+    validationCurrent: false,
+    validationIssueCount: 0,
+    publishedVersions: [],
+    pages: [],
+    offers: []
+};
+
+describe('CatalogAdminProvider page mutations', () => {
+    let studio: Record<string, any>;
+
+    beforeEach(() => {
+        mocks.acquireLock.mockReset();
+        mocks.refresh.mockReset();
+        mocks.sendMessage.mockReset();
+        studio = {
+            session,
+            revision: session.revision,
+            locks: {},
+            lastError: null,
+            acquireLock: mocks.acquireLock,
+            refresh: mocks.refresh,
+            loadHistory: vi.fn(),
+            publish: vi.fn()
+        };
+        mocks.useCatalogStudio.mockImplementation(() => studio);
+    });
+
+    afterEach(cleanup);
+
+    const cases: Array<{
+        action: PageMutationAction;
+        composer: string;
+        args: unknown[];
+    }> = [
+        {
+            action: 'delete',
+            composer: 'CatalogAdminDeletePageComposer',
+            args: [ 42, 'NORMAL', 12, 3, 'token-42', 'Deleted page' ]
+        },
+        {
+            action: 'move',
+            composer: 'CatalogAdminMovePageComposer',
+            args: [ 42, 7, 1, 'NORMAL', 12, 3, 'token-42', 'Moved page' ]
+        },
+        {
+            action: 'toggleEnabled',
+            composer: 'CatalogAdminSetPageEnabledComposer',
+            args: [ 42, false, 'NORMAL', 12, 3, 'token-42', 'Disabled page' ]
+        },
+        {
+            action: 'toggleVisible',
+            composer: 'CatalogAdminSetPageVisibleComposer',
+            args: [ 42, false, 'NORMAL', 12, 3, 'token-42', 'Hidden page' ]
+        }
+    ];
+
+    it.each(cases)('acquires the page lock and resumes a queued $action mutation', async ({ action, composer, args }) => {
+        const view = render(<CatalogAdminProvider><Probe action={action} /></CatalogAdminProvider>);
+
+        act(() => screen.getByText(action).click());
+
+        expect(mocks.acquireLock).toHaveBeenCalledWith('PAGE', 42, 'NORMAL');
+        expect(mocks.sendMessage).not.toHaveBeenCalled();
+
+        studio = {
+            ...studio,
+            locks: {
+                'PAGE:42': {
+                    draftVersionId: 12,
+                    entityType: 'PAGE',
+                    catalogType: 'NORMAL',
+                    entityId: 42,
+                    ownerId: 9,
+                    ownerName: 'Alice',
+                    token: 'token-42',
+                    expiresAt: '2026-08-02T18:00:00Z'
+                }
+            }
+        };
+        view.rerender(<CatalogAdminProvider><Probe action={action} /></CatalogAdminProvider>);
+
+        await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+        const message = mocks.sendMessage.mock.calls[0][0];
+        expect(message.constructor.name).toBe(composer);
+        expect(message.getMessageArray()).toEqual(args);
+    });
+
+    it('refreshes a missing session and then acquires the queued page lock', async () => {
+        studio = { ...studio, session: null };
+        const view = render(<CatalogAdminProvider><Probe action="move" /></CatalogAdminProvider>);
+
+        act(() => screen.getByText('move').click());
+
+        expect(mocks.refresh).toHaveBeenCalledTimes(1);
+        expect(mocks.acquireLock).not.toHaveBeenCalled();
+
+        studio = { ...studio, session };
+        view.rerender(<CatalogAdminProvider><Probe action="move" /></CatalogAdminProvider>);
+
+        await waitFor(() => expect(mocks.acquireLock).toHaveBeenCalledWith('PAGE', 42, 'NORMAL'));
+        expect(mocks.sendMessage).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/catalog/CatalogAdminContext.tsx
+++ b/src/components/catalog/CatalogAdminContext.tsx
@@ -8,7 +8,6 @@ import {
     CatalogAdminMovePageComposer,
     CatalogAdminOfferDetailsEvent,
     CatalogAdminPageDetailsEvent,
-    CatalogAdminPublishComposer,
     CatalogAdminReorderOffersComposer,
     CatalogAdminResultEvent,
     CatalogAdminSaveOfferComposer,
@@ -19,6 +18,15 @@ import {
 import { createContext, FC, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ICatalogNode, IPurchasableOffer, NotificationAlertType, SendMessageComposer } from '../../api';
 import { useCatalogUiState, useMessageEvent, useNotification } from '../../hooks';
+import { useCatalogStudio } from './admin/studio/useCatalogStudio';
+
+const toStudioCatalogType = (catalogType: string): 'NORMAL' | 'BUILDER' =>
+    catalogType === 'BUILDERS_CLUB' || catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL';
+
+const studioLockKey = (entityType: 'PAGE' | 'OFFER', entityId: number, catalogType: string) => {
+    const type = toStudioCatalogType(catalogType);
+    return type === 'NORMAL' ? `${entityType}:${entityId}` : `${type}:${entityType}:${entityId}`;
+};
 
 export interface IPageEditData {
     pageId?: number;
@@ -108,12 +116,6 @@ export interface IEditingPageDetails {
     includes: string;
 }
 
-export interface ICatalogAdminPendingChange {
-    id: string;
-    summary: string;
-    at: number;
-}
-
 interface ICatalogAdminContext {
     adminMode: boolean;
     setAdminMode: (value: boolean) => void;
@@ -138,26 +140,25 @@ interface ICatalogAdminContext {
     saveOffer: (data: IOfferEditData) => void;
     createOffer: (data: IOfferEditData) => void;
     deleteOffer: (offerId: number, summary?: string) => void;
-    reorderOffers: (orders: { id: number; orderNumber: number }[], summary?: string) => void;
+    reorderOffers: (orders: { id: number; orderNumber: number }[], summary?: string, pageId?: number) => void;
     reorderPage: (pageId: number, newParentId: number, newIndex: number, summary?: string) => void;
     togglePageEnabled: (pageId: number, enabled: boolean, summary?: string) => void;
     togglePageVisible: (pageId: number, visible: boolean, summary?: string) => void;
     publishCatalog: () => void;
-    hasPendingChanges: boolean;
-    pendingChanges: ICatalogAdminPendingChange[];
 }
 
 const CatalogAdminContext = createContext<ICatalogAdminContext>(null);
 
 export const useCatalogAdmin = () => useContext(CatalogAdminContext);
 
-let pendingChangeCounter = 0;
+export const CATALOG_ROOT_LOCK_ID = 2147483647;
 
 const PAGE_INDEX_REFRESH_ACTIONS = new Set(['savePage', 'createPage', 'deletePage', 'movePage', 'toggleVisible', 'toggleEnabled']);
 const OFFER_REFRESH_ACTIONS = new Set(['saveOffer', 'createOffer', 'deleteOffer', 'reorder']);
 
 export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const { currentType } = useCatalogUiState();
+    const studio = useCatalogStudio();
     const [adminMode, setAdminMode] = useState(false);
     const [editingOffer, setEditingOfferState] = useState<IPurchasableOffer | null>(null);
     const [editingOfferDetails, setEditingOfferDetails] = useState<IEditingOfferDetails | null>(null);
@@ -168,44 +169,17 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     const [creatingPage, setCreatingPage] = useState(false);
     const [loading, setLoading] = useState(false);
     const [lastError, setLastError] = useState<string | null>(null);
-    const [hasPendingChanges, setHasPendingChanges] = useState(false);
-    const [pendingChanges, setPendingChanges] = useState<ICatalogAdminPendingChange[]>([]);
+    const queuedOfferDeleteRef = useRef<{ offerId: number; summary: string } | null>(null);
     const pendingActionRef = useRef<string | null>(null);
-    const pendingChangeLabelRef = useRef<string | null>(null);
-    const pendingChangeRecordedForBatchRef = useRef(false);
     const { simpleAlert = null } = useNotification();
 
-    const beginAdminAction = useCallback((action: string, summary: string) => {
+    const beginAdminAction = useCallback((action: string, _summary: string) => {
         if (pendingActionRef.current) return false;
 
         setLoading(true);
         setLastError(null);
         pendingActionRef.current = action;
-        pendingChangeLabelRef.current = summary;
-
-        if (action === 'reorder') pendingChangeRecordedForBatchRef.current = false;
         return true;
-    }, []);
-
-    const recordPendingChange = useCallback((action: string | null, summary: string | null) => {
-        if (!action || action === 'publish' || !summary?.length) return;
-
-        if (action === 'reorder') {
-            if (pendingChangeRecordedForBatchRef.current) return;
-            pendingChangeRecordedForBatchRef.current = true;
-        }
-
-        pendingChangeCounter += 1;
-
-        setPendingChanges((prev) => [
-            ...prev,
-            {
-                id: `pending-${pendingChangeCounter}`,
-                summary,
-                at: Date.now()
-            }
-        ]);
-        setHasPendingChanges(true);
     }, []);
 
     const setEditingOffer = useCallback(
@@ -214,10 +188,19 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             setEditingOfferDetails(null);
 
             if (offer && offer.offerId !== -1) {
-                SendMessageComposer(new CatalogAdminLoadOfferComposer(offer.offerId, currentType));
+                if (!studio.session) {
+                    setLastError('Catalog Studio session is not ready');
+                    return;
+                }
+                SendMessageComposer(new CatalogAdminLoadOfferComposer(
+                    offer.offerId,
+                    currentType,
+                    studio.session.draftVersionId,
+                    studio.revision
+                ));
             }
         },
-        [currentType]
+        [currentType, studio.session, studio.revision]
     );
 
     useMessageEvent(CatalogAdminOfferDetailsEvent, (event: CatalogAdminOfferDetailsEvent) => {
@@ -277,9 +260,18 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         (pageId: number) => {
             setEditingPageDetails(null);
             if (pageId == null || pageId < 0) return;
-            SendMessageComposer(new CatalogAdminLoadPageComposer(pageId, currentType));
+            if (!studio.session) {
+                setLastError('Catalog Studio session is not ready');
+                return;
+            }
+            SendMessageComposer(new CatalogAdminLoadPageComposer(
+                pageId,
+                currentType,
+                studio.session.draftVersionId,
+                studio.revision
+            ));
         },
-        [currentType]
+        [currentType, studio.session, studio.revision]
     );
 
     useEffect(() => {
@@ -310,10 +302,8 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     useMessageEvent(CatalogAdminResultEvent, (event: CatalogAdminResultEvent) => {
         const parser = event.getParser();
         const action = pendingActionRef.current;
-        const summary = pendingChangeLabelRef.current;
 
         pendingActionRef.current = null;
-        pendingChangeLabelRef.current = null;
         setLoading(false);
 
         if (!parser.success) {
@@ -330,26 +320,28 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             setEditingPageNode(null);
             setCreatingPage(false);
 
-            if (action === 'publish') {
-                setHasPendingChanges(false);
-                setPendingChanges([]);
-            } else {
-                recordPendingChange(action, summary);
+            studio.refresh();
+            studio.loadHistory();
 
-                if (PAGE_INDEX_REFRESH_ACTIONS.has(action)) {
-                    window.dispatchEvent(new Event('catalog-admin-refresh-index'));
-                }
+            if (action && PAGE_INDEX_REFRESH_ACTIONS.has(action)) {
+                window.dispatchEvent(new Event('catalog-admin-refresh-index'));
+            }
 
-                if (OFFER_REFRESH_ACTIONS.has(action)) {
-                    window.dispatchEvent(new Event('catalog-admin-refresh-current-page'));
-                }
+            if (action && OFFER_REFRESH_ACTIONS.has(action)) {
+                window.dispatchEvent(new Event('catalog-admin-refresh-current-page'));
             }
         }
     });
 
     const savePage = useCallback(
         (data: IPageEditData) => {
-            if (!beginAdminAction('savePage', `Updated page: ${data.caption || `#${data.pageId}`}`)) return;
+            const summary = `Updated page: ${data.caption || `#${data.pageId}`}`;
+            const lock = studio.locks[studioLockKey('PAGE', data.pageId || 0, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Open the page inspector and acquire its edit lock before saving');
+                return;
+            }
+            if (!beginAdminAction('savePage', summary)) return;
 
             SendMessageComposer(
                 new CatalogAdminSavePageComposer(
@@ -376,16 +368,29 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.pageText2 || '',
                     data.pageTextTeaser || '',
                     data.roomId || 0,
-                    data.includes || ''
+                    data.includes || '',
+                    studio.session.draftVersionId,
+                    studio.revision,
+                    lock.token,
+                    summary
                 )
             );
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const createPage = useCallback(
         (data: IPageEditData) => {
-            if (!beginAdminAction('createPage', `Created page: ${data.caption || 'New page'}`)) return;
+            const summary = `Created page: ${data.caption || 'New page'}`;
+            const lockId = data.parentId <= 0 ? CATALOG_ROOT_LOCK_ID : data.parentId;
+            const lock = studio.locks[studioLockKey('PAGE', lockId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError(data.parentId <= 0
+                    ? 'Wait for the catalog root lock before creating a root category'
+                    : 'Open the parent page inspector and acquire its edit lock before creating a sub-page');
+                return;
+            }
+            if (!beginAdminAction('createPage', summary)) return;
             SendMessageComposer(
                 new CatalogAdminCreatePageComposer(
                     data.caption,
@@ -410,24 +415,41 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.pageTextDetails || '',
                     data.pageTextTeaser || '',
                     data.roomId || 0,
-                    data.includes || ''
+                    data.includes || '',
+                    studio.session.draftVersionId,
+                    studio.revision,
+                    lock.token,
+                    summary
                 )
             );
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const deletePage = useCallback(
         (pageId: number, summary?: string) => {
-            if (!beginAdminAction('deletePage', summary || `Deleted page #${pageId}`)) return;
-            SendMessageComposer(new CatalogAdminDeletePageComposer(pageId, currentType));
+            const effectiveSummary = summary || `Deleted page #${pageId}`;
+            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Select the page and wait for its edit lock before deleting it');
+                return;
+            }
+            if (!beginAdminAction('deletePage', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminDeletePageComposer(
+                pageId, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const saveOffer = useCallback(
         (data: IOfferEditData) => {
-            if (!beginAdminAction('saveOffer', `Updated offer: ${data.catalogName || `#${data.offerId}`}`)) return;
+            const summary = `Updated offer: ${data.catalogName || `#${data.offerId}`}`;
+            const lock = studio.locks[studioLockKey('OFFER', data.offerId || 0, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Open the offer inspector and acquire its edit lock before saving');
+                return;
+            }
+            if (!beginAdminAction('saveOffer', summary)) return;
             SendMessageComposer(
                 new CatalogAdminSaveOfferComposer(
                     data.offerId || 0,
@@ -444,16 +466,26 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.offerId_group,
                     data.limitedStack,
                     data.orderNumber,
-                    currentType
+                    currentType,
+                    studio.session.draftVersionId,
+                    studio.revision,
+                    lock.token,
+                    summary
                 )
             );
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const createOffer = useCallback(
         (data: IOfferEditData) => {
-            if (!beginAdminAction('createOffer', `Created offer: ${data.catalogName || 'New offer'}`)) return;
+            const summary = `Created offer: ${data.catalogName || 'New offer'}`;
+            const lock = studio.locks[studioLockKey('PAGE', data.pageId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Open the target page and acquire its edit lock before creating an offer');
+                return;
+            }
+            if (!beginAdminAction('createOffer', summary)) return;
             SendMessageComposer(
                 new CatalogAdminCreateOfferComposer(
                     data.pageId,
@@ -469,59 +501,108 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     data.offerId_group,
                     data.limitedStack,
                     data.orderNumber,
-                    currentType
+                    currentType,
+                    studio.session.draftVersionId,
+                    studio.revision,
+                    lock.token,
+                    summary
                 )
             );
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const deleteOffer = useCallback(
         (offerId: number, summary?: string) => {
-            if (!beginAdminAction('deleteOffer', summary || `Deleted offer #${offerId}`)) return;
-            SendMessageComposer(new CatalogAdminDeleteOfferComposer(offerId, currentType));
+            const effectiveSummary = summary || `Deleted offer #${offerId}`;
+            const lock = studio.locks[studioLockKey('OFFER', offerId, currentType)];
+            if (!studio.session) {
+                setLastError('Catalog Studio session is not ready');
+                return;
+            }
+            if (!lock) {
+                queuedOfferDeleteRef.current = { offerId, summary: effectiveSummary };
+                studio.acquireLock('OFFER', offerId, toStudioCatalogType(currentType));
+                return;
+            }
+            if (!beginAdminAction('deleteOffer', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminDeleteOfferComposer(
+                offerId, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
-    const reorderOffers = useCallback(
-        (orders: { id: number; orderNumber: number }[], summary?: string) => {
-            if (!orders.length) return;
+    useEffect(() => {
+        const queued = queuedOfferDeleteRef.current;
+        if (!queued || !studio.locks[studioLockKey('OFFER', queued.offerId, currentType)]) return;
+        queuedOfferDeleteRef.current = null;
+        deleteOffer(queued.offerId, queued.summary);
+    }, [currentType, deleteOffer, studio.locks]);
 
-            if (!beginAdminAction('reorder', summary || 'Reordered offers')) return;
-            SendMessageComposer(new CatalogAdminReorderOffersComposer(orders, currentType));
+    const reorderOffers = useCallback(
+        (orders: { id: number; orderNumber: number }[], summary?: string, pageId?: number) => {
+            if (!orders.length) return;
+            const effectivePageId = pageId || 0;
+            const lock = studio.locks[studioLockKey('PAGE', effectivePageId, currentType)];
+            const effectiveSummary = summary || 'Reordered offers';
+            if (!studio.session || !lock) {
+                setLastError('Select the page and wait for its edit lock before reordering offers');
+                return;
+            }
+            if (!beginAdminAction('reorder', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminReorderOffersComposer(
+                orders, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const reorderPage = useCallback(
         (pageId: number, newParentId: number, newIndex: number, summary?: string) => {
-            if (!beginAdminAction('movePage', summary || `Moved page #${pageId}`)) return;
-            SendMessageComposer(new CatalogAdminMovePageComposer(pageId, newParentId, newIndex, currentType));
+            const effectiveSummary = summary || `Moved page #${pageId}`;
+            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Select the page and wait for its edit lock before moving it');
+                return;
+            }
+            if (!beginAdminAction('movePage', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminMovePageComposer(
+                pageId, newParentId, newIndex, currentType,
+                studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const togglePageEnabled = useCallback(
         (pageId: number, enabled: boolean, summary?: string) => {
-            if (!beginAdminAction('toggleEnabled', summary || `Toggled enabled state for page #${pageId}`)) return;
-            SendMessageComposer(new CatalogAdminSetPageEnabledComposer(pageId, enabled, currentType));
+            const effectiveSummary = summary || `Toggled enabled state for page #${pageId}`;
+            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Select the page and wait for its edit lock before changing it');
+                return;
+            }
+            if (!beginAdminAction('toggleEnabled', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminSetPageEnabledComposer(
+                pageId, enabled, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
     const togglePageVisible = useCallback(
         (pageId: number, visible: boolean, summary?: string) => {
-            if (!beginAdminAction('toggleVisible', summary || `Toggled visibility for page #${pageId}`)) return;
-            SendMessageComposer(new CatalogAdminSetPageVisibleComposer(pageId, visible, currentType));
+            const effectiveSummary = summary || `Toggled visibility for page #${pageId}`;
+            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
+            if (!studio.session || !lock) {
+                setLastError('Select the page and wait for its edit lock before changing it');
+                return;
+            }
+            if (!beginAdminAction('toggleVisible', effectiveSummary)) return;
+            SendMessageComposer(new CatalogAdminSetPageVisibleComposer(
+                pageId, visible, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
         },
-        [currentType, beginAdminAction]
+        [currentType, beginAdminAction, studio]
     );
 
-    const publishCatalog = useCallback(() => {
-        if (!beginAdminAction('publish', 'Published catalog')) return;
-        SendMessageComposer(new CatalogAdminPublishComposer());
-    }, [beginAdminAction]);
+    const publishCatalog = useCallback(() => studio.publish(), [studio]);
 
     return (
         <CatalogAdminContext
@@ -543,8 +624,6 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 setCreatingPage,
                 loading,
                 lastError,
-                hasPendingChanges,
-                pendingChanges,
                 savePage,
                 createPage,
                 deletePage,

--- a/src/components/catalog/CatalogAdminContext.tsx
+++ b/src/components/catalog/CatalogAdminContext.tsx
@@ -19,6 +19,7 @@ import { createContext, FC, ReactNode, useCallback, useContext, useEffect, useRe
 import { ICatalogNode, IPurchasableOffer, NotificationAlertType, SendMessageComposer } from '../../api';
 import { useCatalogUiState, useMessageEvent, useNotification } from '../../hooks';
 import { useCatalogStudio } from './admin/studio/useCatalogStudio';
+import { createCatalogAdminPageDetailsFromSnapshot } from './views/admin/CatalogAdminPageState';
 
 const toStudioCatalogType = (catalogType: string): 'NORMAL' | 'BUILDER' =>
     catalogType === 'BUILDERS_CLUB' || catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL';
@@ -134,6 +135,9 @@ interface ICatalogAdminContext {
     setCreatingPage: (value: boolean) => void;
     loading: boolean;
     lastError: string | null;
+    studioSessionReady: boolean;
+    ensurePageLock: (pageId: number) => void;
+    hasPageLock: (pageId: number) => boolean;
     savePage: (data: IPageEditData) => void;
     createPage: (data: IPageEditData) => void;
     deletePage: (pageId: number, summary?: string) => void;
@@ -264,6 +268,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 setLastError('Catalog Studio session is not ready');
                 return;
             }
+
+            const catalogType = toStudioCatalogType(currentType);
+            const snapshot = studio.session.pages.find((page) =>
+                page.pageId === pageId && page.catalogType === catalogType);
+            if (snapshot) setEditingPageDetails(createCatalogAdminPageDetailsFromSnapshot(snapshot));
+
+            setLastError(null);
             SendMessageComposer(new CatalogAdminLoadPageComposer(
                 pageId,
                 currentType,
@@ -272,6 +283,32 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             ));
         },
         [currentType, studio.session, studio.revision]
+    );
+
+    const ensurePageLock = useCallback(
+        (pageId: number) => {
+            if (pageId == null || pageId < 0) return;
+
+            const key = studioLockKey('PAGE', pageId, currentType);
+            if (studio.locks[key]) {
+                setLastError(null);
+                return;
+            }
+            if (!studio.session) {
+                setLastError('Catalog Studio session is not ready');
+                studio.refresh();
+                return;
+            }
+
+            setLastError(null);
+            studio.acquireLock('PAGE', pageId, toStudioCatalogType(currentType));
+        },
+        [currentType, studio.acquireLock, studio.locks, studio.refresh, studio.session]
+    );
+
+    const hasPageLock = useCallback(
+        (pageId: number) => !!studio.locks[studioLockKey('PAGE', pageId, currentType)],
+        [currentType, studio.locks]
     );
 
     useEffect(() => {
@@ -623,7 +660,10 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 creatingPage,
                 setCreatingPage,
                 loading,
-                lastError,
+                lastError: lastError || studio.lastError,
+                studioSessionReady: !!studio.session,
+                ensurePageLock,
+                hasPageLock,
                 savePage,
                 createPage,
                 deletePage,

--- a/src/components/catalog/CatalogAdminContext.tsx
+++ b/src/components/catalog/CatalogAdminContext.tsx
@@ -160,6 +160,12 @@ export const CATALOG_ROOT_LOCK_ID = 2147483647;
 const PAGE_INDEX_REFRESH_ACTIONS = new Set(['savePage', 'createPage', 'deletePage', 'movePage', 'toggleVisible', 'toggleEnabled']);
 const OFFER_REFRESH_ACTIONS = new Set(['saveOffer', 'createOffer', 'deleteOffer', 'reorder']);
 
+type QueuedPageMutation =
+    | { kind: 'delete'; pageId: number; catalogType: string; summary: string }
+    | { kind: 'move'; pageId: number; catalogType: string; newParentId: number; newIndex: number; summary: string }
+    | { kind: 'toggleEnabled'; pageId: number; catalogType: string; enabled: boolean; summary: string }
+    | { kind: 'toggleVisible'; pageId: number; catalogType: string; visible: boolean; summary: string };
+
 export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const { currentType } = useCatalogUiState();
     const studio = useCatalogStudio();
@@ -173,6 +179,7 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     const [creatingPage, setCreatingPage] = useState(false);
     const [loading, setLoading] = useState(false);
     const [lastError, setLastError] = useState<string | null>(null);
+    const queuedPageMutationRef = useRef<QueuedPageMutation | null>(null);
     const queuedOfferDeleteRef = useRef<{ offerId: number; summary: string } | null>(null);
     const pendingActionRef = useRef<string | null>(null);
     const { simpleAlert = null } = useNotification();
@@ -463,21 +470,6 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         [currentType, beginAdminAction, studio]
     );
 
-    const deletePage = useCallback(
-        (pageId: number, summary?: string) => {
-            const effectiveSummary = summary || `Deleted page #${pageId}`;
-            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
-            if (!studio.session || !lock) {
-                setLastError('Select the page and wait for its edit lock before deleting it');
-                return;
-            }
-            if (!beginAdminAction('deletePage', effectiveSummary)) return;
-            SendMessageComposer(new CatalogAdminDeletePageComposer(
-                pageId, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
-        },
-        [currentType, beginAdminAction, studio]
-    );
-
     const saveOffer = useCallback(
         (data: IOfferEditData) => {
             const summary = `Updated offer: ${data.catalogName || `#${data.offerId}`}`;
@@ -593,50 +585,120 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         [currentType, beginAdminAction, studio]
     );
 
-    const reorderPage = useCallback(
-        (pageId: number, newParentId: number, newIndex: number, summary?: string) => {
-            const effectiveSummary = summary || `Moved page #${pageId}`;
-            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
-            if (!studio.session || !lock) {
-                setLastError('Select the page and wait for its edit lock before moving it');
+    const performPageMutation = useCallback(
+        (mutation: QueuedPageMutation) => {
+            if (!studio.session) {
+                queuedPageMutationRef.current = mutation;
+                setLastError(null);
+                studio.refresh();
                 return;
             }
-            if (!beginAdminAction('movePage', effectiveSummary)) return;
-            SendMessageComposer(new CatalogAdminMovePageComposer(
-                pageId, newParentId, newIndex, currentType,
-                studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
+
+            const lock = studio.locks[studioLockKey('PAGE', mutation.pageId, mutation.catalogType)];
+            if (!lock) {
+                queuedPageMutationRef.current = mutation;
+                setLastError(null);
+                studio.acquireLock('PAGE', mutation.pageId, toStudioCatalogType(mutation.catalogType));
+                return;
+            }
+
+            if (!beginAdminAction(
+                mutation.kind === 'delete' ? 'deletePage' :
+                    mutation.kind === 'move' ? 'movePage' :
+                        mutation.kind === 'toggleEnabled' ? 'toggleEnabled' : 'toggleVisible',
+                mutation.summary
+            )) return;
+
+            switch (mutation.kind) {
+                case 'delete':
+                    SendMessageComposer(new CatalogAdminDeletePageComposer(
+                        mutation.pageId, mutation.catalogType, studio.session.draftVersionId,
+                        studio.revision, lock.token, mutation.summary));
+                    break;
+                case 'move':
+                    SendMessageComposer(new CatalogAdminMovePageComposer(
+                        mutation.pageId, mutation.newParentId, mutation.newIndex, mutation.catalogType,
+                        studio.session.draftVersionId, studio.revision, lock.token, mutation.summary));
+                    break;
+                case 'toggleEnabled':
+                    SendMessageComposer(new CatalogAdminSetPageEnabledComposer(
+                        mutation.pageId, mutation.enabled, mutation.catalogType, studio.session.draftVersionId,
+                        studio.revision, lock.token, mutation.summary));
+                    break;
+                case 'toggleVisible':
+                    SendMessageComposer(new CatalogAdminSetPageVisibleComposer(
+                        mutation.pageId, mutation.visible, mutation.catalogType, studio.session.draftVersionId,
+                        studio.revision, lock.token, mutation.summary));
+                    break;
+            }
         },
-        [currentType, beginAdminAction, studio]
+        [beginAdminAction, studio.acquireLock, studio.locks, studio.refresh, studio.revision, studio.session]
+    );
+
+    useEffect(() => {
+        const queued = queuedPageMutationRef.current;
+        if (!queued || !studio.session) return;
+
+        const lock = studio.locks[studioLockKey('PAGE', queued.pageId, queued.catalogType)];
+        if (!lock) {
+            studio.acquireLock('PAGE', queued.pageId, toStudioCatalogType(queued.catalogType));
+            return;
+        }
+
+        queuedPageMutationRef.current = null;
+        performPageMutation(queued);
+    }, [performPageMutation, studio.acquireLock, studio.locks, studio.session]);
+
+    const deletePage = useCallback(
+        (pageId: number, summary?: string) => {
+            performPageMutation({
+                kind: 'delete',
+                pageId,
+                catalogType: currentType,
+                summary: summary || `Deleted page #${pageId}`
+            });
+        },
+        [currentType, performPageMutation]
+    );
+
+    const reorderPage = useCallback(
+        (pageId: number, newParentId: number, newIndex: number, summary?: string) => {
+            performPageMutation({
+                kind: 'move',
+                pageId,
+                catalogType: currentType,
+                newParentId,
+                newIndex,
+                summary: summary || `Moved page #${pageId}`
+            });
+        },
+        [currentType, performPageMutation]
     );
 
     const togglePageEnabled = useCallback(
         (pageId: number, enabled: boolean, summary?: string) => {
-            const effectiveSummary = summary || `Toggled enabled state for page #${pageId}`;
-            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
-            if (!studio.session || !lock) {
-                setLastError('Select the page and wait for its edit lock before changing it');
-                return;
-            }
-            if (!beginAdminAction('toggleEnabled', effectiveSummary)) return;
-            SendMessageComposer(new CatalogAdminSetPageEnabledComposer(
-                pageId, enabled, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
+            performPageMutation({
+                kind: 'toggleEnabled',
+                pageId,
+                catalogType: currentType,
+                enabled,
+                summary: summary || `Toggled enabled state for page #${pageId}`
+            });
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, performPageMutation]
     );
 
     const togglePageVisible = useCallback(
         (pageId: number, visible: boolean, summary?: string) => {
-            const effectiveSummary = summary || `Toggled visibility for page #${pageId}`;
-            const lock = studio.locks[studioLockKey('PAGE', pageId, currentType)];
-            if (!studio.session || !lock) {
-                setLastError('Select the page and wait for its edit lock before changing it');
-                return;
-            }
-            if (!beginAdminAction('toggleVisible', effectiveSummary)) return;
-            SendMessageComposer(new CatalogAdminSetPageVisibleComposer(
-                pageId, visible, currentType, studio.session.draftVersionId, studio.revision, lock.token, effectiveSummary));
+            performPageMutation({
+                kind: 'toggleVisible',
+                pageId,
+                catalogType: currentType,
+                visible,
+                summary: summary || `Toggled visibility for page #${pageId}`
+            });
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, performPageMutation]
     );
 
     const publishCatalog = useCallback(() => studio.publish(), [studio]);

--- a/src/components/catalog/CatalogView.tsx
+++ b/src/components/catalog/CatalogView.tsx
@@ -5,6 +5,7 @@ import { CatalogType, GetConfigurationValue, LocalizeShortNumber, LocalizeText, 
 import { LayoutCurrencyIcon, NitroCardContentView, NitroCardHeaderView, NitroCardTabsItemView, NitroCardTabsView, NitroCardView } from '../../common';
 import { useCatalogActions, useCatalogData, useCatalogUiState, useHasPermission, usePurse } from '../../hooks';
 import { CatalogAdminProvider, useCatalogAdmin } from './CatalogAdminContext';
+import { CatalogStudioProvider } from './admin/studio/CatalogStudioProvider';
 import { parseCatalogTabLabel, useCatalogWindowWidth } from './useCatalogWindowWidth';
 import { CatalogAdminManagerView } from './views/admin/CatalogAdminManagerView';
 import { CatalogAdminOfferEditView } from './views/admin/CatalogAdminOfferEditView';
@@ -281,9 +282,11 @@ export const CatalogView: FC<{}> = () => {
     const { catalogLocalizationVersion = 0 } = useCatalogData();
 
     return (
-        <CatalogAdminProvider>
-            <div className="hidden" data-catalog-localization-version={catalogLocalizationVersion} />
-            <CatalogViewInner />
-        </CatalogAdminProvider>
+        <CatalogStudioProvider active>
+            <CatalogAdminProvider>
+                <div className="hidden" data-catalog-localization-version={catalogLocalizationVersion} />
+                <CatalogViewInner />
+            </CatalogAdminProvider>
+        </CatalogStudioProvider>
     );
 };

--- a/src/components/catalog/admin/studio/CatalogPreviewPersona.ts
+++ b/src/components/catalog/admin/studio/CatalogPreviewPersona.ts
@@ -1,0 +1,19 @@
+export interface CatalogPreviewPersona {
+    rank: number;
+    hc: boolean;
+    vip: boolean;
+    buildersClub: boolean;
+    showHidden: boolean;
+    credits: number;
+    currencies: Record<number, number>;
+}
+
+export const DEFAULT_CATALOG_PREVIEW_PERSONA: CatalogPreviewPersona = {
+    rank: 1,
+    hc: false,
+    vip: false,
+    buildersClub: false,
+    showHidden: false,
+    credits: 100,
+    currencies: {}
+};

--- a/src/components/catalog/admin/studio/CatalogStudioBulkPanel.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioBulkPanel.tsx
@@ -1,0 +1,40 @@
+import { FC, useMemo, useState } from 'react';
+import { useCatalogStudio } from './useCatalogStudio';
+
+type BulkOperation = 'PRICE_PERCENT' | 'REPLACE_CURRENCY' | 'SET_VISIBILITY' | 'SET_MIN_RANK' | 'REPARENT';
+
+export const CatalogStudioBulkPanel: FC = () => {
+    const studio = useCatalogStudio();
+    const [operation, setOperation] = useState<BulkOperation>('PRICE_PERCENT');
+    const [catalogType, setCatalogType] = useState<'NORMAL' | 'BUILDER'>('NORMAL');
+    const [ids, setIds] = useState('');
+    const [intValue, setIntValue] = useState(0);
+    const [booleanValue, setBooleanValue] = useState(false);
+    const request = useMemo(() => JSON.stringify({
+        operation, catalogType,
+        entityIds: ids.split(',').map(value => Number(value.trim())).filter(value => value > 0),
+        intValue, booleanValue
+    }), [operation, catalogType, ids, intValue, booleanValue]);
+    const dryRun = studio.documentResult?.format === 'BULK' && studio.documentResult.code === 'DRY_RUN_READY' ? studio.documentResult : null;
+
+    return <div className="nitro-catalog-admin-bulk">
+        <div className="nitro-catalog-admin-section-head"><div><strong>Bulk operations</strong><span>Dry-run first, then one atomic and reversible apply</span></div></div>
+        <div className="nitro-catalog-admin-bulk-grid">
+            <label>Catalog<select value={catalogType} onChange={event => setCatalogType(event.target.value as 'NORMAL' | 'BUILDER')}><option>NORMAL</option><option>BUILDER</option></select></label>
+            <label>Operation<select value={operation} onChange={event => setOperation(event.target.value as BulkOperation)}>
+                <option value="PRICE_PERCENT">Adjust price %</option><option value="REPLACE_CURRENCY">Replace currency</option>
+                <option value="SET_VISIBILITY">Set visibility</option><option value="SET_MIN_RANK">Set minimum rank</option><option value="REPARENT">Move pages</option>
+            </select></label>
+            <label>Entity IDs<input value={ids} onChange={event => setIds(event.target.value)} placeholder="10, 11, 12" /></label>
+            {operation === 'SET_VISIBILITY'
+                ? <label><input type="checkbox" checked={booleanValue} onChange={event => setBooleanValue(event.target.checked)} /> Visible</label>
+                : <label>Value<input type="number" value={intValue} onChange={event => setIntValue(Number(event.target.value))} /></label>}
+        </div>
+        <div className="nitro-catalog-admin-publish-actions">
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.dryRunDocument('BULK', request)}>Dry-run</button>
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.acquireLock('PAGE', 2147483647)}>Acquire apply lock</button>
+            <button className="nitro-catalog-admin-btn is-publish" disabled={!dryRun || studio.loading}
+                onClick={() => dryRun && studio.applyDocument('BULK', request, dryRun.fingerprint, `Bulk ${operation}`)}>Apply {dryRun?.changedEntities ?? 0} changes</button>
+        </div>
+    </div>;
+};

--- a/src/components/catalog/admin/studio/CatalogStudioCommandCenter.test.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioCommandCenter.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { getCatalogStudioCommandState } from './CatalogStudioCommandCenter';
+import * as CommandCenter from './CatalogStudioCommandCenter';
+
+const { getCatalogStudioCommandState } = CommandCenter;
 
 describe('Catalog Studio command center state', () => {
     it('requires current validation before publishing pending changes', () => {
@@ -48,5 +50,13 @@ describe('Catalog Studio command center state', () => {
         expect(state.phase).toBe('blocked');
         expect(state.canPublish).toBe(false);
         expect(state.validationLabel).toBe('4 validation issues');
+    });
+
+    it('uses the catalog type when resolving a page lock', () => {
+        const getPageLockKey = (CommandCenter as any).getCatalogStudioPageLockKey;
+
+        expect(getPageLockKey(976, 'NORMAL')).toBe('PAGE:976');
+        expect(getPageLockKey(976, 'BUILDERS_CLUB')).toBe('BUILDER:PAGE:976');
+        expect(getPageLockKey(976, 'BUILDER')).toBe('BUILDER:PAGE:976');
     });
 });

--- a/src/components/catalog/admin/studio/CatalogStudioCommandCenter.test.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioCommandCenter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getCatalogStudioCommandState } from './CatalogStudioCommandCenter';
+
+describe('Catalog Studio command center state', () => {
+    it('requires current validation before publishing pending changes', () => {
+        const state = getCatalogStudioCommandState({
+            sessionReady: true,
+            pendingCount: 3,
+            actorCount: 2,
+            lockCount: 1,
+            validationCurrent: false,
+            validationIssueCount: 0,
+            loading: false
+        });
+
+        expect(state.phase).toBe('draft');
+        expect(state.canValidate).toBe(true);
+        expect(state.canPublish).toBe(false);
+        expect(state.pendingLabel).toBe('3 pending changes');
+    });
+
+    it('enables publication only for a validated clean draft', () => {
+        const state = getCatalogStudioCommandState({
+            sessionReady: true,
+            pendingCount: 1,
+            actorCount: 1,
+            lockCount: 0,
+            validationCurrent: true,
+            validationIssueCount: 0,
+            loading: false
+        });
+
+        expect(state.phase).toBe('ready');
+        expect(state.canPublish).toBe(true);
+    });
+
+    it('blocks publication when validation found issues', () => {
+        const state = getCatalogStudioCommandState({
+            sessionReady: true,
+            pendingCount: 2,
+            actorCount: 1,
+            lockCount: 0,
+            validationCurrent: true,
+            validationIssueCount: 4,
+            loading: false
+        });
+
+        expect(state.phase).toBe('blocked');
+        expect(state.canPublish).toBe(false);
+        expect(state.validationLabel).toBe('4 validation issues');
+    });
+});

--- a/src/components/catalog/admin/studio/CatalogStudioCommandCenter.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioCommandCenter.ts
@@ -1,0 +1,49 @@
+export interface CatalogStudioCommandInput {
+    sessionReady: boolean;
+    pendingCount: number;
+    actorCount: number;
+    lockCount: number;
+    validationCurrent: boolean;
+    validationIssueCount: number;
+    loading: boolean;
+}
+
+export interface CatalogStudioCommandState {
+    phase: 'offline' | 'clean' | 'draft' | 'blocked' | 'ready';
+    canValidate: boolean;
+    canPublish: boolean;
+    pendingLabel: string;
+    actorLabel: string;
+    lockLabel: string;
+    validationLabel: string;
+}
+
+const quantity = (count: number, singular: string, plural: string) =>
+    `${count} ${count === 1 ? singular : plural}`;
+
+export const getCatalogStudioCommandState = (input: CatalogStudioCommandInput): CatalogStudioCommandState => {
+    const hasPending = input.pendingCount > 0;
+    const hasIssues = input.validationIssueCount > 0;
+    const canValidate = input.sessionReady && hasPending && !input.loading;
+    const canPublish = canValidate && input.validationCurrent && !hasIssues;
+    let phase: CatalogStudioCommandState['phase'] = 'offline';
+
+    if (input.sessionReady) {
+        if (!hasPending) phase = 'clean';
+        else if (input.validationCurrent && hasIssues) phase = 'blocked';
+        else if (canPublish) phase = 'ready';
+        else phase = 'draft';
+    }
+
+    return {
+        phase,
+        canValidate,
+        canPublish,
+        pendingLabel: quantity(input.pendingCount, 'pending change', 'pending changes'),
+        actorLabel: quantity(input.actorCount, 'editor online', 'editors online'),
+        lockLabel: quantity(input.lockCount, 'active lock', 'active locks'),
+        validationLabel: hasIssues
+            ? quantity(input.validationIssueCount, 'validation issue', 'validation issues')
+            : input.validationCurrent ? 'Validation current' : 'Validation required'
+    };
+};

--- a/src/components/catalog/admin/studio/CatalogStudioCommandCenter.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioCommandCenter.ts
@@ -21,6 +21,11 @@ export interface CatalogStudioCommandState {
 const quantity = (count: number, singular: string, plural: string) =>
     `${count} ${count === 1 ? singular : plural}`;
 
+export const getCatalogStudioPageLockKey = (pageId: number, catalogType: string) =>
+    catalogType === 'BUILDERS_CLUB' || catalogType === 'BUILDER'
+        ? `BUILDER:PAGE:${pageId}`
+        : `PAGE:${pageId}`;
+
 export const getCatalogStudioCommandState = (input: CatalogStudioCommandInput): CatalogStudioCommandState => {
     const hasPending = input.pendingCount > 0;
     const hasIssues = input.validationIssueCount > 0;

--- a/src/components/catalog/admin/studio/CatalogStudioImportExportPanel.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioImportExportPanel.tsx
@@ -1,0 +1,27 @@
+import { FC, useEffect, useState } from 'react';
+import { useCatalogStudio } from './useCatalogStudio';
+
+export const CatalogStudioImportExportPanel: FC = () => {
+    const studio = useCatalogStudio();
+    const [format, setFormat] = useState<'JSONC' | 'SQL'>('JSONC');
+    const [document, setDocument] = useState('');
+    const result = studio.documentResult?.format === format ? studio.documentResult : null;
+
+    useEffect(() => {
+        if(result?.code === 'EXPORTED' && result.document) setDocument(result.document);
+    }, [result?.operationId]);
+
+    return <div className="nitro-catalog-admin-import-export">
+        <div className="nitro-catalog-admin-section-head"><div><strong>Import / export</strong><span>JSONC comments stay supported; SQL is parsed and never executed directly</span></div></div>
+        <div className="nitro-catalog-admin-import-toolbar">
+            <select value={format} onChange={event => setFormat(event.target.value as 'JSONC' | 'SQL')}><option>JSONC</option><option>SQL</option></select>
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.exportDocument(format)}>Export draft</button>
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading || !document.trim()} onClick={() => studio.dryRunDocument(format, document)}>Validate and dry-run</button>
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.acquireLock('PAGE', 2147483647)}>Acquire apply lock</button>
+            <button className="nitro-catalog-admin-btn is-publish" disabled={studio.loading || result?.code !== 'DRY_RUN_READY'}
+                onClick={() => result && studio.applyDocument(format, document, result.fingerprint, `Import ${format}`)}>Apply {result?.changedEntities ?? 0} changes</button>
+        </div>
+        <textarea value={document} onChange={event => setDocument(event.target.value)} spellCheck={false} aria-label={`${format} catalog document`} />
+        {result && <div className={`nitro-catalog-admin-publish-status ${result.success ? 'is-ready' : 'is-blocked'}`}>{result.message} · {result.changedEntities} change(s)</div>}
+    </div>;
+};

--- a/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CatalogStudioBulkPanel } from './CatalogStudioBulkPanel';
+import { CatalogStudioImportExportPanel } from './CatalogStudioImportExportPanel';
+import { CatalogStudioPreview } from './CatalogStudioPreview';
+import { useCatalogStudio } from './useCatalogStudio';
+
+vi.mock('./useCatalogStudio', () => ({ useCatalogStudio: vi.fn() }));
+
+const studio = {
+    loading: false,
+    preview: null,
+    documentResult: null,
+    requestPreview: vi.fn(),
+    dryRunDocument: vi.fn(),
+    applyDocument: vi.fn(),
+    acquireLock: vi.fn(),
+    exportDocument: vi.fn()
+};
+
+describe('Catalog Studio advanced panels', () => {
+    beforeEach(() => {
+        Object.values(studio).forEach(value => typeof value === 'function' && value.mockClear());
+        vi.mocked(useCatalogStudio).mockReturnValue(studio as any);
+    });
+
+    it('submits the simulated customer persona to the server preview', () => {
+        render(<CatalogStudioPreview />);
+        fireEvent.change(screen.getByLabelText('Rank'), { target: { value: '7' } });
+        fireEvent.click(screen.getByLabelText('Builders Club'));
+        fireEvent.click(screen.getByText('Refresh preview'));
+
+        expect(studio.requestPreview).toHaveBeenCalledWith(expect.objectContaining({ rank: 7, buildersClub: true }));
+    });
+
+    it('always dry-runs a bulk operation before enabling apply', () => {
+        render(<CatalogStudioBulkPanel />);
+        fireEvent.change(screen.getByLabelText('Entity IDs'), { target: { value: '10, 11' } });
+        fireEvent.click(screen.getByText('Dry-run'));
+
+        expect(studio.dryRunDocument).toHaveBeenCalledWith('BULK', expect.stringContaining('"entityIds":[10,11]'));
+        expect(screen.getByText(/^Apply/)).toBeDisabled();
+    });
+
+    it('keeps JSONC as the default transfer format and validates original text', () => {
+        render(<CatalogStudioImportExportPanel />);
+        fireEvent.change(screen.getByLabelText('JSONC catalog document'), { target: { value: '{ // note\n}' } });
+        fireEvent.click(screen.getByText('Validate and dry-run'));
+
+        expect(studio.dryRunDocument).toHaveBeenCalledWith('JSONC', '{ // note\n}');
+    });
+});

--- a/src/components/catalog/admin/studio/CatalogStudioPreview.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioPreview.tsx
@@ -1,0 +1,40 @@
+import { FC, useMemo, useState } from 'react';
+import { DEFAULT_CATALOG_PREVIEW_PERSONA } from './CatalogPreviewPersona';
+import { useCatalogStudio } from './useCatalogStudio';
+
+export const CatalogStudioPreview: FC = () => {
+    const studio = useCatalogStudio();
+    const [persona, setPersona] = useState(DEFAULT_CATALOG_PREVIEW_PERSONA);
+    const pages = studio.preview?.pages ?? [];
+    const offersByPage = useMemo(() => new Map(pages.map(page => [ `${page.catalogType}:${page.pageId}`,
+        (studio.preview?.offers ?? []).filter(entry => entry.offer.catalogType === page.catalogType && entry.offer.pageId === page.pageId)
+    ])), [pages, studio.preview?.offers]);
+
+    return <div className="nitro-catalog-admin-studio-preview">
+        <div className="nitro-catalog-admin-section-head">
+            <div><strong>Exact draft preview</strong><span>Server-evaluated visibility and purchase eligibility</span></div>
+            <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.requestPreview(persona)}>Refresh preview</button>
+        </div>
+        <div className="nitro-catalog-admin-preview-persona">
+            <label>Rank<input type="number" min={0} value={persona.rank} onChange={event => setPersona(current => ({ ...current, rank: Number(event.target.value) }))} /></label>
+            <label>Credits<input type="number" min={0} value={persona.credits} onChange={event => setPersona(current => ({ ...current, credits: Number(event.target.value) }))} /></label>
+            {([ 'hc', 'vip', 'buildersClub', 'showHidden' ] as const).map(field => <label key={field}>
+                <input type="checkbox" checked={persona[field]} onChange={event => setPersona(current => ({ ...current, [field]: event.target.checked }))} />
+                {field === 'buildersClub' ? 'Builders Club' : field === 'showHidden' ? 'Show hidden' : field.toUpperCase()}
+            </label>)}
+        </div>
+        {!studio.preview && <div className="nitro-catalog-admin-placeholder is-small">Choose a persona and refresh the preview.</div>}
+        <div className="nitro-catalog-admin-preview-pages">
+            {pages.map(page => <section key={`${page.catalogType}:${page.pageId}`} className="nitro-catalog-admin-preview-page">
+                <header><strong>{page.caption}</strong><span>{page.catalogType} · #{page.pageId} · {page.pageLayout}</span></header>
+                <div className="nitro-catalog-admin-preview-offers">
+                    {(offersByPage.get(`${page.catalogType}:${page.pageId}`) ?? []).map(entry => <div key={entry.offer.offerId} className={`nitro-catalog-admin-preview-offer ${entry.eligible ? 'is-eligible' : 'is-blocked'}`}>
+                        <strong>{entry.offer.catalogName}</strong>
+                        <span>{entry.offer.costCredits} credits{entry.offer.costPoints > 0 ? ` + ${entry.offer.costPoints} currency ${entry.offer.pointsType}` : ''}</span>
+                        {!entry.eligible && <small>{entry.reasons.join(', ')}</small>}
+                    </div>)}
+                </div>
+            </section>)}
+        </div>
+    </div>;
+};

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
@@ -115,6 +115,24 @@ describe('CatalogStudioProvider', () => {
         expect(release.getMessageArray()).toEqual(expect.arrayContaining([ 12, 'PAGE', 44, 'token-123' ]));
     });
 
+    it('does not send duplicate lock requests while the first request is pending', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11, draftVersionId: 12, revision: 7,
+            activeUpdatedAt: '', draftCreatedAt: '', pendingCount: 0,
+            actors: [], validationCurrent: false, validationIssueCount: 0, publishedVersions: []
+        });
+
+        act(() => {
+            screen.getByText('lock').click();
+            screen.getByText('lock').click();
+        });
+
+        const acquireCalls = vi.mocked(SendMessageComposer).mock.calls
+            .filter(([ composer ]) => composer.constructor.name === 'CatalogStudioAcquireLockComposer');
+        expect(acquireCalls).toHaveLength(1);
+    });
+
     it('drops locks from the old draft after a successful publication', () => {
         render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
         emit('CatalogStudioSessionEvent', {

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
@@ -1,0 +1,139 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SendMessageComposer } from '../../../../api';
+import { useMessageEvent } from '../../../../hooks';
+import { CatalogStudioProvider } from './CatalogStudioProvider';
+import { useCatalogStudio } from './useCatalogStudio';
+
+vi.mock('../../../../api', () => ({ SendMessageComposer: vi.fn() }));
+vi.mock('../../../../hooks', () => ({ useMessageEvent: vi.fn() }));
+
+const handlers = new Map<string, (event: any) => void>();
+
+const Probe = () => {
+    const studio = useCatalogStudio();
+
+    return (
+        <div>
+            <span data-testid="draft">{studio.session?.draftVersionId ?? 0}</span>
+            <span data-testid="revision">{studio.revision}</span>
+            <span data-testid="pending">{studio.pendingCount}</span>
+            <span data-testid="locks">{Object.keys(studio.locks).length}</span>
+            <button onClick={() => studio.acquireLock('PAGE', 44)}>lock</button>
+            <button onClick={() => studio.releaseLock('PAGE', 44)}>release</button>
+            <button onClick={() => studio.publish()}>publish</button>
+        </div>
+    );
+};
+
+const emit = (eventName: string, parser: Record<string, unknown>) =>
+    act(() => handlers.get(eventName)?.({ getParser: () => parser }));
+
+describe('CatalogStudioProvider', () => {
+    beforeEach(() => {
+        handlers.clear();
+        vi.mocked(SendMessageComposer).mockClear();
+        vi.mocked(useMessageEvent).mockImplementation((eventType: any, handler: any) => {
+            handlers.set(eventType.name, handler);
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+    });
+
+    it('opens and hydrates the shared server session', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+
+        expect(vi.mocked(SendMessageComposer).mock.calls[0][0].constructor.name).toBe('CatalogStudioOpenSessionComposer');
+
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11,
+            draftVersionId: 12,
+            revision: 7,
+            activeUpdatedAt: '2026-08-02T10:00:00Z',
+            draftCreatedAt: '2026-08-02T10:05:00Z',
+            pendingCount: 3,
+            actors: [ { id: 9, username: 'Alice' } ],
+            validationCurrent: false,
+            validationIssueCount: 0,
+            publishedVersions: []
+        });
+
+        expect(screen.getByTestId('draft')).toHaveTextContent('12');
+        expect(screen.getByTestId('revision')).toHaveTextContent('7');
+        expect(screen.getByTestId('pending')).toHaveTextContent('3');
+    });
+
+    it('uses server revisions and recovers from a stale operation', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11, draftVersionId: 12, revision: 7,
+            activeUpdatedAt: '', draftCreatedAt: '', pendingCount: 1,
+            actors: [], validationCurrent: false, validationIssueCount: 0, publishedVersions: []
+        });
+
+        act(() => screen.getByText('publish').click());
+        const publish = vi.mocked(SendMessageComposer).mock.calls.at(-1)[0] as any;
+        expect(publish.getMessageArray().slice(1)).toEqual([ 12, 7 ]);
+
+        emit('CatalogStudioPublishEvent', {
+            operationId: publish.getMessageArray()[0], success: false,
+            code: 'STALE_REVISION', message: 'Refresh required', revision: 8, changedEntities: []
+        });
+
+        expect(screen.getByTestId('revision')).toHaveTextContent('8');
+        expect(vi.mocked(SendMessageComposer).mock.calls.at(-1)[0].constructor.name).toBe('CatalogStudioOpenSessionComposer');
+    });
+
+    it('renews an acquired lock and releases it when requested', () => {
+        vi.useFakeTimers();
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11, draftVersionId: 12, revision: 7,
+            activeUpdatedAt: '', draftCreatedAt: '', pendingCount: 0,
+            actors: [], validationCurrent: false, validationIssueCount: 0, publishedVersions: []
+        });
+
+        act(() => screen.getByText('lock').click());
+        const acquire = vi.mocked(SendMessageComposer).mock.calls.at(-1)[0] as any;
+        emit('CatalogStudioAcquireLockEvent', {
+            operationId: acquire.getMessageArray()[0], success: true, code: 'LOCK_ACQUIRED', message: '',
+            draftVersionId: 12, entityType: 'PAGE', entityId: 44, ownerId: 9,
+            ownerName: 'Alice', token: 'token-123', expiresAt: '2026-08-02T10:06:30Z'
+        });
+
+        act(() => vi.advanceTimersByTime(30_000));
+        expect(vi.mocked(SendMessageComposer).mock.calls.at(-1)[0].constructor.name).toBe('CatalogStudioRenewLockComposer');
+
+        act(() => screen.getByText('release').click());
+        const release = vi.mocked(SendMessageComposer).mock.calls.at(-1)[0] as any;
+        expect(release.constructor.name).toBe('CatalogStudioReleaseLockComposer');
+        expect(release.getMessageArray()).toEqual(expect.arrayContaining([ 12, 'PAGE', 44, 'token-123' ]));
+    });
+
+    it('drops locks from the old draft after a successful publication', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11, draftVersionId: 12, revision: 7,
+            activeUpdatedAt: '', draftCreatedAt: '', pendingCount: 1,
+            actors: [], validationCurrent: true, validationIssueCount: 0, publishedVersions: []
+        });
+        emit('CatalogStudioAcquireLockEvent', {
+            operationId: 'lock', success: true, code: 'LOCK_ACQUIRED', message: '',
+            draftVersionId: 12, entityType: 'PAGE', entityId: 44, ownerId: 9,
+            ownerName: 'Alice', token: 'token-123', expiresAt: '2026-08-02T10:06:30Z'
+        });
+        expect(screen.getByTestId('locks')).toHaveTextContent('1');
+
+        emit('CatalogStudioPublishEvent', {
+            operationId: 'publish', success: true, code: 'PUBLISHED', message: '',
+            revision: 8, changedEntities: []
+        });
+
+        expect(screen.getByTestId('locks')).toHaveTextContent('0');
+    });
+});

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -1,0 +1,352 @@
+import {
+    CatalogStudioAcquireLockComposer,
+    CatalogStudioAcquireLockEvent,
+    CatalogStudioDiscardComposer,
+    CatalogStudioDiscardEvent,
+    CatalogStudioDocumentApplyComposer,
+    CatalogStudioDocumentDryRunComposer,
+    CatalogStudioDocumentResultEvent,
+    CatalogStudioExportComposer,
+    CatalogStudioHistoryComposer,
+    CatalogStudioHistoryEvent,
+    CatalogStudioOpenSessionComposer,
+    CatalogStudioPublishComposer,
+    CatalogStudioPublishEvent,
+    CatalogStudioPreviewComposer,
+    CatalogStudioPreviewEvent,
+    CatalogStudioReleaseLockComposer,
+    CatalogStudioReleaseLockEvent,
+    CatalogStudioRenewLockComposer,
+    CatalogStudioRenewLockEvent,
+    CatalogStudioRestoreComposer,
+    CatalogStudioRestoreEvent,
+    CatalogStudioSessionEvent,
+    CatalogStudioUndoComposer,
+    CatalogStudioUndoEvent,
+    CatalogStudioValidateComposer,
+    CatalogStudioValidationEvent
+} from '@nitrots/nitro-renderer';
+import { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SendMessageComposer } from '../../../../api';
+import { useMessageEvent } from '../../../../hooks';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogPreviewPersona } from './CatalogPreviewPersona';
+import { CatalogStudioContext, CatalogStudioContextValue } from './useCatalogStudio';
+
+const lockKey = (entityType: string, entityId: number, catalogType: string = 'NORMAL') =>
+    catalogType === 'NORMAL' ? `${entityType}:${entityId}` : `${catalogType}:${entityType}:${entityId}`;
+let operationSequence = 0;
+const nextOperationId = (action: string) => `${action}-${Date.now()}-${++operationSequence}`;
+const CATALOG_ROOT_LOCK_ID = 2147483647;
+
+export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }> = ({ active, children }) => {
+    const [session, setSession] = useState<CatalogStudioSession | null>(null);
+    const [history, setHistory] = useState<CatalogStudioHistoryGroup[]>([]);
+    const [historyTotalCount, setHistoryTotalCount] = useState(0);
+    const [validation, setValidation] = useState<CatalogStudioValidationState | null>(null);
+    const [preview, setPreview] = useState<CatalogStudioPreviewState | null>(null);
+    const [documentResult, setDocumentResult] = useState<CatalogStudioDocumentResult | null>(null);
+    const [locks, setLocks] = useState<Record<string, CatalogStudioLock>>({});
+    const [loading, setLoading] = useState(false);
+    const [lastError, setLastError] = useState<string | null>(null);
+    const sessionRef = useRef<CatalogStudioSession | null>(null);
+    const locksRef = useRef<Record<string, CatalogStudioLock>>({});
+
+    const replaceSession = useCallback((next: CatalogStudioSession) => {
+        sessionRef.current = next;
+        setSession(next);
+    }, []);
+
+    const refresh = useCallback(() => {
+        if (!active) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioOpenSessionComposer());
+    }, [active]);
+
+    const updateRevision = useCallback((revision: number) => {
+        setSession((current) => {
+            if (!current || current.revision === revision) return current;
+            const next = { ...current, revision };
+            sessionRef.current = next;
+            return next;
+        });
+    }, []);
+
+    useMessageEvent<CatalogStudioSessionEvent>(CatalogStudioSessionEvent, (event) => {
+        const parser = event.getParser();
+        replaceSession({
+            activeVersionId: parser.activeVersionId,
+            draftVersionId: parser.draftVersionId,
+            revision: parser.revision,
+            activeUpdatedAt: parser.activeUpdatedAt,
+            draftCreatedAt: parser.draftCreatedAt,
+            pendingCount: parser.pendingCount,
+            actors: parser.actors.map((actor) => ({ ...actor })),
+            validationCurrent: parser.validationCurrent,
+            validationIssueCount: parser.validationIssueCount,
+            publishedVersions: parser.publishedVersions.map((version) => ({ ...version })),
+            pages: (parser.pages ?? []).map((page) => ({ ...page })),
+            offers: (parser.offers ?? []).map((offer) => ({ ...offer }))
+        });
+        setLoading(false);
+        setLastError(null);
+    });
+
+    const handleLock = useCallback((event: CatalogStudioAcquireLockEvent | CatalogStudioRenewLockEvent) => {
+        const parser = event.getParser();
+        setLoading(false);
+        if (!parser.success) {
+            setLastError(parser.message || parser.code);
+            return;
+        }
+        const nextLock: CatalogStudioLock = {
+            draftVersionId: parser.draftVersionId,
+            entityType: parser.entityType,
+            catalogType: parser.catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL',
+            entityId: parser.entityId,
+            ownerId: parser.ownerId,
+            ownerName: parser.ownerName,
+            token: parser.token,
+            expiresAt: parser.expiresAt
+        };
+        setLocks((current) => {
+            const next = { ...current, [lockKey(nextLock.entityType, nextLock.entityId, nextLock.catalogType)]: nextLock };
+            locksRef.current = next;
+            return next;
+        });
+        setLastError(null);
+    }, []);
+
+    useMessageEvent<CatalogStudioAcquireLockEvent>(CatalogStudioAcquireLockEvent, handleLock);
+    useMessageEvent<CatalogStudioRenewLockEvent>(CatalogStudioRenewLockEvent, handleLock);
+
+    const handleOperation = useCallback((event: CatalogStudioReleaseLockEvent | CatalogStudioUndoEvent | CatalogStudioPublishEvent | CatalogStudioDiscardEvent | CatalogStudioRestoreEvent) => {
+        const parser = event.getParser();
+        updateRevision(parser.revision);
+        setLoading(false);
+        if (!parser.success) {
+            setLastError(parser.message || parser.code);
+            if (parser.code === 'STALE_REVISION') refresh();
+            return;
+        }
+        setLastError(null);
+        refresh();
+    }, [refresh, updateRevision]);
+
+    const handleLifecycleOperation = useCallback((event: CatalogStudioPublishEvent | CatalogStudioDiscardEvent | CatalogStudioRestoreEvent) => {
+        if (event.getParser().success) {
+            locksRef.current = {};
+            setLocks({});
+        }
+        handleOperation(event);
+    }, [handleOperation]);
+
+    useMessageEvent<CatalogStudioReleaseLockEvent>(CatalogStudioReleaseLockEvent, handleOperation);
+    useMessageEvent<CatalogStudioUndoEvent>(CatalogStudioUndoEvent, handleOperation);
+    useMessageEvent<CatalogStudioPublishEvent>(CatalogStudioPublishEvent, handleLifecycleOperation);
+    useMessageEvent<CatalogStudioDiscardEvent>(CatalogStudioDiscardEvent, handleLifecycleOperation);
+    useMessageEvent<CatalogStudioRestoreEvent>(CatalogStudioRestoreEvent, handleLifecycleOperation);
+
+    useMessageEvent<CatalogStudioHistoryEvent>(CatalogStudioHistoryEvent, (event) => {
+        const parser = event.getParser();
+        updateRevision(parser.revision);
+        setHistory(parser.groups.map((group) => ({ ...group, entries: group.entries.map((entry) => ({ ...entry })) })));
+        setHistoryTotalCount(parser.totalCount);
+        setLoading(false);
+    });
+
+    useMessageEvent<CatalogStudioValidationEvent>(CatalogStudioValidationEvent, (event) => {
+        const parser = event.getParser();
+        const next: CatalogStudioValidationState = {
+            operationId: parser.operationId,
+            success: parser.success,
+            code: parser.code,
+            message: parser.message,
+            revision: parser.revision,
+            current: parser.current,
+            issues: parser.issues.map((issue) => ({ ...issue }))
+        };
+        setValidation(next);
+        updateRevision(parser.revision);
+        setLoading(false);
+        setLastError(parser.success ? null : parser.message || parser.code);
+    });
+
+    useMessageEvent<CatalogStudioPreviewEvent>(CatalogStudioPreviewEvent, (event) => {
+        const parser = event.getParser();
+        setPreview({
+            revision: parser.revision,
+            pages: parser.pages.map((page) => ({ ...page })),
+            offers: parser.offers.map((entry) => ({
+                offer: { ...entry.offer }, eligible: entry.eligible, reasons: [ ...entry.reasons ]
+            }))
+        });
+        setLoading(false);
+        setLastError(null);
+    });
+
+    useMessageEvent<CatalogStudioDocumentResultEvent>(CatalogStudioDocumentResultEvent, (event) => {
+        const parser = event.getParser();
+        const result: CatalogStudioDocumentResult = {
+            operationId: parser.operationId,
+            success: parser.success,
+            code: parser.code,
+            message: parser.message,
+            revision: parser.revision,
+            format: parser.format,
+            document: parser.document,
+            fingerprint: parser.fingerprint,
+            changedEntities: parser.changedEntities
+        };
+        setDocumentResult(result);
+        setLoading(false);
+        setLastError(result.success ? null : result.message || result.code);
+        if(result.code === 'APPLIED' || result.code === 'ALREADY_APPLIED') refresh();
+    });
+
+    useEffect(() => {
+        if (!active) {
+            setSession(null);
+            sessionRef.current = null;
+            return;
+        }
+        refresh();
+    }, [active, refresh]);
+
+    useEffect(() => {
+        if (!active) return;
+        const timer = window.setInterval(() => {
+            Object.values(locksRef.current).forEach((lock) => {
+                SendMessageComposer(new CatalogStudioRenewLockComposer(
+                    nextOperationId('renew-lock'), lock.draftVersionId, lock.entityType,
+                    lock.catalogType, lock.entityId, lock.token
+                ));
+            });
+        }, 30_000);
+        return () => window.clearInterval(timer);
+    }, [active]);
+
+    const acquireLock = useCallback((entityType: string, entityId: number, catalogType: 'NORMAL' | 'BUILDER' = 'NORMAL') => {
+        const current = sessionRef.current;
+        if (!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioAcquireLockComposer(nextOperationId('acquire-lock'), current.draftVersionId, entityType, catalogType, entityId));
+    }, []);
+
+    const releaseLock = useCallback((entityType: string, entityId: number, catalogType: 'NORMAL' | 'BUILDER' = 'NORMAL') => {
+        const lock = locksRef.current[lockKey(entityType, entityId, catalogType)];
+        if (!lock) return;
+        SendMessageComposer(new CatalogStudioReleaseLockComposer(
+            nextOperationId('release-lock'), lock.draftVersionId, lock.entityType, lock.catalogType, lock.entityId, lock.token
+        ));
+        setLocks((current) => {
+            const next = { ...current };
+            delete next[lockKey(entityType, entityId, catalogType)];
+            locksRef.current = next;
+            return next;
+        });
+    }, []);
+
+    const loadHistory = useCallback((offset = 0, limit = 50) => {
+        const current = sessionRef.current;
+        if (!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioHistoryComposer(current.draftVersionId, offset, limit));
+    }, []);
+
+    const revisionAction = useCallback((action: 'validate' | 'publish' | 'discard') => {
+        const current = sessionRef.current;
+        if (!current) return;
+        setLoading(true);
+        const operationId = nextOperationId(action);
+        if (action === 'validate') SendMessageComposer(new CatalogStudioValidateComposer(operationId, current.draftVersionId, current.revision));
+        if (action === 'publish') SendMessageComposer(new CatalogStudioPublishComposer(operationId, current.draftVersionId, current.revision));
+        if (action === 'discard') SendMessageComposer(new CatalogStudioDiscardComposer(operationId, current.draftVersionId, current.revision));
+    }, []);
+
+    const undo = useCallback((groupId: number) => {
+        const current = sessionRef.current;
+        if (!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioUndoComposer(nextOperationId('undo'), current.draftVersionId, current.revision, groupId));
+    }, []);
+
+    const restore = useCallback((sourceVersionId: number) => {
+        const current = sessionRef.current;
+        if (!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioRestoreComposer(nextOperationId('restore'), current.draftVersionId, current.revision, sourceVersionId));
+    }, []);
+
+    const requestPreview = useCallback((persona: CatalogPreviewPersona) => {
+        const current = sessionRef.current;
+        if(!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioPreviewComposer(
+            nextOperationId('preview'), current.draftVersionId, current.revision, persona.rank,
+            persona.hc, persona.vip, persona.buildersClub, persona.showHidden, persona.credits, persona.currencies
+        ));
+    }, []);
+
+    const exportDocument = useCallback((format: 'JSONC' | 'SQL') => {
+        const current = sessionRef.current;
+        if(!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioExportComposer(
+            nextOperationId('export'), current.draftVersionId, current.revision, format
+        ));
+    }, []);
+
+    const dryRunDocument = useCallback((format: 'JSONC' | 'SQL' | 'BULK', document: string) => {
+        const current = sessionRef.current;
+        if(!current) return;
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioDocumentDryRunComposer(
+            nextOperationId('dry-run'), current.draftVersionId, current.revision, format, document
+        ));
+    }, []);
+
+    const applyDocument = useCallback((format: 'JSONC' | 'SQL' | 'BULK', document: string, fingerprint: string, summary: string) => {
+        const current = sessionRef.current;
+        if(!current) return;
+        const rootLock = locksRef.current[lockKey('PAGE', CATALOG_ROOT_LOCK_ID)];
+        if(!rootLock) {
+            setLastError('Acquire the catalog root lock before applying a bulk or import operation.');
+            return;
+        }
+        setLoading(true);
+        SendMessageComposer(new CatalogStudioDocumentApplyComposer(
+            nextOperationId('apply'), current.draftVersionId, current.revision, rootLock.token,
+            format, document, fingerprint, summary
+        ));
+    }, []);
+
+    const value = useMemo<CatalogStudioContextValue>(() => ({
+        session,
+        revision: session?.revision ?? 0,
+        pendingCount: session?.pendingCount ?? 0,
+        history,
+        historyTotalCount,
+        validation,
+        preview,
+        documentResult,
+        locks,
+        loading,
+        lastError,
+        refresh,
+        acquireLock,
+        releaseLock,
+        loadHistory,
+        undo,
+        validate: () => revisionAction('validate'),
+        publish: () => revisionAction('publish'),
+        discard: () => revisionAction('discard'),
+        restore,
+        requestPreview,
+        exportDocument,
+        dryRunDocument,
+        applyDocument
+    }), [session, history, historyTotalCount, validation, preview, documentResult, locks, loading, lastError, refresh, acquireLock, releaseLock, loadHistory, undo, revisionAction, restore, requestPreview, exportDocument, dryRunDocument, applyDocument]);
+
+    return <CatalogStudioContext value={value}>{children}</CatalogStudioContext>;
+};

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -51,6 +51,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
     const [lastError, setLastError] = useState<string | null>(null);
     const sessionRef = useRef<CatalogStudioSession | null>(null);
     const locksRef = useRef<Record<string, CatalogStudioLock>>({});
+    const pendingLockKeysRef = useRef<Set<string>>(new Set());
 
     const replaceSession = useCallback((next: CatalogStudioSession) => {
         sessionRef.current = next;
@@ -94,6 +95,8 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
 
     const handleLock = useCallback((event: CatalogStudioAcquireLockEvent | CatalogStudioRenewLockEvent) => {
         const parser = event.getParser();
+        const parsedCatalogType = parser.catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL';
+        pendingLockKeysRef.current.delete(lockKey(parser.entityType, parser.entityId, parsedCatalogType));
         setLoading(false);
         if (!parser.success) {
             setLastError(parser.message || parser.code);
@@ -102,7 +105,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         const nextLock: CatalogStudioLock = {
             draftVersionId: parser.draftVersionId,
             entityType: parser.entityType,
-            catalogType: parser.catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL',
+            catalogType: parsedCatalogType,
             entityId: parser.entityId,
             ownerId: parser.ownerId,
             ownerName: parser.ownerName,
@@ -208,6 +211,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if (!active) {
             setSession(null);
             sessionRef.current = null;
+            pendingLockKeysRef.current.clear();
             return;
         }
         refresh();
@@ -228,7 +232,9 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
 
     const acquireLock = useCallback((entityType: string, entityId: number, catalogType: 'NORMAL' | 'BUILDER' = 'NORMAL') => {
         const current = sessionRef.current;
-        if (!current) return;
+        const key = lockKey(entityType, entityId, catalogType);
+        if (!current || locksRef.current[key] || pendingLockKeysRef.current.has(key)) return;
+        pendingLockKeysRef.current.add(key);
         setLoading(true);
         SendMessageComposer(new CatalogStudioAcquireLockComposer(nextOperationId('acquire-lock'), current.draftVersionId, entityType, catalogType, entityId));
     }, []);

--- a/src/components/catalog/admin/studio/CatalogStudioTypes.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioTypes.ts
@@ -1,0 +1,143 @@
+export interface CatalogStudioActor {
+    id: number;
+    username: string;
+}
+
+export interface CatalogStudioPublishedVersion {
+    id: number;
+    label: string;
+    publishedAt: string;
+}
+
+export type CatalogStudioCatalogType = 'NORMAL' | 'BUILDER';
+
+export interface CatalogStudioPageSnapshot {
+    catalogType: CatalogStudioCatalogType;
+    pageId: number;
+    parentId: number;
+    captionSave: string;
+    caption: string;
+    pageLayout: string;
+    iconColor: number;
+    iconImage: number;
+    minRank: number;
+    orderNum: number;
+    visible: boolean;
+    enabled: boolean;
+    clubOnly: boolean;
+    catalogMode: string;
+    vipOnly: boolean;
+    pageHeadline: string;
+    pageTeaser: string;
+    pageSpecial: string;
+    pageText1: string;
+    pageText2: string;
+    pageTextDetails: string;
+    pageTextTeaser: string;
+    roomId: number;
+    includes: string;
+}
+
+export interface CatalogStudioOfferSnapshot {
+    catalogType: CatalogStudioCatalogType;
+    offerId: number;
+    itemIds: string;
+    pageId: number;
+    catalogName: string;
+    costCredits: number;
+    costPoints: number;
+    pointsType: number;
+    amount: number;
+    limitedStack: number;
+    orderNumber: number;
+    offerIdClient: number;
+    songId: number;
+    extradata: string;
+    haveOffer: boolean;
+    clubOnly: boolean;
+}
+
+export interface CatalogStudioSession {
+    activeVersionId: number;
+    draftVersionId: number;
+    revision: number;
+    activeUpdatedAt: string;
+    draftCreatedAt: string;
+    pendingCount: number;
+    actors: CatalogStudioActor[];
+    validationCurrent: boolean;
+    validationIssueCount: number;
+    publishedVersions: CatalogStudioPublishedVersion[];
+    pages: CatalogStudioPageSnapshot[];
+    offers: CatalogStudioOfferSnapshot[];
+}
+
+export interface CatalogStudioLock {
+    draftVersionId: number;
+    entityType: string;
+    catalogType: CatalogStudioCatalogType;
+    entityId: number;
+    ownerId: number;
+    ownerName: string;
+    token: string;
+    expiresAt: string;
+}
+
+export interface CatalogStudioHistoryEntry {
+    entityType: string;
+    entityId: number;
+    operation: string;
+}
+
+export interface CatalogStudioHistoryGroup {
+    id: number;
+    revision: number;
+    actorId: number;
+    actorName: string;
+    summary: string;
+    source: string;
+    createdAt: string;
+    entries: CatalogStudioHistoryEntry[];
+}
+
+export interface CatalogStudioValidationIssue {
+    code: string;
+    entityType: string;
+    entityId: number;
+    field: string;
+    message: string;
+}
+
+export interface CatalogStudioValidationState {
+    operationId: string;
+    success: boolean;
+    code: string;
+    message: string;
+    revision: number;
+    current: boolean;
+    issues: CatalogStudioValidationIssue[];
+}
+
+export interface CatalogStudioPreviewOffer {
+    offer: CatalogStudioOfferSnapshot;
+    eligible: boolean;
+    reasons: string[];
+}
+
+export interface CatalogStudioPreviewState {
+    revision: number;
+    pages: CatalogStudioPageSnapshot[];
+    offers: CatalogStudioPreviewOffer[];
+}
+
+export interface CatalogStudioDocumentResult {
+    operationId: string;
+    success: boolean;
+    code: string;
+    message: string;
+    revision: number;
+    format: string;
+    document: string;
+    fingerprint: string;
+    changedEntities: number;
+}

--- a/src/components/catalog/admin/studio/useCatalogStudio.ts
+++ b/src/components/catalog/admin/studio/useCatalogStudio.ts
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogPreviewPersona } from './CatalogPreviewPersona';
+
+export interface CatalogStudioContextValue {
+    session: CatalogStudioSession | null;
+    revision: number;
+    pendingCount: number;
+    history: CatalogStudioHistoryGroup[];
+    historyTotalCount: number;
+    validation: CatalogStudioValidationState | null;
+    preview: CatalogStudioPreviewState | null;
+    documentResult: CatalogStudioDocumentResult | null;
+    locks: Readonly<Record<string, CatalogStudioLock>>;
+    loading: boolean;
+    lastError: string | null;
+    refresh: () => void;
+    acquireLock: (entityType: string, entityId: number, catalogType?: 'NORMAL' | 'BUILDER') => void;
+    releaseLock: (entityType: string, entityId: number, catalogType?: 'NORMAL' | 'BUILDER') => void;
+    loadHistory: (offset?: number, limit?: number) => void;
+    undo: (groupId: number) => void;
+    validate: () => void;
+    publish: () => void;
+    discard: () => void;
+    restore: (sourceVersionId: number) => void;
+    requestPreview: (persona: CatalogPreviewPersona) => void;
+    exportDocument: (format: 'JSONC' | 'SQL') => void;
+    dryRunDocument: (format: 'JSONC' | 'SQL' | 'BULK', document: string) => void;
+    applyDocument: (format: 'JSONC' | 'SQL' | 'BULK', document: string, fingerprint: string, summary: string) => void;
+}
+
+export const CatalogStudioContext = createContext<CatalogStudioContextValue>(null);
+export const useCatalogStudio = () => useContext(CatalogStudioContext);

--- a/src/components/catalog/views/admin/CatalogAdminDraftTree.test.ts
+++ b/src/components/catalog/views/admin/CatalogAdminDraftTree.test.ts
@@ -1,0 +1,71 @@
+import type { ICatalogNode } from '../../../../api';
+import { describe, expect, it } from 'vitest';
+import type { CatalogStudioPageSnapshot } from '../../admin/studio/CatalogStudioTypes';
+import { buildCatalogAdminDraftTree } from './CatalogAdminDraftTree';
+
+const liveNode = (pageId: number, parent: ICatalogNode | null = null): ICatalogNode => ({
+    activate: () => undefined,
+    deactivate: () => undefined,
+    open: () => undefined,
+    close: () => undefined,
+    addChild: () => undefined,
+    depth: parent ? parent.depth + 1 : 0,
+    isBranch: false,
+    isLeaf: true,
+    localization: pageId < 0 ? 'Root' : `Live ${pageId}`,
+    pageId,
+    parentId: parent?.pageId ?? -1,
+    pageName: pageId < 0 ? 'root' : `live-${pageId}`,
+    iconId: 0,
+    children: [],
+    offerIds: [],
+    parent: parent as ICatalogNode,
+    isVisible: true,
+    isActive: false,
+    isOpen: false
+});
+
+const page = (pageId: number, parentId: number, orderNum: number): CatalogStudioPageSnapshot => ({
+    catalogType: 'NORMAL',
+    pageId,
+    parentId,
+    captionSave: `page-${pageId}`,
+    caption: `Page ${pageId}`,
+    pageLayout: 'default_3x3',
+    iconColor: 0,
+    iconImage: 0,
+    minRank: 1,
+    orderNum,
+    visible: true,
+    enabled: true,
+    clubOnly: false,
+    catalogMode: 'NORMAL',
+    vipOnly: false,
+    pageHeadline: '',
+    pageTeaser: '',
+    pageSpecial: '',
+    pageText1: '',
+    pageText2: '',
+    pageTextDetails: '',
+    pageTextTeaser: '',
+    roomId: 0,
+    includes: ''
+});
+
+describe('buildCatalogAdminDraftTree', () => {
+    it('uses the shared draft parent and order instead of the live catalog tree', () => {
+        const root = liveNode(-1);
+        const draft = buildCatalogAdminDraftTree(root, [ page(1, -1, 1), page(2, -1, 0), page(3, 2, 0) ], 'NORMAL');
+
+        expect(draft?.children.map((node) => node.pageId)).toEqual([ 2, 1 ]);
+        expect(draft?.children[0].children.map((node) => node.pageId)).toEqual([ 3 ]);
+        expect(draft?.children[0].children[0].parent.pageId).toBe(2);
+    });
+
+    it('includes categories created only in the shared draft', () => {
+        const draft = buildCatalogAdminDraftTree(liveNode(-1), [ page(99, -1, 0) ], 'NORMAL');
+
+        expect(draft?.children[0].pageId).toBe(99);
+        expect(draft?.children[0].localization).toBe('Page 99');
+    });
+});

--- a/src/components/catalog/views/admin/CatalogAdminDraftTree.ts
+++ b/src/components/catalog/views/admin/CatalogAdminDraftTree.ts
@@ -1,0 +1,95 @@
+import type { NodeData } from '@nitrots/nitro-renderer';
+import { CatalogNode } from '../../../../api/catalog/CatalogNode';
+import type { ICatalogNode } from '../../../../api/catalog/ICatalogNode';
+import type { CatalogStudioCatalogType, CatalogStudioPageSnapshot } from '../../admin/studio/CatalogStudioTypes';
+
+const toStudioCatalogType = (catalogType: string): CatalogStudioCatalogType =>
+    catalogType === 'BUILDERS_CLUB' || catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL';
+
+const collectLiveNodes = (node: ICatalogNode | null, result: Map<number, ICatalogNode>) => {
+    if (!node) return;
+    result.set(node.pageId, node);
+    node.children.forEach((child) => collectLiveNodes(child, result));
+};
+
+const nodeData = (
+    page: CatalogStudioPageSnapshot,
+    liveNode: ICatalogNode | undefined
+): NodeData => ({
+    visible: page.visible,
+    icon: page.iconImage,
+    pageId: page.pageId,
+    parentId: page.parentId,
+    pageName: page.captionSave || liveNode?.pageName || `page-${page.pageId}`,
+    localization: page.caption || liveNode?.localization || page.captionSave || `Page ${page.pageId}`,
+    children: [],
+    offerIds: liveNode?.offerIds ?? []
+} as unknown as NodeData);
+
+const rootData = (root: ICatalogNode): NodeData => ({
+    visible: true,
+    icon: root.iconId,
+    pageId: root.pageId,
+    parentId: root.parentId,
+    pageName: root.pageName || 'root',
+    localization: root.localization,
+    children: [],
+    offerIds: root.offerIds
+} as unknown as NodeData);
+
+export const buildCatalogAdminDraftTree = (
+    liveRoot: ICatalogNode | null,
+    pages: CatalogStudioPageSnapshot[],
+    catalogType: string
+): ICatalogNode | null => {
+    if (!liveRoot) return null;
+
+    const scopedPages = pages.filter((page) => page.catalogType === toStudioCatalogType(catalogType));
+    if (!scopedPages.length) return liveRoot;
+
+    const liveNodes = new Map<number, ICatalogNode>();
+    collectLiveNodes(liveRoot, liveNodes);
+
+    const pageIds = new Set(scopedPages.map((page) => page.pageId));
+    const childrenByParent = new Map<number, CatalogStudioPageSnapshot[]>();
+    const roots: CatalogStudioPageSnapshot[] = [];
+
+    for (const page of scopedPages) {
+        if (!pageIds.has(page.parentId)) {
+            roots.push(page);
+            continue;
+        }
+
+        const siblings = childrenByParent.get(page.parentId) ?? [];
+        siblings.push(page);
+        childrenByParent.set(page.parentId, siblings);
+    }
+
+    const sortPages = (items: CatalogStudioPageSnapshot[]) =>
+        items.sort((left, right) => left.orderNum - right.orderNum || left.pageId - right.pageId);
+
+    sortPages(roots);
+    childrenByParent.forEach(sortPages);
+
+    const draftRoot = new CatalogNode(rootData(liveRoot), 0, null);
+    const visited = new Set<number>();
+
+    const append = (page: CatalogStudioPageSnapshot, parent: ICatalogNode, depth: number): ICatalogNode | null => {
+        if (visited.has(page.pageId)) return null;
+        visited.add(page.pageId);
+
+        const node = new CatalogNode(nodeData(page, liveNodes.get(page.pageId)), depth, parent);
+        for (const child of childrenByParent.get(page.pageId) ?? []) {
+            append(child, node, depth + 1);
+        }
+        parent.addChild(node);
+        return node;
+    };
+
+    roots.forEach((page) => append(page, draftRoot, 1));
+    scopedPages.forEach((page) => {
+        if (!visited.has(page.pageId)) append(page, draftRoot, 1);
+    });
+
+    return draftRoot;
+};

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -25,7 +25,7 @@ import { NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../
 import { useCatalogActions, useCatalogData, useCatalogUiState } from '../../../../hooks';
 import { replaceCatalogPageOffers } from '../../../../hooks/catalog/useCatalog.helpers';
 import { CATALOG_ROOT_LOCK_ID, useCatalogAdmin } from '../../CatalogAdminContext';
-import { getCatalogStudioCommandState } from '../../admin/studio/CatalogStudioCommandCenter';
+import { getCatalogStudioCommandState, getCatalogStudioPageLockKey } from '../../admin/studio/CatalogStudioCommandCenter';
 import { CatalogStudioBulkPanel } from '../../admin/studio/CatalogStudioBulkPanel';
 import { CatalogStudioImportExportPanel } from '../../admin/studio/CatalogStudioImportExportPanel';
 import { CatalogStudioPreview } from '../../admin/studio/CatalogStudioPreview';
@@ -475,7 +475,7 @@ export const CatalogAdminManagerView: FC<{}> = () => {
             return <aside className="nitro-catalog-admin-inspector"><div className="nitro-catalog-admin-placeholder is-small">No page selected</div></aside>;
         }
 
-        const lock = studio.locks[`PAGE:${selectedNode.pageId}`];
+        const lock = studio.locks[getCatalogStudioPageLockKey(selectedNode.pageId, currentType)];
 
         return (
             <aside className="nitro-catalog-admin-inspector">
@@ -484,10 +484,10 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                     <span>Page #{selectedNode.pageId}</span>
                 </div>
                 <dl className="nitro-catalog-admin-inspector-data">
-                    <div><dt>Name</dt><dd>{nodeName(selectedNode)}</dd></div>
+                    <div><dt>Name</dt><dd title={nodeName(selectedNode)}>{nodeName(selectedNode)}</dd></div>
                     <div><dt>Sub-pages</dt><dd>{selectedNode.children.length}</dd></div>
                     <div><dt>Offers</dt><dd>{offers.length}</dd></div>
-                    <div><dt>Visibility</dt><dd>{selectedNode.isVisible ? 'Visible' : 'Hidden'}</dd></div>
+                    <div><dt>Visibility</dt><dd className={selectedNode.isVisible ? 'is-positive' : 'is-muted'}>{selectedNode.isVisible ? 'Visible' : 'Hidden'}</dd></div>
                     <div><dt>Revision</dt><dd>{studio.revision}</dd></div>
                 </dl>
                 <div className={`nitro-catalog-admin-lock-state ${lock ? 'is-owned' : ''}`}>
@@ -690,20 +690,20 @@ export const CatalogAdminManagerView: FC<{}> = () => {
         <NitroCardView classNames={['nitro-catalog-admin-manager']} uniqueKey="catalog-admin-manager">
             <NitroCardHeaderView headerText="Catalog Admin Editor" onCloseClick={() => catalogAdmin.setAdminMode(false)} />
             <NitroCardContentView classNames={['nitro-catalog-admin-manager-body']}>
-                <div className={`nitro-catalog-admin-command-bar is-${commandState.phase}`}>
+                <div aria-live="polite" className={`nitro-catalog-admin-command-bar is-${commandState.phase}`}>
                     <div className="nitro-catalog-admin-command-title">
                         <strong>Catalog Studio</strong>
                         <span>Shared draft command center</span>
                     </div>
                     <div className="nitro-catalog-admin-command-stats">
-                        <span><FaClock /> Revision {studio.revision}</span>
+                        <span className="is-revision"><FaClock /> Revision {studio.revision}</span>
                         <span className={hasPendingChanges ? 'has-pending' : ''}>
                             <FaCloudUploadAlt /> {commandState.pendingLabel}
                         </span>
-                        <span><FaUsers /> {commandState.actorLabel}</span>
-                        <span><FaLock /> {commandState.lockLabel}</span>
-                        <span className={validationIssueCount > 0 ? 'has-error' : validationCurrent ? 'is-valid' : ''}>
-                            {validationIssueCount > 0 ? <FaExclamationTriangle /> : <FaCheckCircle />}
+                        <span className="is-actors"><FaUsers /> {commandState.actorLabel}</span>
+                        <span className="is-locks"><FaLock /> {commandState.lockLabel}</span>
+                        <span className={validationIssueCount > 0 ? 'has-error' : validationCurrent ? 'is-valid' : 'has-warning'}>
+                            {validationCurrent && validationIssueCount === 0 ? <FaCheckCircle /> : <FaExclamationTriangle />}
                             {commandState.validationLabel}
                         </span>
                     </div>

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -1,30 +1,41 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import {
     FaArrowDown,
     FaArrowsAlt,
     FaArrowUp,
     FaChevronDown,
     FaChevronRight,
+    FaCheckCircle,
+    FaClock,
     FaCloudUploadAlt,
     FaEdit,
+    FaExclamationTriangle,
     FaEye,
     FaEyeSlash,
+    FaHistory,
+    FaLock,
     FaPlus,
     FaSearch,
     FaSitemap,
-    FaTrash
+    FaTrash,
+    FaUsers
 } from 'react-icons/fa';
 import { GetConfigurationValue, ICatalogNode, IPurchasableOffer, LocalizeText, ProductTypeEnum } from '../../../../api';
 import { NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
 import { useCatalogActions, useCatalogData, useCatalogUiState } from '../../../../hooks';
 import { replaceCatalogPageOffers } from '../../../../hooks/catalog/useCatalog.helpers';
-import { useCatalogAdmin } from '../../CatalogAdminContext';
+import { CATALOG_ROOT_LOCK_ID, useCatalogAdmin } from '../../CatalogAdminContext';
+import { getCatalogStudioCommandState } from '../../admin/studio/CatalogStudioCommandCenter';
+import { CatalogStudioBulkPanel } from '../../admin/studio/CatalogStudioBulkPanel';
+import { CatalogStudioImportExportPanel } from '../../admin/studio/CatalogStudioImportExportPanel';
+import { CatalogStudioPreview } from '../../admin/studio/CatalogStudioPreview';
+import { useCatalogStudio } from '../../admin/studio/useCatalogStudio';
 import { parseCatalogTabLabel } from '../../useCatalogWindowWidth';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
 import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 
 type CatalogAdminOffer = Parameters<NonNullable<ReturnType<typeof useCatalogAdmin>>['setEditingOffer']>[0];
-type ManagerTab = 'pages' | 'publish';
+type ManagerTab = 'pages' | 'preview' | 'bulk' | 'transfer' | 'activity' | 'publish';
 
 const stripSwfSuffix = (label: string) => (label || '').replace(/\s*\(\D[^)]*\)\s*$/g, '').trim();
 const nodeName = (node: ICatalogNode) => stripSwfSuffix(parseCatalogTabLabel(node.localization).name) || node.pageName;
@@ -74,9 +85,10 @@ const getOfferIconUrl = (offer: IPurchasableOffer): string | null => {
 
 export const CatalogAdminManagerView: FC<{}> = () => {
     const { rootNode = null, currentPage = null } = useCatalogData();
-    const { setCurrentPage } = useCatalogUiState();
+    const { setCurrentPage, currentType } = useCatalogUiState();
     const { activateNode = null } = useCatalogActions();
     const catalogAdmin = useCatalogAdmin();
+    const studio = useCatalogStudio();
     const [activeTab, setActiveTab] = useState<ManagerTab>('pages');
     const [expanded, setExpanded] = useState<Set<number>>(new Set());
     const [search, setSearch] = useState('');
@@ -88,6 +100,29 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     const selectedNode = findNodeByPageId(rootNode, selectedPageId);
     const offers = currentPage?.offers ?? [];
     const categoryCount = rootNode?.children.length ?? 0;
+    const validationCurrent = studio.validation
+        ? studio.validation.current && studio.validation.revision === studio.revision
+        : studio.session?.validationCurrent ?? false;
+    const validationIssueCount = studio.validation?.issues.length ?? studio.session?.validationIssueCount ?? 0;
+    const commandState = getCatalogStudioCommandState({
+        sessionReady: !!studio.session,
+        pendingCount: studio.pendingCount,
+        actorCount: studio.session?.actors.length ?? 0,
+        lockCount: Object.keys(studio.locks).length,
+        validationCurrent,
+        validationIssueCount,
+        loading: studio.loading || !!catalogAdmin?.loading
+    });
+
+    useEffect(() => {
+        if (activeTab !== 'activity' || !catalogAdmin?.adminMode || !studio.session) return;
+        studio.loadHistory();
+    }, [activeTab, catalogAdmin?.adminMode, studio.session?.draftVersionId, studio.loadHistory]);
+
+    useEffect(() => {
+        if (!catalogAdmin?.adminMode || !studio.session) return;
+        studio.loadHistory();
+    }, [catalogAdmin?.adminMode, studio.session?.draftVersionId, studio.loadHistory]);
 
     const handlePageDragStart = useCallback((event: React.DragEvent, node: ICatalogNode) => {
         event.stopPropagation();
@@ -144,7 +179,8 @@ export const CatalogAdminManagerView: FC<{}> = () => {
             const pageLabel = selectedNode ? nodeName(selectedNode) : 'page';
             catalogAdmin.reorderOffers(
                 reordered.map((offer, i) => ({ id: offer.offerId, orderNumber: i })),
-                `Reordered offers on "${pageLabel}"`
+                `Reordered offers on "${pageLabel}"`,
+                currentPage.pageId
             );
         },
         [catalogAdmin, currentPage, offers, selectedNode, setCurrentPage]
@@ -187,7 +223,7 @@ export const CatalogAdminManagerView: FC<{}> = () => {
 
     if (!catalogAdmin?.adminMode) return null;
 
-    const { loading, hasPendingChanges, pendingChanges } = catalogAdmin;
+    const hasPendingChanges = studio.pendingCount > 0;
 
     const toggleExpand = (pageId: number) => {
         setExpanded((prev) => {
@@ -200,10 +236,15 @@ export const CatalogAdminManagerView: FC<{}> = () => {
 
     const selectNode = (node: ICatalogNode) => {
         if (node.children.length) setExpanded((prev) => new Set(prev).add(node.pageId));
-        if (node.pageId > -1) activateNode?.(node);
+        if (node.pageId > -1) {
+        if (selectedPageId > 0 && selectedPageId !== node.pageId) studio.releaseLock('PAGE', selectedPageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
+        studio.acquireLock('PAGE', node.pageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
+            activateNode?.(node);
+        }
     };
 
     const editPage = (node: ICatalogNode | null, isRoot: boolean) => {
+        if (node && node.pageId > 0) studio.acquireLock('PAGE', node.pageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
         catalogAdmin.setCreatingPage(false);
         catalogAdmin.setEditingPageNode(isRoot ? null : node);
         catalogAdmin.setEditingRootPage(isRoot);
@@ -211,6 +252,7 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     };
 
     const createCategory = (parent: ICatalogNode) => {
+        studio.acquireLock('PAGE', parent.pageId > 0 ? parent.pageId : CATALOG_ROOT_LOCK_ID, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
         catalogAdmin.setCreatingPage(true);
         catalogAdmin.setEditingRootPage(false);
         catalogAdmin.setEditingPageNode(parent);
@@ -237,6 +279,8 @@ export const CatalogAdminManagerView: FC<{}> = () => {
 
     const newOffer = () => {
         if (!currentPage) return;
+
+        studio.acquireLock('PAGE', currentPage.pageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
 
         catalogAdmin.setEditingOffer({
             offerId: -1,
@@ -407,7 +451,10 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                                         pointsType={offer.activityPointType}
                                     />
                                     <div className="nitro-catalog-admin-manager-controls">
-                                        <button title="Edit offer" onClick={() => catalogAdmin.setEditingOffer(offer)}>
+                                        <button title="Edit offer" onClick={() => {
+        studio.acquireLock('OFFER', offer.offerId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
+                                            catalogAdmin.setEditingOffer(offer);
+                                        }}>
                                             <FaEdit />
                                         </button>
                                         <button className="danger" title="Delete offer" onClick={() => deleteOffer(offer)}>
@@ -422,6 +469,67 @@ export const CatalogAdminManagerView: FC<{}> = () => {
             </div>
         );
     };
+
+    const renderInspector = () => {
+        if (!selectedNode) {
+            return <aside className="nitro-catalog-admin-inspector"><div className="nitro-catalog-admin-placeholder is-small">No page selected</div></aside>;
+        }
+
+        const lock = studio.locks[`PAGE:${selectedNode.pageId}`];
+
+        return (
+            <aside className="nitro-catalog-admin-inspector">
+                <div className="nitro-catalog-admin-inspector-head">
+                    <strong>Inspector</strong>
+                    <span>Page #{selectedNode.pageId}</span>
+                </div>
+                <dl className="nitro-catalog-admin-inspector-data">
+                    <div><dt>Name</dt><dd>{nodeName(selectedNode)}</dd></div>
+                    <div><dt>Sub-pages</dt><dd>{selectedNode.children.length}</dd></div>
+                    <div><dt>Offers</dt><dd>{offers.length}</dd></div>
+                    <div><dt>Visibility</dt><dd>{selectedNode.isVisible ? 'Visible' : 'Hidden'}</dd></div>
+                    <div><dt>Revision</dt><dd>{studio.revision}</dd></div>
+                </dl>
+                <div className={`nitro-catalog-admin-lock-state ${lock ? 'is-owned' : ''}`}>
+                    <FaLock />
+                    <div>
+                        <strong>{lock ? `Locked by ${lock.ownerName}` : 'Read-only until locked'}</strong>
+                        <span>{lock ? `Lease expires ${formatChangeTime(lock.expiresAt)}` : 'Select or edit the page to acquire its lease.'}</span>
+                    </div>
+                </div>
+                <div className="nitro-catalog-admin-inspector-actions">
+                    <button className="nitro-catalog-admin-btn is-primary" onClick={() => editPage(selectedNode, false)}>
+                        <FaEdit /> Edit
+                    </button>
+                    <button className="nitro-catalog-admin-btn" onClick={() => createCategory(selectedNode)}>
+                        <FaPlus /> Sub-page
+                    </button>
+                    <button className="nitro-catalog-admin-btn" onClick={newOffer}>
+                        <FaPlus /> Offer
+                    </button>
+                </div>
+            </aside>
+        );
+    };
+
+    const renderChangesDrawer = () => (
+        <div className="nitro-catalog-admin-changes-drawer">
+            <div className="nitro-catalog-admin-changes-title">
+                <FaHistory />
+                <div><strong>Draft changes</strong><span>{commandState.pendingLabel}</span></div>
+            </div>
+            <div className="nitro-catalog-admin-changes-feed">
+                {studio.history.length === 0 && <span>No changes recorded.</span>}
+                {studio.history.slice(0, 3).map((group) => (
+                    <button key={group.id} title="Open activity" onClick={() => setActiveTab('activity')}>
+                        <strong>{group.summary}</strong>
+                        <span>r{group.revision} · {group.actorName || `#${group.actorId}`}</span>
+                    </button>
+                ))}
+            </div>
+            <button className="nitro-catalog-admin-btn is-small" onClick={() => setActiveTab('activity')}>Open history</button>
+        </div>
+    );
 
     const renderPagesTab = () => (
         <div className="nitro-catalog-admin-pages">
@@ -449,57 +557,157 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                 </div>
             </div>
             <div className="nitro-catalog-admin-detail">{renderDetail()}</div>
+            {renderInspector()}
+            {renderChangesDrawer()}
         </div>
     );
 
-    const formatChangeTime = (at: number) => new Date(at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    const formatChangeTime = (at: number | string) => new Date(at).toLocaleString([], {
+        day: '2-digit',
+        month: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+
+    const renderActivityTab = () => (
+        <div className="nitro-catalog-admin-activity">
+            <div className="nitro-catalog-admin-section-head">
+                <div>
+                    <strong>Shared draft activity</strong>
+                    <span>{studio.historyTotalCount} recorded change group(s)</span>
+                </div>
+                <button className="nitro-catalog-admin-btn" disabled={studio.loading} onClick={() => studio.loadHistory()}>
+                    <FaHistory /> <span>Refresh</span>
+                </button>
+            </div>
+            <div className="nitro-catalog-admin-history-list">
+                {studio.history.length === 0 && (
+                    <div className="nitro-catalog-admin-placeholder is-small">No draft activity has been recorded yet.</div>
+                )}
+                {studio.history.map((group) => (
+                    <div key={group.id} className="nitro-catalog-admin-history-row">
+                        <div className="nitro-catalog-admin-history-main">
+                            <span className="nitro-catalog-admin-history-summary">{group.summary}</span>
+                            <span className="nitro-catalog-admin-history-meta">
+                                Revision {group.revision} · {group.actorName || `User #${group.actorId}`} · {group.source}
+                            </span>
+                        </div>
+                        <div className="nitro-catalog-admin-history-side">
+                            <span>{formatChangeTime(group.createdAt)}</span>
+                            <button
+                                className="nitro-catalog-admin-btn is-small"
+                                disabled={studio.loading}
+                                title="Undo this change group in the shared draft"
+                                onClick={() => confirm(`Undo "${group.summary}"?`) && studio.undo(group.id)}
+                            >
+                                Undo
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
 
     const renderPublishTab = () => (
         <div className="nitro-catalog-admin-publish">
-            <div className={`nitro-catalog-admin-publish-status ${hasPendingChanges ? 'has-pending' : ''}`}>
-                {hasPendingChanges
-                    ? `${pendingChanges.length} change${pendingChanges.length === 1 ? '' : 's'} awaiting client refresh.`
-                    : 'Catalog is up to date — no changes waiting to be published.'}
+            <div className={`nitro-catalog-admin-publish-status is-${commandState.phase}`}>
+                {commandState.phase === 'clean' && 'The published catalog and shared draft are aligned.'}
+                {commandState.phase === 'draft' && 'The draft has unpublished changes and must be validated.'}
+                {commandState.phase === 'blocked' && `${commandState.validationLabel} must be resolved before publication.`}
+                {commandState.phase === 'ready' && 'The draft is validated and ready to publish.'}
+                {commandState.phase === 'offline' && 'Catalog Studio session is not ready.'}
             </div>
             <p className="nitro-catalog-admin-publish-text">
-                Changes are saved immediately. Publishing reloads the server catalog and tells connected players to refresh it.
+                Publication validates the current revision, replaces the live catalog atomically and creates the next shared draft.
             </p>
 
-            {pendingChanges.length > 0 && (
-                <div className="nitro-catalog-admin-publish-changes">
-                    <div className="nitro-catalog-admin-publish-changes-head">Changes since last publish</div>
-                    <ul className="nitro-catalog-admin-publish-changes-list">
-                        {[...pendingChanges].reverse().map((change) => (
-                            <li key={change.id} className="nitro-catalog-admin-publish-change">
-                                <span className="nitro-catalog-admin-publish-change-summary">{change.summary}</span>
-                                <span className="nitro-catalog-admin-publish-change-time">{formatChangeTime(change.at)}</span>
-                            </li>
-                        ))}
-                    </ul>
+            {studio.validation?.issues.length > 0 && (
+                <div className="nitro-catalog-admin-validation-list">
+                    <div className="nitro-catalog-admin-publish-changes-head">Validation issues</div>
+                    {studio.validation.issues.map((issue, index) => (
+                        <div key={`${issue.code}-${issue.entityType}-${issue.entityId}-${index}`} className="nitro-catalog-admin-validation-row">
+                            <FaExclamationTriangle />
+                            <div>
+                                <strong>{issue.message}</strong>
+                                <span>{issue.entityType} #{issue.entityId} · {issue.field} · {issue.code}</span>
+                            </div>
+                        </div>
+                    ))}
                 </div>
             )}
 
             <div className="nitro-catalog-admin-publish-actions">
                 <button
-                    className={`nitro-catalog-admin-btn is-publish ${hasPendingChanges ? 'has-pending' : ''}`}
-                    disabled={loading || !hasPendingChanges}
+                    className="nitro-catalog-admin-btn"
+                    disabled={!commandState.canValidate}
+                    onClick={() => studio.validate()}
+                >
+                    <FaCheckCircle /> <span>{studio.loading ? 'Working…' : 'Validate draft'}</span>
+                </button>
+                <button
+                    className={`nitro-catalog-admin-btn is-publish ${commandState.canPublish ? 'has-pending' : ''}`}
+                    disabled={!commandState.canPublish}
                     onClick={() => catalogAdmin.publishCatalog()}
                 >
-                    <FaCloudUploadAlt /> <span>{loading ? 'Publishing…' : 'Publish catalog'}</span>
+                    <FaCloudUploadAlt /> <span>{studio.loading ? 'Publishing…' : 'Publish catalog'}</span>
                 </button>
             </div>
+
+            {studio.session?.publishedVersions.length > 0 && (
+                <div className="nitro-catalog-admin-versions">
+                    <div className="nitro-catalog-admin-publish-changes-head">Published versions</div>
+                    {studio.session.publishedVersions.map((version) => (
+                        <div key={version.id} className="nitro-catalog-admin-version-row">
+                            <div>
+                                <strong>{version.label || `Version #${version.id}`}</strong>
+                                <span>{formatChangeTime(version.publishedAt)}</span>
+                            </div>
+                            <button
+                                className="nitro-catalog-admin-btn is-small"
+                                disabled={studio.loading || version.id === studio.session?.activeVersionId}
+                                onClick={() => confirm(`Restore version #${version.id} into the shared draft?`) && studio.restore(version.id)}
+                            >
+                                Restore to draft
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 
     const tabs = [
         { id: 'pages' as ManagerTab, label: 'Pages', icon: <FaSitemap />, count: categoryCount },
-        { id: 'publish' as ManagerTab, label: 'Publish', icon: <FaCloudUploadAlt />, count: pendingChanges.length }
+        { id: 'preview' as ManagerTab, label: 'Preview', icon: <FaEye />, count: studio.preview?.pages.length ?? 0 },
+        { id: 'bulk' as ManagerTab, label: 'Bulk', icon: <FaArrowsAlt />, count: 0 },
+        { id: 'transfer' as ManagerTab, label: 'JSONC / SQL', icon: <FaEdit />, count: 0 },
+        { id: 'activity' as ManagerTab, label: 'Activity', icon: <FaHistory />, count: studio.historyTotalCount },
+        { id: 'publish' as ManagerTab, label: 'Publish', icon: <FaCloudUploadAlt />, count: studio.pendingCount }
     ];
 
     return (
         <NitroCardView classNames={['nitro-catalog-admin-manager']} uniqueKey="catalog-admin-manager">
             <NitroCardHeaderView headerText="Catalog Admin Editor" onCloseClick={() => catalogAdmin.setAdminMode(false)} />
             <NitroCardContentView classNames={['nitro-catalog-admin-manager-body']}>
+                <div className={`nitro-catalog-admin-command-bar is-${commandState.phase}`}>
+                    <div className="nitro-catalog-admin-command-title">
+                        <strong>Catalog Studio</strong>
+                        <span>Shared draft command center</span>
+                    </div>
+                    <div className="nitro-catalog-admin-command-stats">
+                        <span><FaClock /> Revision {studio.revision}</span>
+                        <span className={hasPendingChanges ? 'has-pending' : ''}>
+                            <FaCloudUploadAlt /> {commandState.pendingLabel}
+                        </span>
+                        <span><FaUsers /> {commandState.actorLabel}</span>
+                        <span><FaLock /> {commandState.lockLabel}</span>
+                        <span className={validationIssueCount > 0 ? 'has-error' : validationCurrent ? 'is-valid' : ''}>
+                            {validationIssueCount > 0 ? <FaExclamationTriangle /> : <FaCheckCircle />}
+                            {commandState.validationLabel}
+                        </span>
+                    </div>
+                </div>
                 <div className="nitro-catalog-admin-tabs">
                     {tabs.map((tab) => (
                         <button
@@ -518,6 +726,10 @@ export const CatalogAdminManagerView: FC<{}> = () => {
 
                 <div className="nitro-catalog-admin-panel">
                     {activeTab === 'pages' && renderPagesTab()}
+                    {activeTab === 'preview' && <CatalogStudioPreview />}
+                    {activeTab === 'bulk' && <CatalogStudioBulkPanel />}
+                    {activeTab === 'transfer' && <CatalogStudioImportExportPanel />}
+                    {activeTab === 'activity' && renderActivityTab()}
                     {activeTab === 'publish' && renderPublishTab()}
                 </div>
             </NitroCardContentView>

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
     FaArrowDown,
     FaArrowsAlt,
@@ -32,6 +32,7 @@ import { CatalogStudioPreview } from '../../admin/studio/CatalogStudioPreview';
 import { useCatalogStudio } from '../../admin/studio/useCatalogStudio';
 import { parseCatalogTabLabel } from '../../useCatalogWindowWidth';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
+import { buildCatalogAdminDraftTree } from './CatalogAdminDraftTree';
 import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 
 type CatalogAdminOffer = Parameters<NonNullable<ReturnType<typeof useCatalogAdmin>>['setEditingOffer']>[0];
@@ -94,12 +95,16 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     const [search, setSearch] = useState('');
     const [dragOverPageId, setDragOverPageId] = useState<number | null>(null);
     const [dragOverOfferIndex, setDragOverOfferIndex] = useState<number | null>(null);
+    const [selectedPageId, setSelectedPageId] = useState(currentPage?.pageId ?? -1);
 
     const query = search.trim().toLowerCase();
-    const selectedPageId = currentPage?.pageId ?? -1;
-    const selectedNode = findNodeByPageId(rootNode, selectedPageId);
-    const offers = currentPage?.offers ?? [];
-    const categoryCount = rootNode?.children.length ?? 0;
+    const draftRootNode = useMemo(
+        () => buildCatalogAdminDraftTree(rootNode, studio.session?.pages ?? [], currentType),
+        [currentType, rootNode, studio.session?.pages]
+    );
+    const selectedNode = findNodeByPageId(draftRootNode, selectedPageId);
+    const offers = currentPage?.pageId === selectedPageId ? (currentPage.offers ?? []) : [];
+    const categoryCount = draftRootNode?.children.length ?? 0;
     const validationCurrent = studio.validation
         ? studio.validation.current && studio.validation.revision === studio.revision
         : studio.session?.validationCurrent ?? false;
@@ -123,6 +128,10 @@ export const CatalogAdminManagerView: FC<{}> = () => {
         if (!catalogAdmin?.adminMode || !studio.session) return;
         studio.loadHistory();
     }, [catalogAdmin?.adminMode, studio.session?.draftVersionId, studio.loadHistory]);
+
+    useEffect(() => {
+        if (selectedPageId < 0 && currentPage?.pageId != null) setSelectedPageId(currentPage.pageId);
+    }, [currentPage?.pageId, selectedPageId]);
 
     const handlePageDragStart = useCallback((event: React.DragEvent, node: ICatalogNode) => {
         event.stopPropagation();
@@ -237,9 +246,12 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     const selectNode = (node: ICatalogNode) => {
         if (node.children.length) setExpanded((prev) => new Set(prev).add(node.pageId));
         if (node.pageId > -1) {
-        if (selectedPageId > 0 && selectedPageId !== node.pageId) studio.releaseLock('PAGE', selectedPageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
-        studio.acquireLock('PAGE', node.pageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
-            activateNode?.(node);
+            if (selectedPageId > 0 && selectedPageId !== node.pageId) studio.releaseLock('PAGE', selectedPageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
+            studio.acquireLock('PAGE', node.pageId, currentType === 'BUILDERS_CLUB' || currentType === 'BUILDER' ? 'BUILDER' : 'NORMAL');
+            setSelectedPageId(node.pageId);
+
+            const liveNode = findNodeByPageId(rootNode, node.pageId);
+            if (liveNode) activateNode?.(liveNode);
         }
     };
 
@@ -541,18 +553,18 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                     </span>
                     <button
                         className="nitro-catalog-admin-add"
-                        disabled={!rootNode}
+                        disabled={!draftRootNode}
                         title="New root category"
-                        onClick={() => rootNode && createCategory(rootNode)}
+                        onClick={() => draftRootNode && createCategory(draftRootNode)}
                     >
                         <FaPlus />
                     </button>
                 </div>
                 <div className="nitro-catalog-admin-tree">
-                    {!rootNode || rootNode.children.length === 0 ? (
+                    {!draftRootNode || draftRootNode.children.length === 0 ? (
                         <div className="nitro-catalog-admin-placeholder is-small">No categories</div>
                     ) : (
-                        rootNode.children.map((child) => renderNode(child, 0))
+                        draftRootNode.children.map((child) => renderNode(child, 0))
                     )}
                 </div>
             </div>
@@ -708,6 +720,12 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                         </span>
                     </div>
                 </div>
+                {catalogAdmin.lastError && (
+                    <div className="nitro-catalog-admin-operation-error" role="alert">
+                        <FaExclamationTriangle />
+                        <span>{catalogAdmin.lastError}</span>
+                    </div>
+                )}
                 <div className="nitro-catalog-admin-tabs">
                     {tabs.map((tab) => (
                         <button

--- a/src/components/catalog/views/admin/CatalogAdminPageEditView.test.ts
+++ b/src/components/catalog/views/admin/CatalogAdminPageEditView.test.ts
@@ -1,7 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import * as PageEditor from './CatalogAdminPageEditView';
+import { createCatalogAdminPageDetailsFromSnapshot } from './CatalogAdminPageState';
 
 describe('catalog admin page form state', () => {
+    it('uses the selected catalog node name while page details are loading', () => {
+        const resolveDisplayName = (PageEditor as any).resolveCatalogAdminPageDisplayName;
+
+        expect(resolveDisplayName('', '', 'Front Page (12)', 'front_page', 'Untitled page')).toBe('Front Page');
+    });
+
+    it('explains each blocking state instead of silently disabling save', () => {
+        const resolveInteraction = (PageEditor as any).resolveCatalogAdminPageInteraction;
+
+        expect(resolveInteraction(false, false, false, false, null)).toMatchObject({
+            canSave: false,
+            message: 'Connecting to Catalog Studio...'
+        });
+        expect(resolveInteraction(true, false, false, false, null)).toMatchObject({
+            canSave: false,
+            message: 'Loading page details...'
+        });
+        expect(resolveInteraction(true, true, false, false, null)).toMatchObject({
+            canSave: false,
+            message: 'Waiting for the edit lock...'
+        });
+        expect(resolveInteraction(true, true, true, false, null)).toMatchObject({
+            canSave: true,
+            message: null
+        });
+        expect(resolveInteraction(true, true, true, false, 'Lock denied')).toMatchObject({
+            canSave: false,
+            message: 'Lock denied'
+        });
+    });
+
+    it('maps the complete Catalog Studio page snapshot into editor details', () => {
+        const details = createCatalogAdminPageDetailsFromSnapshot({
+            catalogType: 'NORMAL',
+            pageId: 976,
+            parentId: -1,
+            captionSave: 'front_page',
+            caption: '[Front Page]',
+            pageLayout: 'frontpage',
+            iconColor: 2,
+            iconImage: 7,
+            minRank: 4,
+            orderNum: 3,
+            visible: true,
+            enabled: true,
+            clubOnly: false,
+            catalogMode: 'NORMAL',
+            vipOnly: false,
+            pageHeadline: 'headline',
+            pageTeaser: 'teaser',
+            pageSpecial: 'special',
+            pageText1: 'one',
+            pageText2: 'two',
+            pageTextDetails: 'details',
+            pageTextTeaser: 'teaser text',
+            roomId: 0,
+            includes: '12;13'
+        });
+
+        expect(details).toMatchObject({
+            pageId: 976,
+            caption: '[Front Page]',
+            captionSave: 'front_page',
+            layout: 'frontpage',
+            iconColor: 2,
+            iconImage: 7,
+            minRank: 4,
+            headline: 'headline',
+            textOne: 'one',
+            includes: '12;13'
+        });
+    });
+
     it('uses the authoritative database values returned for the selected page', () => {
         const createFormState = (PageEditor as any).createCatalogAdminPageFormState;
         const state = createFormState({

--- a/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
@@ -2,7 +2,8 @@ import { FC, useEffect, useState } from 'react';
 import { FaLanguage, FaSave, FaSpinner, FaTrash } from 'react-icons/fa';
 import { CatalogType, LocalizeText, localizeWithFallback } from '../../../../api';
 import { useCatalogData, useCatalogUiState, useTranslationActions, useTranslationState } from '../../../../hooks';
-import { IEditingPageDetails, IPageEditData, useCatalogAdmin } from '../../CatalogAdminContext';
+import { CATALOG_ROOT_LOCK_ID, IEditingPageDetails, IPageEditData, useCatalogAdmin } from '../../CatalogAdminContext';
+import { parseCatalogTabLabel } from '../../useCatalogWindowWidth';
 import { CatalogIconView } from '../catalog-icon/CatalogIconView';
 import { CatalogAdminModalView } from './CatalogAdminModalView';
 
@@ -60,6 +61,34 @@ const MODE_OPTIONS = [
     { value: 'BUILDER', label: 'Builder' },
     { value: 'BOTH', label: 'Both' }
 ];
+
+export const resolveCatalogAdminPageDisplayName = (
+    formCaption: string,
+    detailsCaption: string | undefined,
+    nodeLocalization: string,
+    nodePageName: string,
+    fallback: string
+) =>
+    formCaption?.trim() ||
+    detailsCaption?.trim() ||
+    parseCatalogTabLabel(nodeLocalization).name ||
+    nodePageName?.trim() ||
+    fallback;
+
+export const resolveCatalogAdminPageInteraction = (
+    sessionReady: boolean,
+    detailsReady: boolean,
+    lockReady: boolean,
+    loading: boolean,
+    error: string | null
+) => {
+    if (error) return { canSave: false, message: error };
+    if (!sessionReady) return { canSave: false, message: 'Connecting to Catalog Studio...' };
+    if (!detailsReady) return { canSave: false, message: 'Loading page details...' };
+    if (!lockReady) return { canSave: false, message: 'Waiting for the edit lock...' };
+    if (loading) return { canSave: false, message: 'Saving page...' };
+    return { canSave: true, message: null };
+};
 
 export const createCatalogAdminPageFormState = (details: IEditingPageDetails): IPageEditData => ({
     pageId: details.pageId,
@@ -129,6 +158,10 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const creatingPage = catalogAdmin?.creatingPage ?? false;
     const requestPageDetails = catalogAdmin?.requestPageDetails;
     const loading = catalogAdmin?.loading ?? false;
+    const lastError = catalogAdmin?.lastError ?? null;
+    const studioSessionReady = catalogAdmin?.studioSessionReady ?? false;
+    const ensurePageLock = catalogAdmin?.ensurePageLock;
+    const hasPageLock = catalogAdmin?.hasPageLock;
 
     const [caption, setCaption] = useState('');
     const [captionSave, setCaptionSave] = useState('');
@@ -162,6 +195,9 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
 
     const targetPageId = targetNode?.pageId ?? currentPage?.pageId;
     const isRoot = editingRootPage;
+    const lockPageId = creatingPage
+        ? targetNode && targetNode.pageId > 0 ? targetNode.pageId : CATALOG_ROOT_LOCK_ID
+        : targetPageId;
 
     const closeForm = () => {
         catalogAdmin?.setEditingPageData(false);
@@ -226,6 +262,11 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     }, [editingPageData, creatingPage, targetNode, currentPage, currentType, targetPageId, requestPageDetails]);
 
     useEffect(() => {
+        if (!editingPageData || lockPageId == null || lockPageId < 0) return;
+        ensurePageLock?.(lockPageId);
+    }, [editingPageData, lockPageId, ensurePageLock]);
+
+    useEffect(() => {
         if (!editingPageDetails) return;
         if (targetPageId != null && editingPageDetails.pageId !== targetPageId) return;
 
@@ -257,8 +298,16 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     if (!editingPageData || !targetNode) return null;
 
     const inputClass = 'nitro-catalog-admin-input';
-    const previewName = caption || editingPageDetails?.caption || localizeWithFallback('catalog.admin.page.untitled', 'Untitled page');
+    const previewName = resolveCatalogAdminPageDisplayName(
+        caption,
+        editingPageDetails?.caption,
+        targetNode.localization,
+        targetNode.pageName,
+        localizeWithFallback('catalog.admin.page.untitled', 'Untitled page')
+    );
     const detailsReady = creatingPage || editingPageDetails?.pageId === targetPageId;
+    const lockReady = lockPageId != null && lockPageId >= 0 && (hasPageLock?.(lockPageId) ?? false);
+    const interaction = resolveCatalogAdminPageInteraction(studioSessionReady, detailsReady, lockReady, loading, lastError);
     const formData: IPageEditData = {
         pageId: creatingPage ? undefined : targetPageId,
         caption,
@@ -287,7 +336,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const validationError = detailsReady ? validateCatalogAdminPageForm(formData) : null;
 
     const handleSave = async () => {
-        if (!catalogAdmin?.savePage || !catalogAdmin.createPage || !detailsReady) return;
+        if (!catalogAdmin?.savePage || !catalogAdmin.createPage || !interaction.canSave) return;
         if (validationError) return;
 
         if (creatingPage) catalogAdmin.createPage(formData);
@@ -619,7 +668,12 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                     </div>
 
                     <div className="nitro-catalog-admin-form-actions">
-                        {validationError && <span className="nitro-catalog-admin-translate-error">{validationError}</span>}
+                        {(validationError || lastError) && (
+                            <span className="nitro-catalog-admin-translate-error">{validationError || lastError}</span>
+                        )}
+                        {!validationError && !lastError && interaction.message && (
+                            <span className="nitro-catalog-admin-form-status">{interaction.message}</span>
+                        )}
                         {!isRoot && !creatingPage ? (
                             <button className="nitro-catalog-admin-button is-danger" onClick={handleDelete}>
                                 <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
@@ -627,7 +681,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                         ) : (
                             <div />
                         )}
-                        <button className="nitro-catalog-admin-button is-primary" disabled={loading || !detailsReady || !!validationError} onClick={handleSave}>
+                        <button className="nitro-catalog-admin-button is-primary" disabled={!interaction.canSave || !!validationError} onClick={handleSave}>
                             {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
                             {creatingPage ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
                         </button>

--- a/src/components/catalog/views/admin/CatalogAdminPageState.ts
+++ b/src/components/catalog/views/admin/CatalogAdminPageState.ts
@@ -1,0 +1,27 @@
+import type { CatalogStudioPageSnapshot } from '../../admin/studio/CatalogStudioTypes';
+
+export const createCatalogAdminPageDetailsFromSnapshot = (snapshot: CatalogStudioPageSnapshot) => ({
+    pageId: snapshot.pageId,
+    caption: snapshot.caption,
+    captionSave: snapshot.captionSave,
+    parentId: snapshot.parentId,
+    catalogMode: snapshot.catalogMode,
+    layout: snapshot.pageLayout,
+    iconColor: snapshot.iconColor,
+    iconImage: snapshot.iconImage,
+    minRank: snapshot.minRank,
+    orderNum: snapshot.orderNum,
+    visible: snapshot.visible,
+    enabled: snapshot.enabled,
+    clubOnly: snapshot.clubOnly,
+    vipOnly: snapshot.vipOnly,
+    headline: snapshot.pageHeadline,
+    teaser: snapshot.pageTeaser,
+    special: snapshot.pageSpecial,
+    textOne: snapshot.pageText1,
+    textTwo: snapshot.pageText2,
+    textDetails: snapshot.pageTextDetails,
+    textTeaser: snapshot.pageTextTeaser,
+    roomId: snapshot.roomId,
+    includes: snapshot.includes
+});

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -2186,13 +2186,229 @@
 
 /* ============================================================================
    Catalog Admin Editor window
-   Tabbed management console (Pages / Offers / Publish) that lives in its own
+   Shared draft command center that lives in its own
    draggable window, so the main catalog chrome stays identical in browse and
    admin mode (the tab strip no longer carries admin controls).
    ============================================================================ */
 .nitro-catalog-admin-manager {
-    width: 760px;
+    width: 880px;
     max-width: calc(100vw - 16px);
+    color: #263842;
+    font-family: Ubuntu, Arial, sans-serif;
+    font-size: 11px;
+}
+
+.nitro-catalog-admin-manager button,
+.nitro-catalog-admin-manager input,
+.nitro-catalog-admin-manager select {
+    font-family: Ubuntu, Arial, sans-serif;
+}
+
+.nitro-catalog-admin-preview-persona,
+.nitro-catalog-admin-bulk-grid,
+.nitro-catalog-admin-import-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin: 8px 0;
+    padding: 7px 8px;
+    border: 1px solid #a8b5bd;
+    border-radius: 5px;
+    background: linear-gradient(180deg, #edf3f6 0%, #dce7ed 100%);
+}
+
+.nitro-catalog-admin-preview-persona label,
+.nitro-catalog-admin-bulk-grid label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 25px;
+    margin: 0;
+    color: #3b505c;
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-preview-persona input[type="number"],
+.nitro-catalog-admin-bulk-grid input:not([type="checkbox"]),
+.nitro-catalog-admin-bulk-grid select,
+.nitro-catalog-admin-import-toolbar select {
+    height: 25px;
+    min-width: 74px;
+    padding: 2px 7px;
+    border: 1px solid #8499a5;
+    border-radius: 4px;
+    outline: 0;
+    background: #f9fbfc;
+    color: #203844;
+    font: 700 10px Ubuntu, Arial, sans-serif;
+}
+
+.nitro-catalog-admin-preview-persona input:focus,
+.nitro-catalog-admin-bulk-grid input:focus,
+.nitro-catalog-admin-bulk-grid select:focus,
+.nitro-catalog-admin-import-toolbar select:focus,
+.nitro-catalog-admin-import-export textarea:focus {
+    border-color: #3e83b5;
+    box-shadow: 0 0 0 2px rgba(62, 131, 181, .18);
+}
+
+.nitro-catalog-admin-preview-persona input[type="checkbox"],
+.nitro-catalog-admin-bulk-grid input[type="checkbox"] {
+    width: 13px;
+    height: 13px;
+    margin: 0;
+    accent-color: #438ec0;
+}
+
+.nitro-catalog-admin-preview-pages {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(205px, 1fr));
+    gap: 6px;
+    max-height: 355px;
+    padding-right: 3px;
+    overflow: auto;
+}
+
+.nitro-catalog-admin-preview-page,
+.nitro-catalog-admin-preview-offer {
+    border: 1px solid #aab8c0;
+    border-radius: 5px;
+    padding: 6px 7px;
+    background: #f8fafb;
+}
+
+.nitro-catalog-admin-preview-page header,
+.nitro-catalog-admin-preview-offer {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.nitro-catalog-admin-preview-page header strong,
+.nitro-catalog-admin-preview-offer strong {
+    color: #223b48;
+    font-size: 10px;
+    line-height: 1.25;
+}
+
+.nitro-catalog-admin-preview-page header span,
+.nitro-catalog-admin-preview-offer span,
+.nitro-catalog-admin-preview-offer small {
+    color: #647985;
+    font-size: 9px;
+    line-height: 1.3;
+}
+
+.nitro-catalog-admin-preview-offers {
+    display: grid;
+    gap: 4px;
+    margin-top: 6px;
+}
+
+.nitro-catalog-admin-preview-offer.is-eligible {
+    border-left: 3px solid #4a9b63;
+}
+
+.nitro-catalog-admin-preview-offer.is-blocked {
+    border-left: 3px solid #bd574f;
+    background: #fbefee;
+}
+
+.nitro-catalog-admin-preview-offer.is-blocked small {
+    color: #a33d36;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-bulk,
+.nitro-catalog-admin-studio-preview,
+.nitro-catalog-admin-import-export {
+    height: 100%;
+    min-height: 0;
+    color: #263842;
+}
+
+.nitro-catalog-admin-import-export textarea {
+    width: 100%;
+    min-height: 292px;
+    padding: 8px 9px;
+    border: 1px solid #8499a5;
+    border-radius: 5px;
+    outline: 0;
+    background: #f8fafb;
+    color: #243945;
+    resize: vertical;
+    font: 11px/1.45 Consolas, "Courier New", monospace;
+    tab-size: 2;
+}
+
+.nitro-catalog-admin-command-bar {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 9px 10px;
+    border-bottom: 1px solid #4b5964;
+    background: linear-gradient(180deg, #354957 0%, #273845 100%);
+    color: #f7fbff;
+}
+
+.nitro-catalog-admin-command-title {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    line-height: 1.15;
+}
+
+.nitro-catalog-admin-command-title strong {
+    font-size: 12px;
+}
+
+.nitro-catalog-admin-command-title span {
+    color: #bcd0de;
+    font-size: 9px;
+}
+
+.nitro-catalog-admin-command-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    justify-content: flex-end;
+}
+
+.nitro-catalog-admin-command-stats > span {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    min-height: 21px;
+    padding: 2px 7px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.18);
+    color: #e7f1f7;
+    font-size: 9px;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-command-stats > span.has-pending {
+    border-color: #e6ad43;
+    color: #ffe29a;
+}
+
+.nitro-catalog-admin-command-stats > span.has-error {
+    border-color: #db7068;
+    color: #ffc1bc;
+}
+
+.nitro-catalog-admin-command-stats > span.is-valid {
+    border-color: #64b77b;
+    color: #b9edc7;
+}
+
+.nitro-catalog-admin-command-stats svg {
+    width: 9px;
+    height: 9px;
 }
 
 .nitro-catalog-admin-manager-body {
@@ -2333,6 +2549,87 @@
     box-shadow: 0 0 0 2px rgba(240, 163, 24, 0.5);
 }
 
+.nitro-catalog-admin-btn.is-small {
+    height: 23px;
+    padding: 0 8px;
+    font-size: 9px;
+}
+
+/* ---- Activity tab ---- */
+.nitro-catalog-admin-activity {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    height: 100%;
+    min-height: 0;
+}
+
+.nitro-catalog-admin-section-head {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border: 1px solid #aaa9a0;
+    border-radius: 5px;
+    background: #f7f7f2;
+}
+
+.nitro-catalog-admin-section-head > div,
+.nitro-catalog-admin-history-main,
+.nitro-catalog-admin-version-row > div,
+.nitro-catalog-admin-validation-row > div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.nitro-catalog-admin-section-head strong,
+.nitro-catalog-admin-history-summary,
+.nitro-catalog-admin-version-row strong,
+.nitro-catalog-admin-validation-row strong {
+    color: #252521;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-section-head span,
+.nitro-catalog-admin-history-meta,
+.nitro-catalog-admin-version-row span,
+.nitro-catalog-admin-validation-row span,
+.nitro-catalog-admin-history-side > span {
+    color: #75756e;
+    font-size: 9px;
+}
+
+.nitro-catalog-admin-history-list {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 5px;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.nitro-catalog-admin-history-row,
+.nitro-catalog-admin-version-row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border: 1px solid #b7b7ae;
+    border-radius: 5px;
+    background: #fff;
+}
+
+.nitro-catalog-admin-history-side {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 8px;
+    align-items: center;
+}
+
 /* Empty / placeholder states */
 .nitro-catalog-admin-placeholder {
     display: flex;
@@ -2354,7 +2651,8 @@
 /* ---- Pages tab: sidebar tree + detail pane ---- */
 .nitro-catalog-admin-pages {
     display: grid;
-    grid-template-columns: 240px 1fr;
+    grid-template-columns: 220px minmax(0, 1fr) 190px;
+    grid-template-rows: minmax(0, 1fr) 82px;
     gap: 8px;
     height: 100%;
     min-height: 0;
@@ -2863,9 +3161,197 @@
     font-weight: 700;
 }
 
-.nitro-catalog-admin-publish-status.has-pending {
+.nitro-catalog-admin-publish-status.is-draft {
     background: rgba(240, 163, 24, 0.18);
     color: #8a5b00;
+}
+
+.nitro-catalog-admin-inspector {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+    min-height: 0;
+    padding: 9px;
+    border: 1px solid #b7b7ae;
+    border-radius: 4px;
+    background: #f7f7f2;
+    overflow-y: auto;
+}
+
+.nitro-catalog-admin-inspector-head {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #d0d0c8;
+}
+
+.nitro-catalog-admin-inspector-head strong {
+    color: #252521;
+    font-size: 12px;
+}
+
+.nitro-catalog-admin-inspector-head span {
+    color: #77776f;
+    font-size: 9px;
+}
+
+.nitro-catalog-admin-inspector-data {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    margin: 0;
+}
+
+.nitro-catalog-admin-inspector-data > div {
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    padding: 3px 0;
+    border-bottom: 1px dotted #d0d0c8;
+}
+
+.nitro-catalog-admin-inspector-data dt,
+.nitro-catalog-admin-inspector-data dd {
+    margin: 0;
+    font-size: 9px;
+}
+
+.nitro-catalog-admin-inspector-data dt {
+    color: #77776f;
+}
+
+.nitro-catalog-admin-inspector-data dd {
+    min-width: 0;
+    overflow: hidden;
+    color: #252521;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nitro-catalog-admin-lock-state {
+    display: flex;
+    gap: 6px;
+    align-items: flex-start;
+    padding: 6px;
+    border: 1px solid #c6a55c;
+    border-radius: 4px;
+    background: #fff7df;
+    color: #77550e;
+}
+
+.nitro-catalog-admin-lock-state.is-owned {
+    border-color: #76aa82;
+    background: #edf8ef;
+    color: #2c6e3b;
+}
+
+.nitro-catalog-admin-lock-state > div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.nitro-catalog-admin-lock-state strong,
+.nitro-catalog-admin-lock-state span {
+    font-size: 8px;
+    line-height: 1.3;
+}
+
+.nitro-catalog-admin-inspector-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 5px;
+    margin-top: auto;
+}
+
+.nitro-catalog-admin-inspector-actions .nitro-catalog-admin-btn {
+    justify-content: flex-start;
+    width: 100%;
+}
+
+.nitro-catalog-admin-changes-drawer {
+    display: flex;
+    grid-column: 1 / -1;
+    gap: 8px;
+    align-items: center;
+    min-width: 0;
+    padding: 7px 9px;
+    border: 1px solid #9da9b1;
+    border-radius: 4px;
+    background: linear-gradient(180deg, #eef4f7 0%, #dce7ed 100%);
+}
+
+.nitro-catalog-admin-changes-title {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 6px;
+    align-items: center;
+}
+
+.nitro-catalog-admin-changes-title > div {
+    display: flex;
+    flex-direction: column;
+}
+
+.nitro-catalog-admin-changes-title strong {
+    color: #273845;
+    font-size: 10px;
+}
+
+.nitro-catalog-admin-changes-title span {
+    color: #60737f;
+    font-size: 8px;
+}
+
+.nitro-catalog-admin-changes-feed {
+    display: flex;
+    flex: 1 1 auto;
+    gap: 5px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.nitro-catalog-admin-changes-feed > button {
+    display: flex;
+    flex: 1 1 0;
+    flex-direction: column;
+    min-width: 0;
+    padding: 5px 7px;
+    border: 1px solid rgba(58, 84, 99, 0.22);
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.7);
+    text-align: left;
+}
+
+.nitro-catalog-admin-changes-feed > button strong,
+.nitro-catalog-admin-changes-feed > button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nitro-catalog-admin-changes-feed > button strong {
+    color: #273845;
+    font-size: 8px;
+}
+
+.nitro-catalog-admin-changes-feed > button span,
+.nitro-catalog-admin-changes-feed > span {
+    color: #697a85;
+    font-size: 8px;
+}
+
+.nitro-catalog-admin-publish-status.is-blocked,
+.nitro-catalog-admin-publish-status.is-offline {
+    background: rgba(184, 59, 50, 0.14);
+    color: #98342d;
+}
+
+.nitro-catalog-admin-publish-status.is-ready {
+    background: rgba(31, 111, 46, 0.16);
+    color: #1f6f2e;
 }
 
 .nitro-catalog-admin-publish-text {
@@ -2940,7 +3426,33 @@
     display: flex;
     flex: 0 0 auto;
     justify-content: center;
+    gap: 8px;
     padding-top: 4px;
+}
+
+.nitro-catalog-admin-validation-list,
+.nitro-catalog-admin-versions {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.nitro-catalog-admin-validation-row {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 7px 9px;
+    border: 1px solid #d9a39f;
+    border-radius: 4px;
+    background: #fff3f2;
+}
+
+.nitro-catalog-admin-validation-row > svg {
+    flex: 0 0 auto;
+    margin-top: 2px;
+    color: #b83b32;
 }
 
 /* Scrollbars for the console scroll areas (the window isn't .nitro-catalog-window,
@@ -2948,7 +3460,10 @@
 .nitro-catalog-admin-tree,
 .nitro-catalog-admin-offers-list,
 .nitro-catalog-admin-detail,
-.nitro-catalog-admin-publish-changes-list {
+.nitro-catalog-admin-publish-changes-list,
+.nitro-catalog-admin-history-list,
+.nitro-catalog-admin-validation-list,
+.nitro-catalog-admin-versions {
     scrollbar-width: thin;
     scrollbar-color: #a9b4bd #e7e7df;
 }
@@ -2956,7 +3471,10 @@
 .nitro-catalog-admin-tree::-webkit-scrollbar,
 .nitro-catalog-admin-offers-list::-webkit-scrollbar,
 .nitro-catalog-admin-detail::-webkit-scrollbar,
-.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar {
+.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar,
+.nitro-catalog-admin-history-list::-webkit-scrollbar,
+.nitro-catalog-admin-validation-list::-webkit-scrollbar,
+.nitro-catalog-admin-versions::-webkit-scrollbar {
     width: 12px;
     height: 12px;
 }
@@ -2964,7 +3482,10 @@
 .nitro-catalog-admin-tree::-webkit-scrollbar-track,
 .nitro-catalog-admin-offers-list::-webkit-scrollbar-track,
 .nitro-catalog-admin-detail::-webkit-scrollbar-track,
-.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-track {
+.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-track,
+.nitro-catalog-admin-history-list::-webkit-scrollbar-track,
+.nitro-catalog-admin-validation-list::-webkit-scrollbar-track,
+.nitro-catalog-admin-versions::-webkit-scrollbar-track {
     background: #e7e7df;
     border-radius: 6px;
 }
@@ -2972,7 +3493,10 @@
 .nitro-catalog-admin-tree::-webkit-scrollbar-thumb,
 .nitro-catalog-admin-offers-list::-webkit-scrollbar-thumb,
 .nitro-catalog-admin-detail::-webkit-scrollbar-thumb,
-.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-thumb {
+.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-thumb,
+.nitro-catalog-admin-history-list::-webkit-scrollbar-thumb,
+.nitro-catalog-admin-validation-list::-webkit-scrollbar-thumb,
+.nitro-catalog-admin-versions::-webkit-scrollbar-thumb {
     border: 3px solid #e7e7df;
     border-radius: 6px;
     background: #a9b4bd;
@@ -2981,6 +3505,9 @@
 .nitro-catalog-admin-tree::-webkit-scrollbar-thumb:hover,
 .nitro-catalog-admin-offers-list::-webkit-scrollbar-thumb:hover,
 .nitro-catalog-admin-detail::-webkit-scrollbar-thumb:hover,
-.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-thumb:hover {
+.nitro-catalog-admin-publish-changes-list::-webkit-scrollbar-thumb:hover,
+.nitro-catalog-admin-history-list::-webkit-scrollbar-thumb:hover,
+.nitro-catalog-admin-validation-list::-webkit-scrollbar-thumb:hover,
+.nitro-catalog-admin-versions::-webkit-scrollbar-thumb:hover {
     background: #8fa0ac;
 }

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -2486,6 +2486,24 @@
     background: var(--catalog-swf-bg, #d7d7cf) !important;
 }
 
+.nitro-catalog-admin-operation-error {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 30px;
+    padding: 6px 10px;
+    border-bottom: 1px solid #b85b54;
+    background: #f8d9d5;
+    color: #762c27;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-operation-error svg {
+    flex: 0 0 auto;
+    color: #b64038;
+}
+
 /* Tab strip under the header */
 .nitro-catalog-admin-tabs {
     display: flex;

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -556,6 +556,11 @@
     font-size: 9px;
 }
 
+.nitro-catalog-admin-form-status {
+    color: var(--catalog-admin-muted);
+    font-size: 9px;
+}
+
 /* Legacy preview card rules kept for specificity elsewhere */
 .nitro-catalog-admin-offer-preview-card {
     border: none;
@@ -2345,70 +2350,132 @@
 
 .nitro-catalog-admin-command-bar {
     display: flex;
-    gap: 12px;
+    gap: 16px;
     align-items: center;
     justify-content: space-between;
-    padding: 9px 10px;
-    border-bottom: 1px solid #4b5964;
-    background: linear-gradient(180deg, #354957 0%, #273845 100%);
-    color: #f7fbff;
+    min-height: 54px;
+    padding: 10px 12px;
+    border-bottom: 1px solid #9eafb8;
+    background: linear-gradient(180deg, #f4f8fa 0%, #dce8ed 100%);
+    color: #203b49;
+    box-shadow: inset 4px 0 0 #7e949f, inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.nitro-catalog-admin-command-bar.is-draft {
+    box-shadow: inset 4px 0 0 #d99a24, inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.nitro-catalog-admin-command-bar.is-blocked {
+    box-shadow: inset 4px 0 0 #bd5149, inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.nitro-catalog-admin-command-bar.is-clean,
+.nitro-catalog-admin-command-bar.is-ready {
+    box-shadow: inset 4px 0 0 #4f9a67, inset 0 1px 0 rgba(255, 255, 255, 0.85);
 }
 
 .nitro-catalog-admin-command-title {
     display: flex;
     flex: 0 0 auto;
     flex-direction: column;
-    line-height: 1.15;
+    gap: 2px;
+    line-height: 1.2;
 }
 
 .nitro-catalog-admin-command-title strong {
-    font-size: 12px;
+    color: #183541;
+    font-size: 15px;
+    font-weight: 800;
+    letter-spacing: 0.1px;
 }
 
 .nitro-catalog-admin-command-title span {
-    color: #bcd0de;
-    font-size: 9px;
+    color: #617985;
+    font-size: 10px;
+    font-weight: 600;
 }
 
 .nitro-catalog-admin-command-stats {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px;
+    gap: 6px;
     justify-content: flex-end;
 }
 
 .nitro-catalog-admin-command-stats > span {
     display: inline-flex;
-    gap: 4px;
+    gap: 5px;
     align-items: center;
-    min-height: 21px;
-    padding: 2px 7px;
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    border-radius: 10px;
-    background: rgba(0, 0, 0, 0.18);
-    color: #e7f1f7;
-    font-size: 9px;
+    min-height: 27px;
+    padding: 4px 9px;
+    border: 1px solid #adbec7;
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.82);
+    color: #38515e;
+    font-size: 10px;
     font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 1px 1px rgba(36, 62, 75, 0.08), inset 0 1px 0 #ffffff;
+}
+
+.nitro-catalog-admin-command-stats > span.is-revision {
+    border-color: #a9bac3;
+    background: #edf3f6;
+}
+
+.nitro-catalog-admin-command-stats > span.is-actors {
+    border-color: #8fb8d1;
+    background: #e8f4fa;
+    color: #285e7b;
+}
+
+.nitro-catalog-admin-command-stats > span.is-locks {
+    border-color: #aa9bc8;
+    background: #f1edf8;
+    color: #59477d;
 }
 
 .nitro-catalog-admin-command-stats > span.has-pending {
-    border-color: #e6ad43;
-    color: #ffe29a;
+    border-color: #d9a13a;
+    background: #fff3d5;
+    color: #775000;
 }
 
 .nitro-catalog-admin-command-stats > span.has-error {
-    border-color: #db7068;
-    color: #ffc1bc;
+    border-color: #d46d65;
+    background: #fde9e7;
+    color: #8c302a;
+}
+
+.nitro-catalog-admin-command-stats > span.has-warning {
+    border-color: #d6a648;
+    background: #fff6dc;
+    color: #775500;
 }
 
 .nitro-catalog-admin-command-stats > span.is-valid {
-    border-color: #64b77b;
-    color: #b9edc7;
+    border-color: #74b487;
+    background: #e9f6ed;
+    color: #2f7043;
 }
 
 .nitro-catalog-admin-command-stats svg {
-    width: 9px;
-    height: 9px;
+    width: 10px;
+    height: 10px;
+    flex: 0 0 auto;
+    fill: currentColor;
+}
+
+@media (max-width: 760px) {
+    .nitro-catalog-admin-command-bar {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .nitro-catalog-admin-command-stats {
+        justify-content: flex-start;
+    }
 }
 
 .nitro-catalog-admin-manager-body {
@@ -2651,7 +2718,7 @@
 /* ---- Pages tab: sidebar tree + detail pane ---- */
 .nitro-catalog-admin-pages {
     display: grid;
-    grid-template-columns: 220px minmax(0, 1fr) 190px;
+    grid-template-columns: 225px minmax(0, 1fr) 220px;
     grid-template-rows: minmax(0, 1fr) 82px;
     gap: 8px;
     height: 100%;
@@ -3169,82 +3236,119 @@
 .nitro-catalog-admin-inspector {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 10px;
     min-width: 0;
     min-height: 0;
-    padding: 9px;
-    border: 1px solid #b7b7ae;
-    border-radius: 4px;
-    background: #f7f7f2;
+    padding: 10px;
+    border: 1px solid #9fafb8;
+    border-radius: 7px;
+    background: linear-gradient(180deg, #f7fafb 0%, #eaf1f4 100%);
+    box-shadow: inset 0 1px 0 #ffffff, 0 1px 2px rgba(36, 62, 75, 0.08);
     overflow-y: auto;
 }
 
 .nitro-catalog-admin-inspector-head {
     display: flex;
-    flex-direction: column;
-    padding-bottom: 6px;
-    border-bottom: 1px solid #d0d0c8;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #bdcbd2;
 }
 
 .nitro-catalog-admin-inspector-head strong {
-    color: #252521;
-    font-size: 12px;
+    color: #1d3a47;
+    font-size: 14px;
+    font-weight: 800;
 }
 
 .nitro-catalog-admin-inspector-head span {
-    color: #77776f;
+    padding: 3px 7px;
+    border: 1px solid #aabcc5;
+    border-radius: 7px;
+    background: #ffffff;
+    color: #55707d;
     font-size: 9px;
+    font-weight: 700;
 }
 
 .nitro-catalog-admin-inspector-data {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 0;
     margin: 0;
+    overflow: hidden;
+    border: 1px solid #c5d0d5;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.78);
 }
 
 .nitro-catalog-admin-inspector-data > div {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(70px, 0.8fr) minmax(0, 1.2fr);
     gap: 8px;
-    justify-content: space-between;
-    padding: 3px 0;
-    border-bottom: 1px dotted #d0d0c8;
+    align-items: center;
+    min-height: 30px;
+    padding: 5px 8px;
+    border-bottom: 1px solid #dce4e8;
+}
+
+.nitro-catalog-admin-inspector-data > div:last-child {
+    border-bottom: 0;
 }
 
 .nitro-catalog-admin-inspector-data dt,
 .nitro-catalog-admin-inspector-data dd {
     margin: 0;
-    font-size: 9px;
+    font-size: 10px;
 }
 
 .nitro-catalog-admin-inspector-data dt {
-    color: #77776f;
+    color: #657b86;
+    font-weight: 600;
 }
 
 .nitro-catalog-admin-inspector-data dd {
     min-width: 0;
     overflow: hidden;
-    color: #252521;
+    color: #203b49;
     font-weight: 700;
+    text-align: right;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
+.nitro-catalog-admin-inspector-data dd.is-positive {
+    color: #2f7043;
+}
+
+.nitro-catalog-admin-inspector-data dd.is-muted {
+    color: #9a4b43;
+}
+
 .nitro-catalog-admin-lock-state {
     display: flex;
-    gap: 6px;
+    gap: 8px;
     align-items: flex-start;
-    padding: 6px;
-    border: 1px solid #c6a55c;
-    border-radius: 4px;
-    background: #fff7df;
-    color: #77550e;
+    padding: 8px 9px;
+    border: 1px solid #d3a54b;
+    border-radius: 6px;
+    background: linear-gradient(180deg, #fff8e5 0%, #ffefc7 100%);
+    color: #765000;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .nitro-catalog-admin-lock-state.is-owned {
-    border-color: #76aa82;
-    background: #edf8ef;
+    border-color: #74ad83;
+    background: linear-gradient(180deg, #f1faf3 0%, #dff1e4 100%);
     color: #2c6e3b;
+}
+
+.nitro-catalog-admin-lock-state > svg {
+    width: 12px;
+    height: 12px;
+    margin-top: 1px;
+    flex: 0 0 auto;
+    fill: currentColor;
 }
 
 .nitro-catalog-admin-lock-state > div {
@@ -3255,20 +3359,29 @@
 
 .nitro-catalog-admin-lock-state strong,
 .nitro-catalog-admin-lock-state span {
-    font-size: 8px;
-    line-height: 1.3;
+    font-size: 9px;
+    line-height: 1.35;
+}
+
+.nitro-catalog-admin-lock-state strong {
+    font-size: 10px;
+    font-weight: 800;
 }
 
 .nitro-catalog-admin-inspector-actions {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 5px;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
     margin-top: auto;
 }
 
 .nitro-catalog-admin-inspector-actions .nitro-catalog-admin-btn {
-    justify-content: flex-start;
+    justify-content: center;
     width: 100%;
+}
+
+.nitro-catalog-admin-inspector-actions .nitro-catalog-admin-btn:first-child {
+    grid-column: 1 / -1;
 }
 
 .nitro-catalog-admin-changes-drawer {

--- a/src/nitro-renderer.mock.ts
+++ b/src/nitro-renderer.mock.ts
@@ -392,6 +392,42 @@ export class GroupJoinComposer extends StubClass {}
 export class GroupUnfavoriteComposer extends StubClass {}
 export class UserProfileComposer extends StubClass {}
 
+// Catalog Studio — keep request arguments observable so provider tests can
+// verify the renderer/emulator field order without loading Pixi.
+class CatalogStudioComposerStub {
+    private readonly data: unknown[];
+    constructor(...args: unknown[]) { this.data = args; }
+    public getMessageArray() { return this.data; }
+}
+
+export class CatalogStudioOpenSessionComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioAcquireLockComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioRenewLockComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioReleaseLockComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioHistoryComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioUndoComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioValidateComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioPublishComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioDiscardComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioRestoreComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioPreviewComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioExportComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioDocumentDryRunComposer extends CatalogStudioComposerStub {}
+export class CatalogStudioDocumentApplyComposer extends CatalogStudioComposerStub {}
+
+export class CatalogStudioSessionEvent extends MessageEvent {}
+export class CatalogStudioAcquireLockEvent extends MessageEvent {}
+export class CatalogStudioRenewLockEvent extends MessageEvent {}
+export class CatalogStudioReleaseLockEvent extends MessageEvent {}
+export class CatalogStudioHistoryEvent extends MessageEvent {}
+export class CatalogStudioUndoEvent extends MessageEvent {}
+export class CatalogStudioValidationEvent extends MessageEvent {}
+export class CatalogStudioPublishEvent extends MessageEvent {}
+export class CatalogStudioDiscardEvent extends MessageEvent {}
+export class CatalogStudioRestoreEvent extends MessageEvent {}
+export class CatalogStudioPreviewEvent extends MessageEvent {}
+export class CatalogStudioDocumentResultEvent extends MessageEvent {}
+
 // `ChooserSelectionFilter` is used as a string enum in some call sites.
 export const ChooserSelectionFilter = makeEnumProxy('ChooserSelectionFilter');
 

--- a/src/nitro-renderer.mock.ts
+++ b/src/nitro-renderer.mock.ts
@@ -414,6 +414,10 @@ export class CatalogStudioPreviewComposer extends CatalogStudioComposerStub {}
 export class CatalogStudioExportComposer extends CatalogStudioComposerStub {}
 export class CatalogStudioDocumentDryRunComposer extends CatalogStudioComposerStub {}
 export class CatalogStudioDocumentApplyComposer extends CatalogStudioComposerStub {}
+export class CatalogAdminDeletePageComposer extends CatalogStudioComposerStub {}
+export class CatalogAdminMovePageComposer extends CatalogStudioComposerStub {}
+export class CatalogAdminSetPageEnabledComposer extends CatalogStudioComposerStub {}
+export class CatalogAdminSetPageVisibleComposer extends CatalogStudioComposerStub {}
 
 export class CatalogStudioSessionEvent extends MessageEvent {}
 export class CatalogStudioAcquireLockEvent extends MessageEvent {}


### PR DESCRIPTION
## Summary
- add the Catalog Studio command center with session, validation, history, preview, and publication controls
- add bulk dry-run/apply and JSONC/SQL import/export panels
- support NORMAL and BUILDER catalog locks without splitting permissions
- restore complete page loading and saving from the authoritative shared-draft snapshot
- queue move, delete, enabled, and visibility mutations until the required page lock is available
- render the page tree from the shared draft so reorders, reparenting, new pages, and visibility changes appear immediately
- expose server and lock failures in the manager instead of silently discarding actions
- polish the command bar and Inspector with a brighter semantic palette, larger typography, clearer spacing, and responsive status badges

## Verification
- `yarn test` (123 files, 797 tests)
- `yarn biome lint` on all changed UI, state, and test files
- `yarn typecheck`
- `yarn build`

## Companion PRs
- emulator: https://github.com/duckietm/Polaris-Emulator/pull/555
- renderer: https://github.com/duckietm/Nitro_Render_V3/pull/158