### PR TITLE
feat(catalog): add lossless Smart Save editors

### DIFF
--- a/src/components/catalog/CatalogAdminContext.test.tsx
+++ b/src/components/catalog/CatalogAdminContext.test.tsx
@@ -6,6 +6,9 @@ import { CatalogAdminProvider, useCatalogAdmin } from './CatalogAdminContext';
 
 const mocks = vi.hoisted(() => ({
     acquireLock: vi.fn(),
+    applyMutation: vi.fn(),
+    handlers: new Map<string, (event: any) => void>(),
+    loadHistory: vi.fn(),
     refresh: vi.fn(),
     sendMessage: vi.fn(),
     useCatalogStudio: vi.fn()
@@ -18,7 +21,8 @@ vi.mock('../../api', () => ({
 
 vi.mock('../../hooks', () => ({
     useCatalogUiState: () => ({ currentType: 'NORMAL' }),
-    useMessageEvent: vi.fn(),
+    useMessageEvent: (eventType: any, handler: (event: any) => void) =>
+        mocks.handlers.set(`${eventType?.name ?? 'anonymous'}-${mocks.handlers.size}`, handler),
     useNotification: () => ({ simpleAlert: null })
 }));
 
@@ -62,6 +66,19 @@ const OfferProbe = () => {
     );
 };
 
+const SaveProbe = () => {
+    const admin = useCatalogAdmin();
+    return <div>
+        <button onClick={() => admin.savePage({
+            pageId: 42, caption: 'Renamed', captionSave: 'page_42', parentId: -1, catalogMode: 'NORMAL',
+            pageLayout: 'default_3x3', iconColor: 1, iconImage: 1, enabled: '1', visible: '1', minRank: 1,
+            orderNum: 1
+        })}>save-page</button>
+        <span data-testid="mutation-id">{admin.lastMutationResult?.operationId ?? ''}</span>
+        <span data-testid="field-error">{admin.lastMutationResult?.fieldErrors.caption ?? ''}</span>
+    </div>;
+};
+
 const session = {
     activeVersionId: 11,
     draftVersionId: 12,
@@ -77,11 +94,19 @@ const session = {
     offers: []
 };
 
+const emitAdminResult = (parser: Record<string, unknown>) => {
+    const handler = Array.from(mocks.handlers.values()).at(-1);
+    act(() => handler?.({ getParser: () => parser }));
+};
+
 describe('CatalogAdminProvider page mutations', () => {
     let studio: Record<string, any>;
 
     beforeEach(() => {
         mocks.acquireLock.mockReset();
+        mocks.applyMutation.mockReset();
+        mocks.handlers.clear();
+        mocks.loadHistory.mockReset();
         mocks.refresh.mockReset();
         mocks.sendMessage.mockReset();
         studio = {
@@ -91,7 +116,8 @@ describe('CatalogAdminProvider page mutations', () => {
             lastError: null,
             acquireLock: mocks.acquireLock,
             refresh: mocks.refresh,
-            loadHistory: vi.fn(),
+            loadHistory: mocks.loadHistory,
+            applyMutation: mocks.applyMutation,
             publish: vi.fn()
         };
         mocks.useCatalogStudio.mockImplementation(() => studio);
@@ -209,5 +235,106 @@ describe('CatalogAdminProvider page mutations', () => {
         await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
         expect(mocks.sendMessage.mock.calls[0][0].constructor.name).toBe('CatalogAdminLoadOfferComposer');
         expect(screen.getByTestId('offer-name')).toHaveTextContent('studio_offer');
+    });
+
+    it('applies a correlated Smart Save result without broad refreshes', () => {
+        const dispatchEvent = vi.spyOn(window, 'dispatchEvent');
+        studio = {
+            ...studio,
+            locks: {
+                'PAGE:42': { draftVersionId: 12, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42,
+                    ownerId: 9, ownerName: 'Alice', token: 'page-token', expiresAt: '' }
+            }
+        };
+        render(<CatalogAdminProvider><SaveProbe /></CatalogAdminProvider>);
+
+        act(() => screen.getByText('save-page').click());
+        const composer = mocks.sendMessage.mock.calls[0][0];
+        const operationId = composer.getMessageArray().at(-1);
+        expect(operationId).toMatch(/^savePage-/);
+
+        const entity = {
+            catalogType: 'NORMAL', pageId: 42, parentId: -1, captionSave: 'page_42', caption: 'Renamed',
+            pageLayout: 'default_3x3', iconColor: 1, iconImage: 1, minRank: 1, orderNum: 1,
+            visible: true, enabled: true, clubOnly: false, catalogMode: 'NORMAL', vipOnly: false,
+            pageHeadline: '', pageTeaser: '', pageSpecial: '', pageText1: '', pageText2: '', pageTextDetails: '',
+            pageTextTeaser: '', roomId: 0, includes: ''
+        };
+        emitAdminResult({
+            success: true, message: 'Saved', smartSaveResult: {
+                protocolVersion: 1, operationId, action: 'savePage', code: 'SAVED', draftVersionId: 12,
+                revision: 4, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42, entity,
+                historyGroup: { id: 91, revision: 4, actorId: 9, actorName: 'Alice', summary: 'Edit page',
+                    source: 'UI', createdAt: '', entries: [ { entityType: 'PAGE', entityId: 42, operation: 'UPDATE' } ] },
+                fieldErrors: {}, serverDurationMs: 7
+            }
+        });
+
+        expect(mocks.applyMutation).toHaveBeenCalledTimes(1);
+        expect(mocks.refresh).not.toHaveBeenCalled();
+        expect(mocks.loadHistory).not.toHaveBeenCalled();
+        expect(dispatchEvent).not.toHaveBeenCalled();
+        expect(screen.getByTestId('mutation-id')).toHaveTextContent(operationId);
+        dispatchEvent.mockRestore();
+    });
+
+    it('exposes correlated field errors without clearing the editor', () => {
+        studio = {
+            ...studio,
+            locks: {
+                'PAGE:42': { draftVersionId: 12, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42,
+                    ownerId: 9, ownerName: 'Alice', token: 'page-token', expiresAt: '' }
+            }
+        };
+        render(<CatalogAdminProvider><SaveProbe /></CatalogAdminProvider>);
+        act(() => screen.getByText('save-page').click());
+        const operationId = mocks.sendMessage.mock.calls[0][0].getMessageArray().at(-1);
+
+        emitAdminResult({
+            success: false, message: 'Page caption is required', smartSaveResult: {
+                protocolVersion: 1, operationId, action: 'savePage', code: 'VALIDATION_FAILED', draftVersionId: 12,
+                revision: 3, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42, entity: null,
+                historyGroup: null, fieldErrors: { caption: 'Page caption is required' }, serverDurationMs: 2
+            }
+        });
+
+        expect(screen.getByTestId('field-error')).toHaveTextContent('Page caption is required');
+        expect(mocks.applyMutation).not.toHaveBeenCalled();
+        expect(mocks.refresh).not.toHaveBeenCalled();
+    });
+
+    it('retains broad refresh behavior for a legacy two-field result', () => {
+        studio = {
+            ...studio,
+            locks: {
+                'PAGE:42': { draftVersionId: 12, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42,
+                    ownerId: 9, ownerName: 'Alice', token: 'page-token', expiresAt: '' }
+            }
+        };
+        render(<CatalogAdminProvider><SaveProbe /></CatalogAdminProvider>);
+        act(() => screen.getByText('save-page').click());
+        emitAdminResult({
+            success: true, message: 'Saved', smartSaveResult: null
+        });
+
+        expect(mocks.refresh).toHaveBeenCalledTimes(1);
+        expect(mocks.loadHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps public catalog refreshes for a legacy delete result', () => {
+        const dispatchEvent = vi.spyOn(window, 'dispatchEvent');
+        studio = {
+            ...studio,
+            locks: {
+                'PAGE:42': { draftVersionId: 12, entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42,
+                    ownerId: 9, ownerName: 'Alice', token: 'token-42', expiresAt: '' }
+            }
+        };
+        render(<CatalogAdminProvider><Probe action="delete" /></CatalogAdminProvider>);
+        act(() => screen.getByText('delete').click());
+        emitAdminResult({ success: true, message: 'Deleted', smartSaveResult: null });
+
+        expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'catalog-admin-refresh-index' }));
+        dispatchEvent.mockRestore();
     });
 });

--- a/src/components/catalog/CatalogAdminContext.tsx
+++ b/src/components/catalog/CatalogAdminContext.tsx
@@ -19,6 +19,8 @@ import { createContext, FC, ReactNode, useCallback, useContext, useEffect, useRe
 import { ICatalogNode, IPurchasableOffer, NotificationAlertType, SendMessageComposer } from '../../api';
 import { useCatalogUiState, useMessageEvent, useNotification } from '../../hooks';
 import { useCatalogStudio } from './admin/studio/useCatalogStudio';
+import { nextCatalogStudioOperationId } from './admin/studio/CatalogStudioOperationId';
+import { CatalogStudioHistoryGroup, CatalogStudioOfferSnapshot, CatalogStudioPageSnapshot } from './admin/studio/CatalogStudioTypes';
 import { createCatalogAdminPageDetailsFromSnapshot } from './views/admin/CatalogAdminPageState';
 
 const toStudioCatalogType = (catalogType: string): 'NORMAL' | 'BUILDER' =>
@@ -119,6 +121,23 @@ export interface IEditingPageDetails {
     includes: string;
 }
 
+type CatalogAdminMutationAction = 'createPage' | 'savePage' | 'createOffer' | 'saveOffer';
+
+export interface CatalogAdminMutationResult {
+    operationId: string;
+    action: CatalogAdminMutationAction;
+    success: boolean;
+    code: string;
+    message: string;
+    entityType: 'PAGE' | 'OFFER';
+    catalogType: 'NORMAL' | 'BUILDER';
+    entityId: number;
+    entity: CatalogStudioPageSnapshot | CatalogStudioOfferSnapshot | null;
+    historyGroup: CatalogStudioHistoryGroup | null;
+    fieldErrors: Record<string, string>;
+    acknowledgedAt: number;
+}
+
 interface ICatalogAdminContext {
     adminMode: boolean;
     setAdminMode: (value: boolean) => void;
@@ -137,14 +156,17 @@ interface ICatalogAdminContext {
     setCreatingPage: (value: boolean) => void;
     loading: boolean;
     lastError: string | null;
+    lastMutationResult: CatalogAdminMutationResult | null;
     studioSessionReady: boolean;
     ensurePageLock: (pageId: number) => void;
     hasPageLock: (pageId: number) => boolean;
-    savePage: (data: IPageEditData) => void;
-    createPage: (data: IPageEditData) => void;
+    ensureOfferLock: (offerId: number) => void;
+    hasOfferLock: (offerId: number) => boolean;
+    savePage: (data: IPageEditData) => string | null;
+    createPage: (data: IPageEditData) => string | null;
     deletePage: (pageId: number, summary?: string) => void;
-    saveOffer: (data: IOfferEditData) => void;
-    createOffer: (data: IOfferEditData) => void;
+    saveOffer: (data: IOfferEditData) => string | null;
+    createOffer: (data: IOfferEditData) => string | null;
     deleteOffer: (offerId: number, summary?: string) => void;
     reorderOffers: (orders: { id: number; orderNumber: number }[], summary?: string, pageId?: number) => void;
     reorderPage: (pageId: number, newParentId: number, newIndex: number, summary?: string) => void;
@@ -159,14 +181,20 @@ export const useCatalogAdmin = () => useContext(CatalogAdminContext);
 
 export const CATALOG_ROOT_LOCK_ID = 2147483647;
 
-const PAGE_INDEX_REFRESH_ACTIONS = new Set(['savePage', 'createPage', 'deletePage', 'movePage', 'toggleVisible', 'toggleEnabled']);
-const OFFER_REFRESH_ACTIONS = new Set(['saveOffer', 'createOffer', 'deleteOffer', 'reorder']);
+const PAGE_INDEX_REFRESH_ACTIONS = new Set(['deletePage', 'movePage', 'toggleVisible', 'toggleEnabled']);
+const OFFER_REFRESH_ACTIONS = new Set(['deleteOffer', 'reorder']);
 
 type QueuedPageMutation =
     | { kind: 'delete'; pageId: number; catalogType: string; summary: string }
     | { kind: 'move'; pageId: number; catalogType: string; newParentId: number; newIndex: number; summary: string }
     | { kind: 'toggleEnabled'; pageId: number; catalogType: string; enabled: boolean; summary: string }
     | { kind: 'toggleVisible'; pageId: number; catalogType: string; visible: boolean; summary: string };
+
+interface PendingCatalogAdminMutation {
+    operationId: string;
+    action: CatalogAdminMutationAction;
+    submittedAt: number;
+}
 
 export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const { currentType } = useCatalogUiState();
@@ -181,10 +209,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
     const [creatingPage, setCreatingPage] = useState(false);
     const [loading, setLoading] = useState(false);
     const [lastError, setLastError] = useState<string | null>(null);
+    const [lastMutationResult, setLastMutationResult] = useState<CatalogAdminMutationResult | null>(null);
     const queuedPageMutationRef = useRef<QueuedPageMutation | null>(null);
     const queuedOfferDeleteRef = useRef<{ offerId: number; summary: string } | null>(null);
     const requestedOfferKeyRef = useRef<string | null>(null);
     const pendingActionRef = useRef<string | null>(null);
+    const pendingSmartSaveRef = useRef<Map<string, PendingCatalogAdminMutation>>(new Map());
+    const pendingSmartSaveOrderRef = useRef<string[]>([]);
     const { simpleAlert = null } = useNotification();
 
     const beginAdminAction = useCallback((action: string, _summary: string) => {
@@ -194,6 +225,16 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         setLastError(null);
         pendingActionRef.current = action;
         return true;
+    }, []);
+
+    const beginSmartSave = useCallback((action: CatalogAdminMutationAction) => {
+        const operationId = nextCatalogStudioOperationId(action);
+        pendingSmartSaveRef.current.set(operationId, { operationId, action, submittedAt: Date.now() });
+        pendingSmartSaveOrderRef.current.push(operationId);
+        setLoading(true);
+        setLastError(null);
+        setLastMutationResult(null);
+        return operationId;
     }, []);
 
     const setEditingOffer = useCallback(
@@ -357,6 +398,30 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
         [currentType, studio.locks]
     );
 
+    const ensureOfferLock = useCallback(
+        (offerId: number) => {
+            if (offerId == null || offerId <= 0) return;
+            const key = studioLockKey('OFFER', offerId, currentType);
+            if (studio.locks[key]) {
+                setLastError(null);
+                return;
+            }
+            if (!studio.session) {
+                setLastError('Catalog Studio session is not ready');
+                studio.refresh();
+                return;
+            }
+            setLastError(null);
+            studio.acquireLock('OFFER', offerId, toStudioCatalogType(currentType));
+        },
+        [currentType, studio.acquireLock, studio.locks, studio.refresh, studio.session]
+    );
+
+    const hasOfferLock = useCallback(
+        (offerId: number) => !!studio.locks[studioLockKey('OFFER', offerId, currentType)],
+        [currentType, studio.locks]
+    );
+
     useEffect(() => {
         if (!adminMode) return;
 
@@ -384,10 +449,87 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
 
     useMessageEvent(CatalogAdminResultEvent, (event: CatalogAdminResultEvent) => {
         const parser = event.getParser();
-        const action = pendingActionRef.current;
+        const smartSaveResult = parser.smartSaveResult;
+
+        if (smartSaveResult) {
+            const pending = pendingSmartSaveRef.current.get(smartSaveResult.operationId);
+            if (!pending || pending.action !== smartSaveResult.action) return;
+
+            pendingSmartSaveRef.current.delete(smartSaveResult.operationId);
+            pendingSmartSaveOrderRef.current = pendingSmartSaveOrderRef.current
+                .filter(operationId => operationId !== smartSaveResult.operationId);
+            setLoading(pendingSmartSaveRef.current.size > 0 || !!pendingActionRef.current);
+
+            const mutationResult: CatalogAdminMutationResult = {
+                operationId: smartSaveResult.operationId,
+                action: smartSaveResult.action,
+                success: parser.success,
+                code: smartSaveResult.code,
+                message: parser.message || smartSaveResult.code,
+                entityType: smartSaveResult.entityType,
+                catalogType: smartSaveResult.catalogType,
+                entityId: smartSaveResult.entityId,
+                entity: smartSaveResult.entity,
+                historyGroup: smartSaveResult.historyGroup,
+                fieldErrors: { ...smartSaveResult.fieldErrors },
+                acknowledgedAt: Date.now()
+            };
+            setLastMutationResult(mutationResult);
+
+            if (!parser.success || !smartSaveResult.entity || !smartSaveResult.historyGroup) {
+                setLastError(parser.message || smartSaveResult.code || 'Operation failed');
+                return;
+            }
+
+            studio.applyMutation({
+                operationId: smartSaveResult.operationId,
+                action: smartSaveResult.action,
+                revision: smartSaveResult.revision,
+                entityType: smartSaveResult.entityType,
+                catalogType: smartSaveResult.catalogType,
+                entity: smartSaveResult.entity,
+                historyGroup: smartSaveResult.historyGroup
+            });
+            if (smartSaveResult.entityType === 'PAGE') {
+                setEditingPageDetails(createCatalogAdminPageDetailsFromSnapshot(
+                    smartSaveResult.entity as CatalogStudioPageSnapshot));
+            } else {
+                const offer = smartSaveResult.entity as CatalogStudioOfferSnapshot;
+                setEditingOfferDetails(current => ({
+                    offerId: offer.offerId,
+                    pageId: offer.pageId,
+                    itemIds: offer.itemIds,
+                    catalogName: offer.catalogName,
+                    costCredits: offer.costCredits,
+                    costPoints: offer.costPoints,
+                    pointsType: offer.pointsType,
+                    amount: offer.amount,
+                    clubOnly: offer.clubOnly,
+                    extradata: offer.extradata,
+                    haveOffer: offer.haveOffer,
+                    offerIdGroup: offer.offerIdClient,
+                    songId: offer.songId,
+                    limitedStack: offer.limitedStack,
+                    limitedSells: current?.limitedSells ?? 0,
+                    orderNumber: offer.orderNumber,
+                    catalogMode: offer.catalogType
+                }));
+            }
+            setLastError(null);
+            return;
+        }
+
+        let action = pendingActionRef.current;
+        if (!action) {
+            const operationId = pendingSmartSaveOrderRef.current.shift();
+            if (operationId) {
+                action = pendingSmartSaveRef.current.get(operationId)?.action ?? null;
+                pendingSmartSaveRef.current.delete(operationId);
+            }
+        }
 
         pendingActionRef.current = null;
-        setLoading(false);
+        setLoading(pendingSmartSaveRef.current.size > 0);
 
         if (!parser.success) {
             setLastError(parser.message || 'Operation failed');
@@ -422,9 +564,9 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             const lock = studio.locks[studioLockKey('PAGE', data.pageId || 0, currentType)];
             if (!studio.session || !lock) {
                 setLastError('Open the page inspector and acquire its edit lock before saving');
-                return;
+                return null;
             }
-            if (!beginAdminAction('savePage', summary)) return;
+            const operationId = beginSmartSave('savePage');
 
             SendMessageComposer(
                 new CatalogAdminSavePageComposer(
@@ -455,11 +597,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     studio.session.draftVersionId,
                     studio.revision,
                     lock.token,
-                    summary
+                    summary,
+                    operationId
                 )
             );
+            return operationId;
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, beginSmartSave, studio]
     );
 
     const createPage = useCallback(
@@ -471,9 +615,9 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 setLastError(data.parentId <= 0
                     ? 'Wait for the catalog root lock before creating a root category'
                     : 'Open the parent page inspector and acquire its edit lock before creating a sub-page');
-                return;
+                return null;
             }
-            if (!beginAdminAction('createPage', summary)) return;
+            const operationId = beginSmartSave('createPage');
             SendMessageComposer(
                 new CatalogAdminCreatePageComposer(
                     data.caption,
@@ -502,11 +646,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     studio.session.draftVersionId,
                     studio.revision,
                     lock.token,
-                    summary
+                    summary,
+                    operationId
                 )
             );
+            return operationId;
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, beginSmartSave, studio]
     );
 
     const saveOffer = useCallback(
@@ -515,9 +661,9 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             const lock = studio.locks[studioLockKey('OFFER', data.offerId || 0, currentType)];
             if (!studio.session || !lock) {
                 setLastError('Open the offer inspector and acquire its edit lock before saving');
-                return;
+                return null;
             }
-            if (!beginAdminAction('saveOffer', summary)) return;
+            const operationId = beginSmartSave('saveOffer');
             SendMessageComposer(
                 new CatalogAdminSaveOfferComposer(
                     data.offerId || 0,
@@ -539,11 +685,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     studio.session.draftVersionId,
                     studio.revision,
                     lock.token,
-                    summary
+                    summary,
+                    operationId
                 )
             );
+            return operationId;
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, beginSmartSave, studio]
     );
 
     const createOffer = useCallback(
@@ -552,9 +700,9 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
             const lock = studio.locks[studioLockKey('PAGE', data.pageId, currentType)];
             if (!studio.session || !lock) {
                 setLastError('Open the target page and acquire its edit lock before creating an offer');
-                return;
+                return null;
             }
-            if (!beginAdminAction('createOffer', summary)) return;
+            const operationId = beginSmartSave('createOffer');
             SendMessageComposer(
                 new CatalogAdminCreateOfferComposer(
                     data.pageId,
@@ -575,11 +723,13 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                     studio.session.draftVersionId,
                     studio.revision,
                     lock.token,
-                    summary
+                    summary,
+                    operationId
                 )
             );
+            return operationId;
         },
-        [currentType, beginAdminAction, studio]
+        [currentType, beginSmartSave, studio]
     );
 
     const deleteOffer = useCallback(
@@ -764,9 +914,12 @@ export const CatalogAdminProvider: FC<{ children: ReactNode }> = ({ children }) 
                 setCreatingPage,
                 loading,
                 lastError: lastError || studio.lastError,
+                lastMutationResult,
                 studioSessionReady: !!studio.session,
                 ensurePageLock,
                 hasPageLock,
+                ensureOfferLock,
+                hasOfferLock,
                 savePage,
                 createPage,
                 deletePage,

--- a/src/components/catalog/admin/studio/CatalogStudioMutationState.test.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioMutationState.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { applyCatalogStudioMutation } from './CatalogStudioMutationState';
+import { CatalogStudioMutationResult, CatalogStudioPageSnapshot, CatalogStudioSession } from './CatalogStudioTypes';
+
+const page = (catalogType: 'NORMAL' | 'BUILDER', pageId: number, caption: string): CatalogStudioPageSnapshot => ({
+    catalogType, pageId, parentId: -1, captionSave: `page_${pageId}`, caption, pageLayout: 'default_3x3',
+    iconColor: 1, iconImage: 1, minRank: 1, orderNum: 1, visible: true, enabled: true,
+    clubOnly: false, catalogMode: catalogType, vipOnly: false, pageHeadline: '', pageTeaser: '',
+    pageSpecial: '', pageText1: '', pageText2: '', pageTextDetails: '', pageTextTeaser: '', roomId: 0, includes: ''
+});
+
+const session = (): CatalogStudioSession => ({
+    activeVersionId: 11, draftVersionId: 12, revision: 7, activeUpdatedAt: '', draftCreatedAt: '',
+    pendingCount: 3, actors: [], validationCurrent: true, validationIssueCount: 0, publishedVersions: [],
+    pages: [ page('NORMAL', 42, 'Original'), page('BUILDER', 42, 'Builder') ], offers: []
+});
+
+const mutation = (entity: CatalogStudioPageSnapshot): CatalogStudioMutationResult => ({
+    operationId: 'save-page-1', action: 'savePage', revision: 8, entityType: 'PAGE', catalogType: entity.catalogType,
+    entity, historyGroup: {
+        id: 91, revision: 8, actorId: 9, actorName: 'Alice', summary: 'Edit page', source: 'UI', createdAt: '',
+        entries: [ { entityType: 'PAGE', entityId: entity.pageId, operation: 'UPDATE' } ]
+    }
+});
+
+describe('applyCatalogStudioMutation', () =>
+{
+    it('replaces only the matching catalog identity and advances draft metadata', () =>
+    {
+        const original = session();
+        const result = applyCatalogStudioMutation(original, mutation(page('NORMAL', 42, 'Renamed')));
+
+        expect(result).toMatchObject({ revision: 8, pendingCount: 4, validationCurrent: false });
+        expect(result.pages.find(entry => entry.catalogType === 'NORMAL' && entry.pageId === 42)?.caption).toBe('Renamed');
+        expect(result.pages.find(entry => entry.catalogType === 'BUILDER' && entry.pageId === 42)?.caption).toBe('Builder');
+        expect(original.pages[0].caption).toBe('Original');
+        expect(result.pages).not.toBe(original.pages);
+    });
+
+    it('inserts a newly committed entity when no identity exists', () =>
+    {
+        const result = applyCatalogStudioMutation(session(), {
+            ...mutation(page('NORMAL', 55, 'New page')),
+            action: 'createPage'
+        });
+
+        expect(result.pages).toHaveLength(3);
+        expect(result.pages.at(-1)?.pageId).toBe(55);
+    });
+});

--- a/src/components/catalog/admin/studio/CatalogStudioMutationState.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioMutationState.ts
@@ -1,0 +1,37 @@
+import { CatalogStudioMutationResult, CatalogStudioOfferSnapshot, CatalogStudioPageSnapshot, CatalogStudioSession } from './CatalogStudioTypes';
+
+export const applyCatalogStudioMutation = (
+    session: CatalogStudioSession,
+    mutation: CatalogStudioMutationResult): CatalogStudioSession =>
+{
+    if(mutation.entityType === 'PAGE')
+    {
+        const entity = mutation.entity as CatalogStudioPageSnapshot;
+        const index = session.pages.findIndex(page =>
+            page.catalogType === mutation.catalogType && page.pageId === entity.pageId);
+        const pages = session.pages.map(page => ({ ...page }));
+        if(index >= 0) pages[index] = { ...entity };
+        else pages.push({ ...entity });
+        return {
+            ...session,
+            revision: mutation.revision,
+            pendingCount: session.pendingCount + 1,
+            validationCurrent: false,
+            pages
+        };
+    }
+
+    const entity = mutation.entity as CatalogStudioOfferSnapshot;
+    const index = session.offers.findIndex(offer =>
+        offer.catalogType === mutation.catalogType && offer.offerId === entity.offerId);
+    const offers = session.offers.map(offer => ({ ...offer }));
+    if(index >= 0) offers[index] = { ...entity };
+    else offers.push({ ...entity });
+    return {
+        ...session,
+        revision: mutation.revision,
+        pendingCount: session.pendingCount + 1,
+        validationCurrent: false,
+        offers
+    };
+};

--- a/src/components/catalog/admin/studio/CatalogStudioOperationId.test.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioOperationId.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { nextCatalogStudioOperationId } from './CatalogStudioOperationId';
+
+describe('nextCatalogStudioOperationId', () =>
+{
+    it('creates unique bounded identifiers with a readable action prefix', () =>
+    {
+        const first = nextCatalogStudioOperationId('savePage');
+        const second = nextCatalogStudioOperationId('savePage');
+        const long = nextCatalogStudioOperationId('x'.repeat(200));
+
+        expect(first).not.toBe(second);
+        expect(first.startsWith('savePage-')).toBe(true);
+        expect(first.length).toBeLessThanOrEqual(96);
+        expect(long.length).toBeLessThanOrEqual(96);
+    });
+});

--- a/src/components/catalog/admin/studio/CatalogStudioOperationId.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioOperationId.ts
@@ -1,0 +1,8 @@
+let operationSequence = 0;
+
+export const nextCatalogStudioOperationId = (action: string): string =>
+{
+    const prefix = action.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 48) || 'operation';
+    operationSequence = (operationSequence + 1) % Number.MAX_SAFE_INTEGER;
+    return `${prefix}-${Date.now().toString(36)}-${operationSequence.toString(36)}`.slice(0, 96);
+};

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
@@ -11,6 +11,13 @@ vi.mock('../../../../api', () => ({ SendMessageComposer: vi.fn() }));
 vi.mock('../../../../hooks', () => ({ useConnectionState: vi.fn(), useMessageEvent: vi.fn() }));
 
 const handlers = new Map<string, (event: any) => void>();
+const pageSnapshot = (caption: string) => ({
+    catalogType: 'NORMAL' as const, pageId: 42, parentId: -1, captionSave: 'page_42', caption,
+    pageLayout: 'default_3x3', iconColor: 1, iconImage: 1, minRank: 1, orderNum: 1,
+    visible: true, enabled: true, clubOnly: false, catalogMode: 'NORMAL', vipOnly: false,
+    pageHeadline: '', pageTeaser: '', pageSpecial: '', pageText1: '', pageText2: '',
+    pageTextDetails: '', pageTextTeaser: '', roomId: 0, includes: ''
+});
 
 const Probe = () => {
     const studio = useCatalogStudio();
@@ -22,10 +29,20 @@ const Probe = () => {
             <span data-testid="pending">{studio.pendingCount}</span>
             <span data-testid="locks">{Object.keys(studio.locks).length}</span>
             <span data-testid="error">{studio.lastError ?? ''}</span>
+            <span data-testid="page-caption">{studio.session?.pages.find(page => page.pageId === 42)?.caption ?? ''}</span>
+            <span data-testid="history-count">{studio.historyTotalCount}</span>
             <button onClick={() => studio.acquireLock('PAGE', 44)}>lock</button>
             <button onClick={() => studio.releaseLock('PAGE', 44)}>release</button>
             <button onClick={() => studio.publish()}>publish</button>
             <button onClick={() => studio.applyDocument('JSONC', '{"pages":[]}', 'fingerprint', 'Import JSONC')}>apply</button>
+            <button onClick={() => studio.applyMutation({
+                operationId: 'save-page-1', action: 'savePage', revision: 8, entityType: 'PAGE', catalogType: 'NORMAL',
+                entity: pageSnapshot('Renamed'),
+                historyGroup: {
+                    id: 91, revision: 8, actorId: 9, actorName: 'Alice', summary: 'Edit page', source: 'UI', createdAt: '',
+                    entries: [ { entityType: 'PAGE', catalogType: 'NORMAL', entityId: 42, operation: 'UPDATE' } ]
+                }
+            })}>delta</button>
         </div>
     );
 };
@@ -76,6 +93,25 @@ describe('CatalogStudioProvider', () => {
         expect(screen.getByTestId('draft')).toHaveTextContent('12');
         expect(screen.getByTestId('revision')).toHaveTextContent('7');
         expect(screen.getByTestId('pending')).toHaveTextContent('3');
+    });
+
+    it('applies a mutation delta without requesting a broad session or history refresh', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+        emit('CatalogStudioSessionEvent', {
+            activeVersionId: 11, draftVersionId: 12, revision: 7,
+            activeUpdatedAt: '', draftCreatedAt: '', pendingCount: 3,
+            actors: [], validationCurrent: true, validationIssueCount: 0, publishedVersions: [],
+            pages: [ pageSnapshot('Original') ], offers: []
+        });
+        const callsBefore = vi.mocked(SendMessageComposer).mock.calls.length;
+
+        act(() => screen.getByText('delta').click());
+
+        expect(screen.getByTestId('revision')).toHaveTextContent('8');
+        expect(screen.getByTestId('pending')).toHaveTextContent('4');
+        expect(screen.getByTestId('page-caption')).toHaveTextContent('Renamed');
+        expect(screen.getByTestId('history-count')).toHaveTextContent('1');
+        expect(vi.mocked(SendMessageComposer).mock.calls).toHaveLength(callsBefore);
     });
 
     it('waits for authentication and opens a fresh session after reconnecting', () => {

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -29,14 +29,14 @@ import {
 import { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SendMessageComposer } from '../../../../api';
 import { useConnectionState, useMessageEvent } from '../../../../hooks';
-import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
 import { CatalogPreviewPersona } from './CatalogPreviewPersona';
+import { applyCatalogStudioMutation } from './CatalogStudioMutationState';
+import { nextCatalogStudioOperationId } from './CatalogStudioOperationId';
 import { CatalogStudioContext, CatalogStudioContextValue } from './useCatalogStudio';
 
 const lockKey = (entityType: string, entityId: number, catalogType: string = 'NORMAL') =>
     catalogType === 'NORMAL' ? `${entityType}:${entityId}` : `${catalogType}:${entityType}:${entityId}`;
-let operationSequence = 0;
-const nextOperationId = (action: string) => `${action}-${Date.now()}-${++operationSequence}`;
 const CATALOG_ROOT_LOCK_ID = 2147483647;
 type PendingDocumentApply = {
     format: 'JSONC' | 'SQL' | 'BULK';
@@ -61,6 +61,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
     const locksRef = useRef<Record<string, CatalogStudioLock>>({});
     const pendingLockKeysRef = useRef<Set<string>>(new Set());
     const pendingDocumentApplyRef = useRef<PendingDocumentApply | null>(null);
+    const historyGroupIdsRef = useRef<Set<number>>(new Set());
 
     const replaceSession = useCallback((next: CatalogStudioSession) => {
         sessionRef.current = next;
@@ -141,7 +142,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
             pendingDocumentApplyRef.current = null;
             setLoading(true);
             SendMessageComposer(new CatalogStudioDocumentApplyComposer(
-                nextOperationId('apply'), current.draftVersionId, current.revision, nextLock.token,
+                nextCatalogStudioOperationId('apply'), current.draftVersionId, current.revision, nextLock.token,
                 pendingApply.format, pendingApply.document, pendingApply.fingerprint, pendingApply.summary
             ));
         }
@@ -180,7 +181,9 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
     useMessageEvent<CatalogStudioHistoryEvent>(CatalogStudioHistoryEvent, (event) => {
         const parser = event.getParser();
         updateRevision(parser.revision);
-        setHistory(parser.groups.map((group) => ({ ...group, entries: group.entries.map((entry) => ({ ...entry })) })));
+        const nextHistory = parser.groups.map((group) => ({ ...group, entries: group.entries.map((entry) => ({ ...entry })) }));
+        historyGroupIdsRef.current = new Set(nextHistory.map(group => group.id));
+        setHistory(nextHistory);
         setHistoryTotalCount(parser.totalCount);
         setLoading(false);
     });
@@ -257,7 +260,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         const timer = window.setInterval(() => {
             Object.values(locksRef.current).forEach((lock) => {
                 SendMessageComposer(new CatalogStudioRenewLockComposer(
-                    nextOperationId('renew-lock'), lock.draftVersionId, lock.entityType,
+                    nextCatalogStudioOperationId('renew-lock'), lock.draftVersionId, lock.entityType,
                     lock.catalogType, lock.entityId, lock.token
                 ));
             });
@@ -271,14 +274,14 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if (!current || locksRef.current[key] || pendingLockKeysRef.current.has(key)) return;
         pendingLockKeysRef.current.add(key);
         setLoading(true);
-        SendMessageComposer(new CatalogStudioAcquireLockComposer(nextOperationId('acquire-lock'), current.draftVersionId, entityType, catalogType, entityId));
+        SendMessageComposer(new CatalogStudioAcquireLockComposer(nextCatalogStudioOperationId('acquire-lock'), current.draftVersionId, entityType, catalogType, entityId));
     }, []);
 
     const releaseLock = useCallback((entityType: string, entityId: number, catalogType: 'NORMAL' | 'BUILDER' = 'NORMAL') => {
         const lock = locksRef.current[lockKey(entityType, entityId, catalogType)];
         if (!lock) return;
         SendMessageComposer(new CatalogStudioReleaseLockComposer(
-            nextOperationId('release-lock'), lock.draftVersionId, lock.entityType, lock.catalogType, lock.entityId, lock.token
+            nextCatalogStudioOperationId('release-lock'), lock.draftVersionId, lock.entityType, lock.catalogType, lock.entityId, lock.token
         ));
         setLocks((current) => {
             const next = { ...current };
@@ -299,7 +302,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         const current = sessionRef.current;
         if (!current) return;
         setLoading(true);
-        const operationId = nextOperationId(action);
+        const operationId = nextCatalogStudioOperationId(action);
         if (action === 'validate') SendMessageComposer(new CatalogStudioValidateComposer(operationId, current.draftVersionId, current.revision));
         if (action === 'publish') SendMessageComposer(new CatalogStudioPublishComposer(operationId, current.draftVersionId, current.revision));
         if (action === 'discard') SendMessageComposer(new CatalogStudioDiscardComposer(operationId, current.draftVersionId, current.revision));
@@ -309,14 +312,14 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         const current = sessionRef.current;
         if (!current) return;
         setLoading(true);
-        SendMessageComposer(new CatalogStudioUndoComposer(nextOperationId('undo'), current.draftVersionId, current.revision, groupId));
+        SendMessageComposer(new CatalogStudioUndoComposer(nextCatalogStudioOperationId('undo'), current.draftVersionId, current.revision, groupId));
     }, []);
 
     const restore = useCallback((sourceVersionId: number) => {
         const current = sessionRef.current;
         if (!current) return;
         setLoading(true);
-        SendMessageComposer(new CatalogStudioRestoreComposer(nextOperationId('restore'), current.draftVersionId, current.revision, sourceVersionId));
+        SendMessageComposer(new CatalogStudioRestoreComposer(nextCatalogStudioOperationId('restore'), current.draftVersionId, current.revision, sourceVersionId));
     }, []);
 
     const requestPreview = useCallback((persona: CatalogPreviewPersona) => {
@@ -324,7 +327,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if(!current) return;
         setLoading(true);
         SendMessageComposer(new CatalogStudioPreviewComposer(
-            nextOperationId('preview'), current.draftVersionId, current.revision, persona.rank,
+            nextCatalogStudioOperationId('preview'), current.draftVersionId, current.revision, persona.rank,
             persona.hc, persona.vip, persona.buildersClub, persona.showHidden, persona.credits, persona.currencies
         ));
     }, []);
@@ -334,7 +337,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if(!current) return;
         setLoading(true);
         SendMessageComposer(new CatalogStudioExportComposer(
-            nextOperationId('export'), current.draftVersionId, current.revision, format
+            nextCatalogStudioOperationId('export'), current.draftVersionId, current.revision, format
         ));
     }, []);
 
@@ -343,7 +346,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if(!current) return;
         setLoading(true);
         SendMessageComposer(new CatalogStudioDocumentDryRunComposer(
-            nextOperationId('dry-run'), current.draftVersionId, current.revision, format, document
+            nextCatalogStudioOperationId('dry-run'), current.draftVersionId, current.revision, format, document
         ));
     }, []);
 
@@ -359,10 +362,24 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         }
         setLoading(true);
         SendMessageComposer(new CatalogStudioDocumentApplyComposer(
-            nextOperationId('apply'), current.draftVersionId, current.revision, rootLock.token,
+            nextCatalogStudioOperationId('apply'), current.draftVersionId, current.revision, rootLock.token,
             format, document, fingerprint, summary
         ));
     }, [acquireLock]);
+
+    const applyMutation = useCallback((mutation: CatalogStudioMutationResult) => {
+        setSession(current => {
+            if(!current) return current;
+            const next = applyCatalogStudioMutation(current, mutation);
+            sessionRef.current = next;
+            return next;
+        });
+        if(!historyGroupIdsRef.current.has(mutation.historyGroup.id)) {
+            historyGroupIdsRef.current.add(mutation.historyGroup.id);
+            setHistory(current => [ mutation.historyGroup, ...current ].slice(0, 50));
+            setHistoryTotalCount(current => current + 1);
+        }
+    }, []);
 
     const value = useMemo<CatalogStudioContextValue>(() => ({
         session,
@@ -388,8 +405,9 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         requestPreview,
         exportDocument,
         dryRunDocument,
-        applyDocument
-    }), [session, history, historyTotalCount, validation, preview, documentResult, locks, loading, lastError, refresh, acquireLock, releaseLock, loadHistory, undo, revisionAction, restore, requestPreview, exportDocument, dryRunDocument, applyDocument]);
+        applyDocument,
+        applyMutation
+    }), [session, history, historyTotalCount, validation, preview, documentResult, locks, loading, lastError, refresh, acquireLock, releaseLock, loadHistory, undo, revisionAction, restore, requestPreview, exportDocument, dryRunDocument, applyDocument, applyMutation]);
 
     return <CatalogStudioContext value={value}>{children}</CatalogStudioContext>;
 };

--- a/src/components/catalog/admin/studio/CatalogStudioTypes.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioTypes.ts
@@ -85,6 +85,7 @@ export interface CatalogStudioLock {
 
 export interface CatalogStudioHistoryEntry {
     entityType: string;
+    catalogType?: CatalogStudioCatalogType;
     entityId: number;
     operation: string;
 }
@@ -152,4 +153,14 @@ export interface CatalogStudioDocumentResult {
     document: string;
     fingerprint: string;
     changedEntities: number;
+}
+
+export interface CatalogStudioMutationResult {
+    operationId: string;
+    action: 'createPage' | 'savePage' | 'createOffer' | 'saveOffer';
+    revision: number;
+    entityType: 'PAGE' | 'OFFER';
+    catalogType: CatalogStudioCatalogType;
+    entity: CatalogStudioPageSnapshot | CatalogStudioOfferSnapshot;
+    historyGroup: CatalogStudioHistoryGroup;
 }

--- a/src/components/catalog/admin/studio/useCatalogStudio.ts
+++ b/src/components/catalog/admin/studio/useCatalogStudio.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioPreviewState, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
 import { CatalogPreviewPersona } from './CatalogPreviewPersona';
 
 export interface CatalogStudioContextValue {
@@ -27,6 +27,7 @@ export interface CatalogStudioContextValue {
     exportDocument: (format: 'JSONC' | 'SQL') => void;
     dryRunDocument: (format: 'JSONC' | 'SQL' | 'BULK', document: string) => void;
     applyDocument: (format: 'JSONC' | 'SQL' | 'BULK', document: string, fingerprint: string, summary: string) => void;
+    applyMutation: (mutation: CatalogStudioMutationResult) => void;
 }
 
 export const CatalogStudioContext = createContext<CatalogStudioContextValue>(null);

--- a/src/components/catalog/views/admin/CatalogAdminOfferEditView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminOfferEditView.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect, useRef, useState } from 'react';
-import { FaCubes, FaSave, FaSpinner, FaTrash } from 'react-icons/fa';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FaCubes, FaSave, FaSpinner, FaTrash, FaUndo } from 'react-icons/fa';
 import { CatalogType, GetConfigurationValue, IPurchasableOffer, LocalizeText, localizeWithFallback, ProductTypeEnum } from '../../../../api';
 import { useCatalogData, useCatalogUiState, usePurse } from '../../../../hooks';
 import { IEditingOfferDetails, IOfferEditData, useCatalogAdmin } from '../../CatalogAdminContext';
@@ -7,6 +7,8 @@ import { CatalogAdminModalView } from './CatalogAdminModalView';
 import { CatalogAdminOfferPriceView } from './CatalogAdminOfferPriceView';
 import { useCatalogStudio } from '../../admin/studio/useCatalogStudio';
 import { claimCatalogAdminHydration } from './CatalogAdminFormHydration';
+import { CatalogStudioOfferSnapshot } from '../../admin/studio/CatalogStudioTypes';
+import { useCatalogAdminSmartSave } from './useCatalogAdminSmartSave';
 
 const getOfferIconUrl = (offer: IPurchasableOffer | null): string | null => {
     const product = offer?.product;
@@ -114,27 +116,80 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
     const createOffer = catalogAdmin?.createOffer;
     const loading = catalogAdmin?.loading ?? false;
     const lastError = catalogAdmin?.lastError ?? null;
+    const lastMutationResult = catalogAdmin?.lastMutationResult ?? null;
     const studioSessionReady = catalogAdmin?.studioSessionReady ?? false;
+    const ensurePageLock = catalogAdmin?.ensurePageLock;
+    const hasPageLock = catalogAdmin?.hasPageLock;
+    const ensureOfferLock = catalogAdmin?.ensureOfferLock;
+    const hasOfferLock = catalogAdmin?.hasOfferLock;
 
-    const [itemIds, setItemIds] = useState('');
-    const [catalogName, setCatalogName] = useState('');
-    const [costCredits, setCostCredits] = useState(0);
-    const [costPoints, setCostPoints] = useState(0);
-    const [pointsType, setPointsType] = useState(0);
-    const [amount, setAmount] = useState(1);
-    const [clubOnly, setClubOnly] = useState('0');
-    const [extradata, setExtradata] = useState('');
-    const [haveOffer, setHaveOffer] = useState('1');
-    const [offerId, setOfferIdGroup] = useState(-1);
-    const [songId, setSongId] = useState(0);
-    const [limitedStack, setLimitedStack] = useState(0);
-    const [orderNumber, setOrderNumber] = useState(0);
     const [isNew, setIsNew] = useState(false);
     const initializationClaimRef = useRef({ current: null as string | null });
     const detailsClaimRef = useRef({ current: null as string | null });
+    const catalogNameInputRef = useRef<HTMLInputElement>(null);
+    const itemIdsInputRef = useRef<HTMLInputElement>(null);
+    const limitedStackInputRef = useRef<HTMLInputElement>(null);
     const formTargetKey = editingOffer
         ? `offer:${currentType}:${editingOffer.offerId}:${editingOffer.offerId === -1 ? currentPage?.pageId || 0 : editingOffer.offerId}`
         : null;
+    const closeForm = useCallback(() => setEditingOffer?.(null), [setEditingOffer]);
+    const smartSave = useCatalogAdminSmartSave<IOfferEditData>({
+        initial: createCatalogAdminNewOfferFormState(0),
+        acknowledgement: lastMutationResult,
+        submit: draft => draft.offerId == null
+            ? createOffer?.(draft) ?? null
+            : saveOffer?.(draft) ?? null,
+        canSubmit: draft => {
+            const builderCatalog = currentType === CatalogType.BUILDER;
+            const sold = draft.offerId == null ? 0 : editingOfferDetails?.limitedSells || 0;
+            const hasLock = draft.offerId == null
+                ? (hasPageLock?.(draft.pageId) ?? false)
+                : (hasOfferLock?.(draft.offerId) ?? false);
+            return studioSessionReady && hasLock && !validateCatalogAdminOfferForm(draft, builderCatalog, sold);
+        },
+        toCommitted: acknowledgement => {
+            if(!acknowledgement.entity) return null;
+            const offer = acknowledgement.entity as CatalogStudioOfferSnapshot;
+            return {
+                offerId: offer.offerId,
+                pageId: offer.pageId,
+                itemIds: offer.itemIds,
+                catalogName: offer.catalogName,
+                costCredits: offer.costCredits,
+                costPoints: offer.costPoints,
+                pointsType: offer.pointsType,
+                amount: offer.amount,
+                clubOnly: offer.clubOnly ? '1' : '0',
+                extradata: offer.extradata,
+                haveOffer: offer.haveOffer ? '1' : '0',
+                offerId_group: offer.offerIdClient,
+                songId: offer.songId,
+                limitedStack: offer.limitedStack,
+                orderNumber: offer.orderNumber
+            };
+        },
+        onClose: closeForm
+    });
+    const {
+        itemIds, catalogName, costCredits, costPoints, pointsType, amount, clubOnly,
+        extradata, haveOffer, offerId_group: offerId, songId = 0, limitedStack, orderNumber
+    } = smartSave.draft;
+    const patchForm = smartSave.patch;
+    const setItemIds = (value: string) => patchForm({ itemIds: value });
+    const setCatalogName = (value: string) => patchForm({ catalogName: value });
+    const setCostCredits = (value: number) => patchForm({ costCredits: value });
+    const setCostPoints = (value: number) => patchForm({ costPoints: value });
+    const setPointsType = (value: number) => patchForm({ pointsType: value });
+    const setAmount = (value: number) => patchForm({ amount: value });
+    const setClubOnly = (value: string) => patchForm({ clubOnly: value });
+    const setExtradata = (value: string) => patchForm({ extradata: value });
+    const setHaveOffer = (value: string) => patchForm({ haveOffer: value });
+    const setOfferIdGroup = (value: number) => patchForm({ offerId_group: value });
+    const setSongId = (value: number) => patchForm({ songId: value });
+    const setLimitedStack = (value: number) => patchForm({ limitedStack: value });
+    const setOrderNumber = (value: number) => patchForm({ orderNumber: value });
+    const effectiveOfferId = smartSave.draft.offerId ?? editingOffer?.offerId ?? -1;
+    const isNewOffer = isNew && smartSave.baseline.offerId == null;
 
     useEffect(() => {
         if (!editingOffer) {
@@ -157,36 +212,28 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                 .map((offer) => offer.orderNumber);
             const form = createCatalogAdminNewOfferFormState(pageId, siblingOrders.length ? Math.max(...siblingOrders) + 1 : 0);
             setIsNew(true);
-            setItemIds(form.itemIds);
-            setCatalogName(form.catalogName);
-            setCostCredits(form.costCredits);
-            setCostPoints(form.costPoints);
-            setPointsType(form.pointsType);
-            setAmount(form.amount);
-            setClubOnly(form.clubOnly);
-            setExtradata(form.extradata);
-            setHaveOffer(form.haveOffer);
-            setOfferIdGroup(form.offerId_group);
-            setSongId(form.songId);
-            setLimitedStack(form.limitedStack);
-            setOrderNumber(form.orderNumber);
+            smartSave.hydrate(form);
         } else {
             setIsNew(false);
-            setItemIds(editingOffer.itemIds || '');
-            setCatalogName(editingOffer.localizationName || '');
-            setCostCredits(editingOffer.priceInCredits);
-            setCostPoints(editingOffer.priceInActivityPoints);
-            setPointsType(editingOffer.activityPointType);
-            setAmount(editingOffer.product?.productCount || 1);
-            setClubOnly(editingOffer.clubLevel > 0 ? '1' : '0');
-            setExtradata(editingOffer.product?.extraParam || '');
-            setHaveOffer(editingOffer.haveOffer ? '1' : '0');
-            setOfferIdGroup(0);
-            setSongId(0);
-            setLimitedStack(0);
-            setOrderNumber(0);
+            smartSave.hydrate({
+                offerId: editingOffer.offerId,
+                pageId: currentPage?.pageId || 0,
+                itemIds: editingOffer.itemIds || '',
+                catalogName: editingOffer.localizationName || '',
+                costCredits: editingOffer.priceInCredits,
+                costPoints: editingOffer.priceInActivityPoints,
+                pointsType: editingOffer.activityPointType,
+                amount: editingOffer.product?.productCount || 1,
+                clubOnly: editingOffer.clubLevel > 0 ? '1' : '0',
+                extradata: editingOffer.product?.extraParam || '',
+                haveOffer: editingOffer.haveOffer ? '1' : '0',
+                offerId_group: 0,
+                songId: 0,
+                limitedStack: 0,
+                orderNumber: 0
+            });
         }
-    }, [editingOffer, currentPage?.pageId, currentType, formTargetKey, studio.session]);
+    }, [editingOffer, currentPage?.pageId, currentType, formTargetKey, smartSave.hydrate, studio.session]);
 
     useEffect(() => {
         if (!editingOfferDetails) return;
@@ -194,73 +241,73 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
         if (!claimCatalogAdminHydration(detailsClaimRef.current, `${formTargetKey}:details`)) return;
 
         const form = createCatalogAdminOfferFormState(editingOfferDetails);
-        setItemIds(form.itemIds);
-        setCatalogName(form.catalogName);
-        setCostCredits(form.costCredits);
-        setCostPoints(form.costPoints);
-        setPointsType(form.pointsType);
-        setAmount(form.amount);
-        setClubOnly(form.clubOnly);
-        setExtradata(form.extradata);
-        setHaveOffer(form.haveOffer);
-        setOfferIdGroup(form.offerId_group);
-        setSongId(form.songId);
-        setLimitedStack(form.limitedStack);
-        setOrderNumber(form.orderNumber);
-    }, [editingOffer, editingOfferDetails, formTargetKey]);
+        smartSave.hydrate(form);
+    }, [editingOffer, editingOfferDetails, formTargetKey, smartSave.hydrate]);
+
+    useEffect(() => {
+        if(!editingOffer) return;
+        if(isNewOffer && smartSave.draft.pageId > 0) ensurePageLock?.(smartSave.draft.pageId);
+        else if(effectiveOfferId > 0) ensureOfferLock?.(effectiveOfferId);
+    }, [editingOffer, effectiveOfferId, ensureOfferLock, ensurePageLock, isNewOffer, smartSave.draft.pageId]);
+
+    useEffect(() => {
+        if(smartSave.fieldErrors.catalogName) catalogNameInputRef.current?.focus();
+        else if(smartSave.fieldErrors.itemIds) itemIdsInputRef.current?.focus();
+        else if(smartSave.fieldErrors.limitedStack) limitedStackInputRef.current?.focus();
+    }, [smartSave.fieldErrors]);
 
     if (!editingOffer) return null;
 
-    const detailsReady = isNew || editingOfferDetails?.offerId === editingOffer.offerId;
-    const interaction = resolveCatalogAdminOfferInteraction(studioSessionReady, detailsReady, loading, lastError);
-    const limitedSells = isNew ? 0 : editingOfferDetails?.limitedSells || 0;
-    const formData: IOfferEditData = {
-        offerId: isNew ? undefined : editingOffer.offerId,
-        pageId: isNew ? currentPage?.pageId || 0 : editingOfferDetails?.pageId || 0,
-        itemIds,
-        catalogName,
-        costCredits,
-        costPoints,
-        pointsType,
-        amount,
-        clubOnly,
-        extradata,
-        haveOffer,
-        offerId_group: offerId,
-        songId,
-        limitedStack,
-        orderNumber
-    };
+    const detailsReady = isNewOffer || editingOfferDetails?.offerId === effectiveOfferId;
+    const lockReady = isNewOffer
+        ? (hasPageLock?.(smartSave.draft.pageId) ?? false)
+        : effectiveOfferId > 0 && (hasOfferLock?.(effectiveOfferId) ?? false);
+    const smartSaveError = lastMutationResult?.success === false ? null : lastError;
+    const interaction = resolveCatalogAdminOfferInteraction(
+        studioSessionReady, detailsReady, loading && smartSave.status !== 'saving', smartSaveError);
+    const limitedSells = isNewOffer ? 0 : editingOfferDetails?.limitedSells || 0;
+    const formData = smartSave.draft;
     const validationError = detailsReady ? validateCatalogAdminOfferForm(formData, currentType === CatalogType.BUILDER, limitedSells) : null;
     const currencyTypes = Array.from(new Set([0, 5, 101, pointsType, ...Array.from(purse?.activityPoints?.keys?.() || [])]))
         .filter((type) => type >= 0)
         .sort((left, right) => left - right);
 
-    const handleSave = async () => {
-        if (!saveOffer || !createOffer || !interaction.canSave) return;
-        if (validationError) return;
+    const saveStatusText = smartSave.status === 'saving'
+        ? 'Saving...'
+        : smartSave.status === 'dirty'
+          ? 'Unsaved changes'
+          : smartSave.status === 'conflict'
+            ? (smartSave.message || 'The catalog changed. Review and save again.')
+            : smartSave.status === 'error'
+              ? (smartSave.message || 'Save failed')
+              : smartSave.lastSavedAt
+                ? `Saved · ${new Date(smartSave.lastSavedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+                : 'Saved';
+    const canSubmit = interaction.canSave && lockReady && !validationError && (smartSave.isDirty || !!smartSave.inFlight);
 
-        if (isNew) createOffer(formData);
-        else saveOffer(formData);
+    const handleSave = (closeAfter = false) => {
+        if (!saveOffer || !createOffer || !interaction.canSave || !lockReady) return;
+        if (validationError) return;
+        smartSave.save(closeAfter);
     };
 
     const handleDelete = () => {
-        if (isNew || !deleteOffer || !confirm(LocalizeText('catalog.admin.delete.offer.confirm'))) return;
+        if (isNewOffer || !deleteOffer || !confirm(LocalizeText('catalog.admin.delete.offer.confirm'))) return;
 
-        deleteOffer(editingOffer.offerId);
+        deleteOffer(effectiveOfferId);
     };
 
     const inputClass = 'nitro-catalog-admin-input';
-    const previewIconUrl = isNew ? null : getOfferIconUrl(editingOffer);
+    const previewIconUrl = isNewOffer ? null : getOfferIconUrl(editingOffer);
     const previewName =
-        catalogName || editingOffer.localizationName || (isNew ? localizeWithFallback('catalog.admin.offer.new', 'New offer') : `#${editingOffer.offerId}`);
-    const previewFallbackIcon = isNew ? null : editingOffer.product?.getIconUrl(editingOffer);
+        catalogName || editingOffer.localizationName || (isNewOffer ? localizeWithFallback('catalog.admin.offer.new', 'New offer') : `#${effectiveOfferId}`);
+    const previewFallbackIcon = isNewOffer ? null : editingOffer.product?.getIconUrl(editingOffer);
 
     return (
         <CatalogAdminModalView
-            title={isNew ? LocalizeText('catalog.admin.offer.new') : localizeWithFallback('catalog.admin.edit.offer', 'Edit offer')}
+            title={isNewOffer ? LocalizeText('catalog.admin.offer.new') : localizeWithFallback('catalog.admin.edit.offer', 'Edit offer')}
             widthClassName="w-[500px]"
-            onClose={() => setEditingOffer(null)}
+            onClose={smartSave.requestClose}
         >
             <div className="nitro-catalog-admin-form">
                 <div className="nitro-catalog-admin-form-sheet">
@@ -287,9 +334,9 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                     {previewName}
                                 </span>
                                 <span className="nitro-catalog-admin-offer-preview-sub">
-                                    {isNew
+                                    {isNewOffer
                                         ? localizeWithFallback('catalog.admin.offer.new', 'New offer')
-                                        : `${localizeWithFallback('catalog.admin.offer.id', 'Offer ID')} #${editingOffer.offerId}`}
+                                        : `${localizeWithFallback('catalog.admin.offer.id', 'Offer ID')} #${effectiveOfferId}`}
                                     {amount > 1 ? ` · x${amount}` : ''}
                                 </span>
                                 <span className="nitro-catalog-admin-offer-preview-price">
@@ -304,12 +351,15 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                             <div className="nitro-catalog-admin-form-field">
                                 <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.name')}</label>
                                 <input
+                                    ref={catalogNameInputRef}
+                                    aria-invalid={!!smartSave.fieldErrors.catalogName}
                                     className={inputClass}
                                     placeholder={localizeWithFallback('catalog.admin.offer.name.placeholder', 'e.g. rare_dragon_lamp')}
                                     type="text"
                                     value={catalogName}
                                     onChange={(e) => setCatalogName(e.target.value)}
                                 />
+                                {smartSave.fieldErrors.catalogName && <span className="nitro-catalog-admin-field-error">{smartSave.fieldErrors.catalogName}</span>}
                             </div>
                             <div className="nitro-catalog-admin-form-grid is-3col">
                                 <div className="nitro-catalog-admin-form-field is-span-3">
@@ -317,16 +367,21 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                         {localizeWithFallback('catalog.admin.offer.item.ids', 'Item IDs')}
                                     </label>
                                     <input
+                                        ref={itemIdsInputRef}
+                                        aria-invalid={!!smartSave.fieldErrors.itemIds}
                                         className={inputClass}
                                         placeholder={localizeWithFallback('catalog.admin.offer.item.ids.placeholder', '1234 or 100;200')}
                                         type="text"
                                         value={itemIds}
                                         onChange={(e) => setItemIds(e.target.value)}
                                     />
+                                    {smartSave.fieldErrors.itemIds && <span className="nitro-catalog-admin-field-error">{smartSave.fieldErrors.itemIds}</span>}
                                 </div>
                                 <div className="nitro-catalog-admin-form-field">
                                     <label className="nitro-catalog-admin-label is-field">{LocalizeText('catalog.admin.offer.quantity')}</label>
                                     <input
+                                        ref={limitedStackInputRef}
+                                        aria-invalid={!!smartSave.fieldErrors.limitedStack}
                                         className={inputClass}
                                         min={1}
                                         type="number"
@@ -412,8 +467,9 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                                         value={limitedStack}
                                         onChange={(e) => setLimitedStack(parseInt(e.target.value) || 0)}
                                     />
+                                    {smartSave.fieldErrors.limitedStack && <span className="nitro-catalog-admin-field-error">{smartSave.fieldErrors.limitedStack}</span>}
                                 </div>
-                                {!isNew && (
+                                {!isNewOffer && (
                                     <div className="nitro-catalog-admin-form-field">
                                         <label className="nitro-catalog-admin-label is-field">
                                             {localizeWithFallback('catalog.admin.offer.limited.sold', 'Already sold')}
@@ -456,23 +512,43 @@ export const CatalogAdminOfferEditView: FC<{}> = () => {
                         </section>
                     </div>
 
-                    <div className="nitro-catalog-admin-form-actions">
-                        {(validationError || interaction.message) && (
-                            <span className={validationError || lastError ? 'nitro-catalog-admin-translate-error' : 'nitro-catalog-admin-form-status'}>
-                                {validationError || interaction.message}
-                            </span>
-                        )}
-                        {!isNew ? (
-                            <button className="nitro-catalog-admin-button is-danger" onClick={handleDelete}>
-                                <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
+                    <div className={`nitro-catalog-admin-savebar is-${smartSave.status}`}>
+                        <div className="nitro-catalog-admin-savebar-status" aria-live="polite">
+                            <span>{validationError || smartSave.message || interaction.message || (!lockReady ? 'Waiting for the edit lock...' : saveStatusText)}</span>
+                            <small>Ctrl+S</small>
+                        </div>
+                        <div className="nitro-catalog-admin-savebar-actions">
+                            {!isNewOffer && (
+                                <button className="nitro-catalog-admin-button is-danger" type="button" onClick={handleDelete}>
+                                    <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
+                                </button>
+                            )}
+                            <button
+                                className="nitro-catalog-admin-button is-muted"
+                                disabled={!smartSave.isDirty || !!smartSave.inFlight}
+                                type="button"
+                                onClick={smartSave.reset}
+                            >
+                                <FaUndo className="text-[8px]" /> Reset
                             </button>
-                        ) : (
-                            <div />
-                        )}
-                        <button className="nitro-catalog-admin-button is-primary" disabled={!interaction.canSave || !!validationError} onClick={handleSave}>
-                            {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
-                            {isNew ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
-                        </button>
+                            <button
+                                className="nitro-catalog-admin-button is-muted"
+                                disabled={!canSubmit}
+                                type="button"
+                                onClick={() => handleSave(true)}
+                            >
+                                Save and close
+                            </button>
+                            <button
+                                className="nitro-catalog-admin-button is-primary"
+                                disabled={!canSubmit}
+                                type="button"
+                                onClick={() => handleSave(false)}
+                            >
+                                {smartSave.status === 'saving' ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
+                                {isNewOffer ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminPageEditView.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect, useRef, useState } from 'react';
-import { FaLanguage, FaSave, FaSpinner, FaTrash } from 'react-icons/fa';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FaLanguage, FaSave, FaSpinner, FaTrash, FaUndo } from 'react-icons/fa';
 import { CatalogType, LocalizeText, localizeWithFallback } from '../../../../api';
 import { useCatalogData, useCatalogUiState, useTranslationActions, useTranslationState } from '../../../../hooks';
 import { CATALOG_ROOT_LOCK_ID, IEditingPageDetails, IPageEditData, useCatalogAdmin } from '../../CatalogAdminContext';
@@ -8,6 +8,8 @@ import { CatalogIconView } from '../catalog-icon/CatalogIconView';
 import { CatalogAdminModalView } from './CatalogAdminModalView';
 import { useCatalogStudio } from '../../admin/studio/useCatalogStudio';
 import { claimCatalogAdminHydration } from './CatalogAdminFormHydration';
+import { createCatalogAdminPageDetailsFromSnapshot } from './CatalogAdminPageState';
+import { useCatalogAdminSmartSave } from './useCatalogAdminSmartSave';
 
 const LAYOUT_OPTIONS = [
     'default_3x3',
@@ -130,7 +132,18 @@ export const createCatalogAdminNewPageFormState = (parentId: number, catalogMode
     minRank: 1,
     orderNum,
     visible: '1',
-    enabled: '1'
+    enabled: '1',
+    clubOnly: '0',
+    vipOnly: '0',
+    pageHeadline: '',
+    pageTeaser: '',
+    pageSpecial: '',
+    pageText1: '',
+    pageText2: '',
+    pageTextDetails: '',
+    pageTextTeaser: '',
+    roomId: 0,
+    includes: ''
 });
 
 export const validateCatalogAdminPageForm = (data: IPageEditData): string | null => {
@@ -161,32 +174,11 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const requestPageDetails = catalogAdmin?.requestPageDetails;
     const loading = catalogAdmin?.loading ?? false;
     const lastError = catalogAdmin?.lastError ?? null;
+    const lastMutationResult = catalogAdmin?.lastMutationResult ?? null;
     const studioSessionReady = catalogAdmin?.studioSessionReady ?? false;
     const ensurePageLock = catalogAdmin?.ensurePageLock;
     const hasPageLock = catalogAdmin?.hasPageLock;
 
-    const [caption, setCaption] = useState('');
-    const [captionSave, setCaptionSave] = useState('');
-    const [catalogMode, setCatalogMode] = useState<string>('NORMAL');
-    const [pageLayout, setPageLayout] = useState('default_3x3');
-    const [iconColor, setIconColor] = useState(1);
-    const [iconImage, setIconImage] = useState(0);
-    const [minRank, setMinRank] = useState(1);
-    const [visible, setVisible] = useState('1');
-    const [enabled, setEnabled] = useState('1');
-    const [orderNum, setOrderNum] = useState(0);
-    const [parentId, setParentId] = useState(-1);
-    const [clubOnly, setClubOnly] = useState('0');
-    const [vipOnly, setVipOnly] = useState('0');
-    const [pageHeadline, setPageHeadline] = useState('');
-    const [pageTeaser, setPageTeaser] = useState('');
-    const [pageSpecial, setPageSpecial] = useState('');
-    const [pageText1, setPageText1] = useState('');
-    const [pageText2, setPageText2] = useState('');
-    const [pageTextDetails, setPageTextDetails] = useState('');
-    const [pageTextTeaser, setPageTextTeaser] = useState('');
-    const [roomId, setRoomId] = useState(0);
-    const [includes, setIncludes] = useState('');
     const [showTranslate, setShowTranslate] = useState(false);
     const [translateTargetLanguage, setTranslateTargetLanguage] = useState('en');
     const [isTranslating, setIsTranslating] = useState(false);
@@ -194,6 +186,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const initializationClaimRef = useRef({ current: null as string | null });
     const detailsClaimRef = useRef({ current: null as string | null });
     const requestClaimRef = useRef({ current: null as string | null });
+    const captionInputRef = useRef<HTMLInputElement>(null);
     const { supportedLanguages = [], languagesLoading = false } = useTranslationState();
     const { translateText, ensureSupportedLanguagesLoaded } = useTranslationActions();
     const targetNode = editingPageNode ? editingPageNode : editingRootPage ? rootNode : activeNodes.length > 0 ? activeNodes[activeNodes.length - 1] : null;
@@ -201,19 +194,65 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     const targetPageId = targetNode?.pageId ?? currentPage?.pageId;
     const isRoot = editingRootPage;
     const pageCatalogMode = currentType === CatalogType.BUILDER ? 'BUILDER' : 'NORMAL';
-    const formTargetKey = editingPageData && targetNode
-        ? `page:${pageCatalogMode}:${creatingPage ? 'new' : 'edit'}:${creatingPage ? targetNode.pageId : targetPageId}`
-        : null;
-    const lockPageId = creatingPage
-        ? targetNode && targetNode.pageId > 0 ? targetNode.pageId : CATALOG_ROOT_LOCK_ID
-        : targetPageId;
-
-    const closeForm = () => {
+    const closeForm = useCallback(() => {
         catalogAdmin?.setEditingPageData(false);
         catalogAdmin?.setEditingRootPage(false);
         catalogAdmin?.setEditingPageNode(null);
         catalogAdmin?.setCreatingPage(false);
-    };
+    }, [catalogAdmin]);
+
+    const smartSave = useCatalogAdminSmartSave<IPageEditData>({
+        initial: createCatalogAdminNewPageFormState(-1, pageCatalogMode),
+        acknowledgement: lastMutationResult,
+        submit: draft => draft.pageId == null
+            ? catalogAdmin?.createPage(draft) ?? null
+            : catalogAdmin?.savePage(draft) ?? null,
+        canSubmit: draft => {
+            const draftLockId = draft.pageId ?? (targetNode && targetNode.pageId > 0 ? targetNode.pageId : CATALOG_ROOT_LOCK_ID);
+            return studioSessionReady && (hasPageLock?.(draftLockId) ?? false) && !validateCatalogAdminPageForm(draft);
+        },
+        toCommitted: acknowledgement => acknowledgement.entity
+            ? createCatalogAdminPageFormState(createCatalogAdminPageDetailsFromSnapshot(acknowledgement.entity as any))
+            : null,
+        onClose: closeForm
+    });
+    const {
+        caption, captionSave, catalogMode, pageLayout, iconColor, iconImage, minRank, visible, enabled,
+        orderNum, parentId, clubOnly = '0', vipOnly = '0', pageHeadline = '', pageTeaser = '',
+        pageSpecial = '', pageText1 = '', pageText2 = '', pageTextDetails = '', pageTextTeaser = '',
+        roomId = 0, includes = ''
+    } = smartSave.draft;
+    const patchForm = smartSave.patch;
+    const setCaption = (value: string) => patchForm({ caption: value });
+    const setCaptionSave = (value: string) => patchForm({ captionSave: value });
+    const setCatalogMode = (value: string) => patchForm({ catalogMode: value });
+    const setPageLayout = (value: string) => patchForm({ pageLayout: value });
+    const setIconColor = (value: number) => patchForm({ iconColor: value });
+    const setIconImage = (value: number) => patchForm({ iconImage: value });
+    const setMinRank = (value: number) => patchForm({ minRank: value });
+    const setVisible = (value: string) => patchForm({ visible: value });
+    const setEnabled = (value: string) => patchForm({ enabled: value });
+    const setOrderNum = (value: number) => patchForm({ orderNum: value });
+    const setParentId = (value: number) => patchForm({ parentId: value });
+    const setClubOnly = (value: string) => patchForm({ clubOnly: value });
+    const setVipOnly = (value: string) => patchForm({ vipOnly: value });
+    const setPageHeadline = (value: string) => patchForm({ pageHeadline: value });
+    const setPageTeaser = (value: string) => patchForm({ pageTeaser: value });
+    const setPageSpecial = (value: string) => patchForm({ pageSpecial: value });
+    const setPageText1 = (value: string) => patchForm({ pageText1: value });
+    const setPageText2 = (value: string) => patchForm({ pageText2: value });
+    const setPageTextDetails = (value: string) => patchForm({ pageTextDetails: value });
+    const setPageTextTeaser = (value: string) => patchForm({ pageTextTeaser: value });
+    const setRoomId = (value: number) => patchForm({ roomId: value });
+    const setIncludes = (value: string) => patchForm({ includes: value });
+    const effectivePageId = smartSave.draft.pageId ?? targetPageId;
+    const isNewPage = creatingPage && smartSave.baseline.pageId == null;
+    const formTargetKey = editingPageData && targetNode
+        ? `page:${pageCatalogMode}:${creatingPage ? 'new' : 'edit'}:${creatingPage ? targetNode.pageId : targetPageId}`
+        : null;
+    const lockPageId = isNewPage
+        ? targetNode && targetNode.pageId > 0 ? targetNode.pageId : CATALOG_ROOT_LOCK_ID
+        : effectivePageId;
 
     useEffect(() => {
         if (!editingPageData || !targetNode) {
@@ -237,53 +276,27 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                 .map((page) => page.orderNum);
             const nextOrder = siblingOrders.length ? Math.max(...siblingOrders) + 1 : 0;
             const form = createCatalogAdminNewPageFormState(parentId, mode, nextOrder);
-            setCaption(form.caption);
-            setCaptionSave(form.captionSave);
-            setCatalogMode(form.catalogMode);
-            setPageLayout(form.pageLayout);
-            setIconColor(form.iconColor);
-            setIconImage(form.iconImage);
-            setMinRank(form.minRank);
-            setOrderNum(form.orderNum);
-            setParentId(form.parentId);
-            setVisible(form.visible);
-            setEnabled(form.enabled);
-            setClubOnly(form.clubOnly || '0');
-            setVipOnly(form.vipOnly || '0');
-            setPageHeadline('');
-            setPageTeaser('');
-            setPageSpecial('');
-            setPageText1('');
-            setPageText2('');
-            setPageTextDetails('');
-            setPageTextTeaser('');
-            setRoomId(0);
-            setIncludes('');
+            smartSave.hydrate(form);
             setShowTranslate(false);
             setIsTranslating(false);
             setTranslateError(null);
             return;
         }
 
-        setCaption('');
-        setCaptionSave('');
-        setMinRank(1);
-        setOrderNum(0);
-        setEnabled('1');
-
-        setCatalogMode(pageCatalogMode);
-        setPageLayout('default_3x3');
-        setIconImage(targetNode.iconId ?? 0);
-        setVisible(targetNode.isVisible ? '1' : '0');
-
-        setPageText1('');
+        const wireParentId = targetNode.parentId;
+        smartSave.hydrate({
+            ...createCatalogAdminNewPageFormState(
+                typeof wireParentId === 'number' && wireParentId !== -1 ? wireParentId : targetNode.parent ? targetNode.parent.pageId : -1,
+                pageCatalogMode
+            ),
+            pageId: targetPageId,
+            iconImage: targetNode.iconId ?? 0,
+            visible: targetNode.isVisible ? '1' : '0'
+        });
         setShowTranslate(false);
         setIsTranslating(false);
         setTranslateError(null);
-        const wireParentId = targetNode.parentId;
-        setParentId(typeof wireParentId === 'number' && wireParentId !== -1 ? wireParentId : targetNode.parent ? targetNode.parent.pageId : -1);
-
-    }, [editingPageData, creatingPage, targetNode, formTargetKey, pageCatalogMode, studio.session]);
+    }, [editingPageData, creatingPage, targetNode, formTargetKey, pageCatalogMode, studio.session, smartSave.hydrate, targetPageId]);
 
     useEffect(() => {
         if (!editingPageData || creatingPage || targetPageId == null || targetPageId < 0) {
@@ -313,29 +326,12 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
         if (!claimCatalogAdminHydration(detailsClaimRef.current, `${formTargetKey}:details`)) return;
 
         const form = createCatalogAdminPageFormState(editingPageDetails);
-        setCaption(form.caption);
-        setCaptionSave(form.captionSave);
-        setCatalogMode(form.catalogMode);
-        setPageLayout(form.pageLayout);
-        setIconColor(form.iconColor);
-        setIconImage(form.iconImage);
-        setMinRank(form.minRank);
-        setOrderNum(form.orderNum);
-        setParentId(form.parentId);
-        setVisible(form.visible);
-        setEnabled(form.enabled);
-        setClubOnly(form.clubOnly || '0');
-        setVipOnly(form.vipOnly || '0');
-        setPageHeadline(form.pageHeadline || '');
-        setPageTeaser(form.pageTeaser || '');
-        setPageSpecial(form.pageSpecial || '');
-        setPageText1(form.pageText1 || '');
-        setPageText2(form.pageText2 || '');
-        setPageTextDetails(form.pageTextDetails || '');
-        setPageTextTeaser(form.pageTextTeaser || '');
-        setRoomId(form.roomId || 0);
-        setIncludes(form.includes || '');
-    }, [editingPageDetails, formTargetKey, targetPageId]);
+        smartSave.hydrate(form);
+    }, [editingPageDetails, formTargetKey, smartSave.hydrate, targetPageId]);
+
+    useEffect(() => {
+        if (smartSave.fieldErrors.caption) captionInputRef.current?.focus();
+    }, [smartSave.fieldErrors.caption]);
 
     if (!editingPageData || !targetNode) return null;
 
@@ -347,42 +343,30 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
         targetNode.pageName,
         localizeWithFallback('catalog.admin.page.untitled', 'Untitled page')
     );
-    const detailsReady = creatingPage || editingPageDetails?.pageId === targetPageId;
+    const detailsReady = isNewPage || editingPageDetails?.pageId === effectivePageId;
     const lockReady = lockPageId != null && lockPageId >= 0 && (hasPageLock?.(lockPageId) ?? false);
-    const interaction = resolveCatalogAdminPageInteraction(studioSessionReady, detailsReady, lockReady, loading, lastError);
-    const formData: IPageEditData = {
-        pageId: creatingPage ? undefined : targetPageId,
-        caption,
-        captionSave,
-        catalogMode,
-        pageLayout,
-        iconColor,
-        iconImage,
-        minRank,
-        visible,
-        enabled,
-        orderNum,
-        parentId,
-        clubOnly,
-        vipOnly,
-        pageHeadline,
-        pageTeaser,
-        pageSpecial,
-        pageText1,
-        pageText2,
-        pageTextDetails,
-        pageTextTeaser,
-        roomId,
-        includes
-    };
+    const smartSaveError = lastMutationResult?.success === false ? null : lastError;
+    const interaction = resolveCatalogAdminPageInteraction(
+        studioSessionReady, detailsReady, lockReady, loading && smartSave.status !== 'saving', smartSaveError);
+    const formData = smartSave.draft;
     const validationError = detailsReady ? validateCatalogAdminPageForm(formData) : null;
+    const saveStatusText = smartSave.status === 'saving'
+        ? 'Saving...'
+        : smartSave.status === 'dirty'
+          ? 'Unsaved changes'
+          : smartSave.status === 'conflict'
+            ? (smartSave.message || 'The catalog changed. Review and save again.')
+            : smartSave.status === 'error'
+              ? (smartSave.message || 'Save failed')
+              : smartSave.lastSavedAt
+                ? `Saved · ${new Date(smartSave.lastSavedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+                : 'Saved';
+    const canSubmit = interaction.canSave && !validationError && (smartSave.isDirty || !!smartSave.inFlight);
 
-    const handleSave = async () => {
+    const handleSave = (closeAfter = false) => {
         if (!catalogAdmin?.savePage || !catalogAdmin.createPage || !interaction.canSave) return;
         if (validationError) return;
-
-        if (creatingPage) catalogAdmin.createPage(formData);
-        else catalogAdmin.savePage(formData);
+        smartSave.save(closeAfter);
     };
 
     const openTranslate = () => {
@@ -418,7 +402,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     };
 
     const handleDelete = async () => {
-        if (!catalogAdmin?.deletePage || isRoot || creatingPage) return;
+        if (!catalogAdmin?.deletePage || isRoot || isNewPage) return;
         if (!confirm(LocalizeText('catalog.admin.delete.page.confirm', ['name'], [editingPageDetails?.caption ?? '']))) return;
 
         catalogAdmin.deletePage(targetPageId);
@@ -428,14 +412,14 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
     return (
         <CatalogAdminModalView
             title={
-                creatingPage
+                isNewPage
                     ? localizeWithFallback('catalog.admin.create.page', 'Create page')
                     : isRoot
                       ? LocalizeText('catalog.admin.edit.root')
                       : localizeWithFallback('catalog.admin.edit.page', 'Edit page')
             }
             widthClassName="w-[540px]"
-            onClose={closeForm}
+            onClose={smartSave.requestClose}
         >
             <div className="nitro-catalog-admin-form">
                 <div className="nitro-catalog-admin-form-sheet">
@@ -447,7 +431,7 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                     {previewName}
                                 </span>
                                 <span className="nitro-catalog-admin-page-preview-sub">
-                                    {localizeWithFallback('catalog.admin.page.id', 'Page ID')} {targetPageId ?? '—'} · {pageLayout} · {catalogMode}
+                                    {localizeWithFallback('catalog.admin.page.id', 'Page ID')} {effectivePageId ?? '—'} · {pageLayout} · {catalogMode}
                                 </span>
                             </div>
                         </div>
@@ -459,7 +443,8 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                                     <label className="nitro-catalog-admin-label is-field">
                                         {localizeWithFallback('catalog.admin.page.caption', 'Caption')}
                                     </label>
-                                    <input className={inputClass} value={caption} onChange={(e) => setCaption(e.target.value)} />
+                                    <input ref={captionInputRef} aria-invalid={!!smartSave.fieldErrors.caption} className={inputClass} value={caption} onChange={(e) => setCaption(e.target.value)} />
+                                    {smartSave.fieldErrors.caption && <span className="nitro-catalog-admin-field-error">{smartSave.fieldErrors.caption}</span>}
                                 </div>
                                 <div className="nitro-catalog-admin-form-field is-span-2">
                                     <label className="nitro-catalog-admin-label is-field">
@@ -708,24 +693,43 @@ export const CatalogAdminPageEditView: FC<{}> = () => {
                         </section>
                     </div>
 
-                    <div className="nitro-catalog-admin-form-actions">
-                        {(validationError || lastError) && (
-                            <span className="nitro-catalog-admin-translate-error">{validationError || lastError}</span>
-                        )}
-                        {!validationError && !lastError && interaction.message && (
-                            <span className="nitro-catalog-admin-form-status">{interaction.message}</span>
-                        )}
-                        {!isRoot && !creatingPage ? (
-                            <button className="nitro-catalog-admin-button is-danger" onClick={handleDelete}>
-                                <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
+                    <div className={`nitro-catalog-admin-savebar is-${smartSave.status}`}>
+                        <div className="nitro-catalog-admin-savebar-status" aria-live="polite">
+                            <span>{validationError || smartSave.message || interaction.message || saveStatusText}</span>
+                            <small>Ctrl+S</small>
+                        </div>
+                        <div className="nitro-catalog-admin-savebar-actions">
+                            {!isRoot && !isNewPage && (
+                                <button className="nitro-catalog-admin-button is-danger" type="button" onClick={handleDelete}>
+                                    <FaTrash className="text-[8px]" /> {LocalizeText('catalog.admin.delete')}
+                                </button>
+                            )}
+                            <button
+                                className="nitro-catalog-admin-button is-muted"
+                                disabled={!smartSave.isDirty || !!smartSave.inFlight}
+                                type="button"
+                                onClick={smartSave.reset}
+                            >
+                                <FaUndo className="text-[8px]" /> Reset
                             </button>
-                        ) : (
-                            <div />
-                        )}
-                        <button className="nitro-catalog-admin-button is-primary" disabled={!interaction.canSave || !!validationError} onClick={handleSave}>
-                            {loading ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
-                            {creatingPage ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
-                        </button>
+                            <button
+                                className="nitro-catalog-admin-button is-muted"
+                                disabled={!canSubmit}
+                                type="button"
+                                onClick={() => handleSave(true)}
+                            >
+                                Save and close
+                            </button>
+                            <button
+                                className="nitro-catalog-admin-button is-primary"
+                                disabled={!canSubmit}
+                                type="button"
+                                onClick={() => handleSave(false)}
+                            >
+                                {smartSave.status === 'saving' ? <FaSpinner className="text-[8px] animate-spin" /> : <FaSave className="text-[8px]" />}{' '}
+                                {isNewPage ? LocalizeText('catalog.admin.create') : LocalizeText('catalog.admin.save')}
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/catalog/views/admin/CatalogAdminSmartSaveState.test.ts
+++ b/src/components/catalog/views/admin/CatalogAdminSmartSaveState.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { catalogAdminSmartSaveReducer, createCatalogAdminSmartSaveState, isCatalogAdminFormDirty, mergeCatalogAdminCommittedForm } from './CatalogAdminSmartSaveState';
+
+interface FormState
+{
+    caption: string;
+    minRank: number;
+}
+
+describe('CatalogAdminSmartSaveState', () =>
+{
+    it('tracks edits and restores the authoritative baseline', () =>
+    {
+        const initial = createCatalogAdminSmartSaveState<FormState>({ caption: 'Original', minRank: 1 });
+        const dirty = catalogAdminSmartSaveReducer(initial, { type: 'patch', patch: { caption: 'Edited' } });
+        const reset = catalogAdminSmartSaveReducer(dirty, { type: 'reset' });
+
+        expect(dirty.status).toBe('dirty');
+        expect(isCatalogAdminFormDirty(dirty.baseline, dirty.draft)).toBe(true);
+        expect(reset.draft).toEqual({ caption: 'Original', minRank: 1 });
+        expect(reset.status).toBe('saved');
+    });
+
+    it('preserves edits made after submit while applying server normalization', () =>
+    {
+        const submitted = { caption: 'First', minRank: 1 };
+        const current = { caption: 'Second', minRank: 1 };
+        const committed = { caption: 'First', minRank: 2 };
+
+        expect(mergeCatalogAdminCommittedForm(submitted, current, committed)).toEqual({
+            caption: 'Second',
+            minRank: 2
+        });
+    });
+
+    it('acknowledges only the matching operation and keeps a newer draft dirty', () =>
+    {
+        let state = createCatalogAdminSmartSaveState<FormState>({ caption: 'Original', minRank: 1 });
+        state = catalogAdminSmartSaveReducer(state, { type: 'patch', patch: { caption: 'First' } });
+        state = catalogAdminSmartSaveReducer(state, {
+            type: 'submit', operationId: 'save-page-1', submitted: state.draft, closeAfter: false
+        });
+        state = catalogAdminSmartSaveReducer(state, { type: 'patch', patch: { caption: 'Second' } });
+
+        const unmatched = catalogAdminSmartSaveReducer(state, {
+            type: 'success', operationId: 'other', committed: { caption: 'First', minRank: 2 }, savedAt: 10
+        });
+        const acknowledged = catalogAdminSmartSaveReducer(state, {
+            type: 'success', operationId: 'save-page-1', committed: { caption: 'First', minRank: 2 }, savedAt: 10
+        });
+
+        expect(unmatched).toBe(state);
+        expect(acknowledged.draft).toEqual({ caption: 'Second', minRank: 2 });
+        expect(acknowledged.baseline).toEqual({ caption: 'First', minRank: 2 });
+        expect(acknowledged.status).toBe('dirty');
+        expect(acknowledged.lastSavedAt).toBe(10);
+    });
+
+    it('queues a save intent and exposes validation or conflict feedback', () =>
+    {
+        let state = createCatalogAdminSmartSaveState<FormState>({ caption: 'Original', minRank: 1 });
+        state = catalogAdminSmartSaveReducer(state, { type: 'patch', patch: { caption: 'Edited' } });
+        state = catalogAdminSmartSaveReducer(state, {
+            type: 'submit', operationId: 'save-page-1', submitted: state.draft, closeAfter: false
+        });
+        state = catalogAdminSmartSaveReducer(state, { type: 'queue', closeAfter: true });
+        const failed = catalogAdminSmartSaveReducer(state, {
+            type: 'failure', operationId: 'save-page-1', message: 'Invalid', fieldErrors: { caption: 'Required' }
+        });
+
+        expect(state.queued).toEqual({ closeAfter: true });
+        expect(failed.status).toBe('error');
+        expect(failed.fieldErrors.caption).toBe('Required');
+
+        const resubmitted = catalogAdminSmartSaveReducer(failed, {
+            type: 'submit', operationId: 'save-page-2', submitted: failed.draft, closeAfter: false
+        });
+        const conflict = catalogAdminSmartSaveReducer(resubmitted, {
+            type: 'conflict', operationId: 'save-page-2', message: 'Revision changed'
+        });
+        expect(conflict.status).toBe('conflict');
+    });
+});

--- a/src/components/catalog/views/admin/CatalogAdminSmartSaveState.ts
+++ b/src/components/catalog/views/admin/CatalogAdminSmartSaveState.ts
@@ -1,0 +1,139 @@
+export type CatalogAdminSaveStatus = 'saved' | 'dirty' | 'saving' | 'error' | 'conflict';
+
+export interface CatalogAdminSmartSaveState<T>
+{
+    baseline: T;
+    draft: T;
+    inFlight: { operationId: string; submitted: T; closeAfter: boolean } | null;
+    queued: { closeAfter: boolean } | null;
+    status: CatalogAdminSaveStatus;
+    lastSavedAt: number | null;
+    message: string | null;
+    fieldErrors: Record<string, string>;
+}
+
+export type CatalogAdminSmartSaveAction<T> =
+    | { type: 'hydrate'; value: T }
+    | { type: 'patch'; patch: Partial<T> }
+    | { type: 'submit'; operationId: string; submitted: T; closeAfter: boolean }
+    | { type: 'queue'; closeAfter: boolean }
+    | { type: 'success'; operationId: string; committed: T; savedAt: number; message?: string | null }
+    | { type: 'failure'; operationId: string; message: string; fieldErrors: Record<string, string> }
+    | { type: 'conflict'; operationId: string; message: string }
+    | { type: 'reset' };
+
+export const isCatalogAdminFormDirty = <T extends object>(baseline: T, draft: T): boolean =>
+{
+    const baselineKeys = Object.keys(baseline).sort();
+    const draftKeys = Object.keys(draft).sort();
+    if(baselineKeys.length !== draftKeys.length) return true;
+    for(let index = 0; index < baselineKeys.length; index++)
+    {
+        if(baselineKeys[index] !== draftKeys[index]) return true;
+        const key = baselineKeys[index] as keyof T;
+        if(!Object.is(baseline[key], draft[key])) return true;
+    }
+    return false;
+};
+
+export const mergeCatalogAdminCommittedForm = <T extends object>(submitted: T, current: T, committed: T): T =>
+{
+    const merged = { ...current };
+    for(const key of Object.keys(committed) as (keyof T)[])
+    {
+        if(Object.is(current[key], submitted[key])) merged[key] = committed[key];
+    }
+    return merged;
+};
+
+export const createCatalogAdminSmartSaveState = <T extends object>(initial: T): CatalogAdminSmartSaveState<T> => ({
+    baseline: { ...initial },
+    draft: { ...initial },
+    inFlight: null,
+    queued: null,
+    status: 'saved',
+    lastSavedAt: null,
+    message: null,
+    fieldErrors: {}
+});
+
+export const catalogAdminSmartSaveReducer = <T extends object>(
+    state: CatalogAdminSmartSaveState<T>,
+    action: CatalogAdminSmartSaveAction<T>): CatalogAdminSmartSaveState<T> =>
+{
+    switch(action.type)
+    {
+        case 'hydrate':
+            return createCatalogAdminSmartSaveState(action.value);
+        case 'patch':
+        {
+            const draft = { ...state.draft, ...action.patch };
+            return {
+                ...state,
+                draft,
+                status: state.inFlight ? 'saving' : (isCatalogAdminFormDirty(state.baseline, draft) ? 'dirty' : 'saved'),
+                message: null,
+                fieldErrors: {}
+            };
+        }
+        case 'submit':
+            return {
+                ...state,
+                inFlight: {
+                    operationId: action.operationId,
+                    submitted: { ...action.submitted },
+                    closeAfter: action.closeAfter
+                },
+                queued: null,
+                status: 'saving',
+                message: null,
+                fieldErrors: {}
+            };
+        case 'queue':
+            return state.inFlight ? { ...state, queued: { closeAfter: action.closeAfter } } : state;
+        case 'success':
+        {
+            if(state.inFlight?.operationId !== action.operationId) return state;
+            const draft = mergeCatalogAdminCommittedForm(state.inFlight.submitted, state.draft, action.committed);
+            return {
+                ...state,
+                baseline: { ...action.committed },
+                draft,
+                inFlight: null,
+                status: isCatalogAdminFormDirty(action.committed, draft) ? 'dirty' : 'saved',
+                lastSavedAt: action.savedAt,
+                message: action.message ?? null,
+                fieldErrors: {}
+            };
+        }
+        case 'failure':
+            if(state.inFlight?.operationId !== action.operationId) return state;
+            return {
+                ...state,
+                inFlight: null,
+                queued: null,
+                status: 'error',
+                message: action.message,
+                fieldErrors: { ...action.fieldErrors }
+            };
+        case 'conflict':
+            if(state.inFlight?.operationId !== action.operationId) return state;
+            return {
+                ...state,
+                inFlight: null,
+                queued: null,
+                status: 'conflict',
+                message: action.message,
+                fieldErrors: {}
+            };
+        case 'reset':
+            return {
+                ...state,
+                draft: { ...state.baseline },
+                queued: null,
+                status: 'saved',
+                message: null,
+                fieldErrors: {}
+            };
+    }
+};

--- a/src/components/catalog/views/admin/useCatalogAdminSmartSave.test.tsx
+++ b/src/components/catalog/views/admin/useCatalogAdminSmartSave.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useCatalogAdminSmartSave } from './useCatalogAdminSmartSave';
+
+interface FormState
+{
+    caption: string;
+    minRank: number;
+}
+
+describe('useCatalogAdminSmartSave', () =>
+{
+    it('keeps edits made while a matching save is in flight', () =>
+    {
+        const submit = vi.fn(() => 'save-1');
+        const { result, rerender } = renderHook(
+            ({ acknowledgement }) => useCatalogAdminSmartSave<FormState>({
+                initial: { caption: 'Original', minRank: 1 },
+                acknowledgement,
+                submit,
+                toCommitted: value => value.entity as FormState
+            }),
+            { initialProps: { acknowledgement: null as any } }
+        );
+
+        act(() => result.current.patch({ caption: 'First' }));
+        act(() => result.current.save());
+        act(() => result.current.patch({ caption: 'Second' }));
+        rerender({
+            acknowledgement: {
+                operationId: 'save-1', success: true, code: 'SAVED', message: 'Saved',
+                entity: { caption: 'First', minRank: 2 }, fieldErrors: {}, acknowledgedAt: 100
+            }
+        });
+
+        expect(result.current.draft).toEqual({ caption: 'Second', minRank: 2 });
+        expect(result.current.status).toBe('dirty');
+    });
+
+    it('queues the latest draft and closes only after its acknowledgement', () =>
+    {
+        let sequence = 0;
+        const submit = vi.fn(() => `save-${++sequence}`);
+        const close = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ acknowledgement }) => useCatalogAdminSmartSave<FormState>({
+                initial: { caption: 'Original', minRank: 1 }, acknowledgement, submit, onClose: close,
+                toCommitted: value => value.entity as FormState
+            }),
+            { initialProps: { acknowledgement: null as any } }
+        );
+
+        act(() => result.current.patch({ caption: 'First' }));
+        act(() => result.current.save());
+        act(() => result.current.patch({ caption: 'Second' }));
+        act(() => result.current.save(true));
+        expect(submit).toHaveBeenCalledTimes(1);
+
+        rerender({ acknowledgement: {
+            operationId: 'save-1', success: true, code: 'SAVED', message: 'Saved',
+            entity: { caption: 'First', minRank: 1 }, fieldErrors: {}, acknowledgedAt: 100
+        } });
+        expect(submit).toHaveBeenCalledTimes(2);
+        expect(close).not.toHaveBeenCalled();
+
+        rerender({ acknowledgement: {
+            operationId: 'save-2', success: true, code: 'SAVED', message: 'Saved',
+            entity: { caption: 'Second', minRank: 1 }, fieldErrors: {}, acknowledgedAt: 200
+        } });
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes field errors and guards a dirty close', () =>
+    {
+        const confirmClose = vi.fn(() => false);
+        const close = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ acknowledgement }) => useCatalogAdminSmartSave<FormState>({
+                initial: { caption: 'Original', minRank: 1 }, acknowledgement,
+                submit: () => 'save-1', onClose: close, confirmClose,
+                toCommitted: value => value.entity as FormState
+            }),
+            { initialProps: { acknowledgement: null as any } }
+        );
+
+        act(() => result.current.patch({ caption: '' }));
+        act(() => result.current.requestClose());
+        expect(confirmClose).toHaveBeenCalledTimes(1);
+        expect(close).not.toHaveBeenCalled();
+
+        act(() => result.current.save());
+        rerender({ acknowledgement: {
+            operationId: 'save-1', success: false, code: 'VALIDATION_FAILED', message: 'Invalid',
+            entity: null, fieldErrors: { caption: 'Required' }, acknowledgedAt: 100
+        } });
+        expect(result.current.fieldErrors.caption).toBe('Required');
+        expect(result.current.status).toBe('error');
+    });
+
+    it('does not submit through the keyboard when the current draft is invalid', () =>
+    {
+        const submit = vi.fn(() => 'save-1');
+        const { result } = renderHook(() => useCatalogAdminSmartSave<FormState>({
+            initial: { caption: 'Original', minRank: 1 }, acknowledgement: null, submit,
+            canSubmit: draft => draft.caption.trim().length > 0,
+            toCommitted: value => value.entity as FormState
+        }));
+        act(() => result.current.patch({ caption: '' }));
+        act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true, cancelable: true })));
+        expect(submit).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/catalog/views/admin/useCatalogAdminSmartSave.ts
+++ b/src/components/catalog/views/admin/useCatalogAdminSmartSave.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import {
+    catalogAdminSmartSaveReducer,
+    createCatalogAdminSmartSaveState,
+    isCatalogAdminFormDirty,
+    mergeCatalogAdminCommittedForm
+} from './CatalogAdminSmartSaveState';
+
+export interface CatalogAdminSaveAcknowledgement
+{
+    operationId: string;
+    success: boolean;
+    code: string;
+    message: string;
+    entity: unknown;
+    fieldErrors: Record<string, string>;
+    acknowledgedAt: number;
+}
+
+interface UseCatalogAdminSmartSaveOptions<T extends object>
+{
+    initial: T;
+    acknowledgement: CatalogAdminSaveAcknowledgement | null;
+    submit: (draft: T) => string | null;
+    canSubmit?: (draft: T) => boolean;
+    toCommitted: (acknowledgement: CatalogAdminSaveAcknowledgement) => T | null;
+    onClose?: () => void;
+    confirmClose?: () => boolean;
+}
+
+export const useCatalogAdminSmartSave = <T extends object>({
+    initial,
+    acknowledgement,
+    submit,
+    canSubmit = () => true,
+    toCommitted,
+    onClose,
+    confirmClose = () => window.confirm('Discard unsaved changes?')
+}: UseCatalogAdminSmartSaveOptions<T>) =>
+{
+    const [state, dispatch] = useReducer(catalogAdminSmartSaveReducer<T>, initial, createCatalogAdminSmartSaveState<T>);
+    const stateRef = useRef(state);
+    const submitRef = useRef(submit);
+    const canSubmitRef = useRef(canSubmit);
+    const closeRef = useRef(onClose);
+    const toCommittedRef = useRef(toCommitted);
+    stateRef.current = state;
+    submitRef.current = submit;
+    canSubmitRef.current = canSubmit;
+    closeRef.current = onClose;
+    toCommittedRef.current = toCommitted;
+
+    const patch = useCallback((value: Partial<T>) => dispatch({ type: 'patch', patch: value }), []);
+    const hydrate = useCallback((value: T) => dispatch({ type: 'hydrate', value }), []);
+    const reset = useCallback(() => dispatch({ type: 'reset' }), []);
+
+    const save = useCallback((closeAfter = false) =>
+    {
+        const current = stateRef.current;
+        if(current.inFlight)
+        {
+            dispatch({ type: 'queue', closeAfter });
+            return current.inFlight.operationId;
+        }
+        if(!isCatalogAdminFormDirty(current.baseline, current.draft))
+        {
+            if(closeAfter) closeRef.current?.();
+            return null;
+        }
+        if(!canSubmitRef.current(current.draft)) return null;
+
+        const operationId = submitRef.current(current.draft);
+        if(!operationId) return null;
+        dispatch({ type: 'submit', operationId, submitted: current.draft, closeAfter });
+        return operationId;
+    }, []);
+
+    const requestClose = useCallback(() =>
+    {
+        const current = stateRef.current;
+        if((current.inFlight || isCatalogAdminFormDirty(current.baseline, current.draft)) && !confirmClose()) return;
+        closeRef.current?.();
+    }, [confirmClose]);
+
+    useEffect(() =>
+    {
+        if(!acknowledgement) return;
+        const current = stateRef.current;
+        const inFlight = current.inFlight;
+        if(!inFlight || inFlight.operationId !== acknowledgement.operationId) return;
+
+        if(!acknowledgement.success)
+        {
+            if(acknowledgement.code === 'STALE_REVISION')
+                dispatch({ type: 'conflict', operationId: acknowledgement.operationId, message: acknowledgement.message });
+            else
+                dispatch({
+                    type: 'failure',
+                    operationId: acknowledgement.operationId,
+                    message: acknowledgement.message,
+                    fieldErrors: acknowledgement.fieldErrors
+                });
+            return;
+        }
+
+        const committed = toCommittedRef.current(acknowledgement);
+        if(!committed)
+        {
+            dispatch({
+                type: 'failure', operationId: acknowledgement.operationId,
+                message: acknowledgement.message || 'The server returned an incomplete save result.', fieldErrors: {}
+            });
+            return;
+        }
+
+        const merged = mergeCatalogAdminCommittedForm(inFlight.submitted, current.draft, committed);
+        const shouldClose = inFlight.closeAfter && !current.queued && !isCatalogAdminFormDirty(committed, merged);
+        dispatch({
+            type: 'success', operationId: acknowledgement.operationId, committed,
+            savedAt: acknowledgement.acknowledgedAt, message: acknowledgement.message
+        });
+        if(shouldClose) closeRef.current?.();
+    }, [acknowledgement]);
+
+    useEffect(() =>
+    {
+        if(state.inFlight || !state.queued) return;
+        if(!isCatalogAdminFormDirty(state.baseline, state.draft))
+        {
+            const closeAfter = state.queued.closeAfter;
+            dispatch({ type: 'reset' });
+            if(closeAfter) closeRef.current?.();
+            return;
+        }
+
+        if(!canSubmitRef.current(state.draft)) return;
+        const operationId = submitRef.current(state.draft);
+        if(!operationId) return;
+        dispatch({ type: 'submit', operationId, submitted: state.draft, closeAfter: state.queued.closeAfter });
+    }, [state.baseline, state.draft, state.inFlight, state.queued]);
+
+    useEffect(() =>
+    {
+        const handleKeyboardSave = (event: KeyboardEvent) =>
+        {
+            if(!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== 's') return;
+            event.preventDefault();
+            save(false);
+        };
+        window.addEventListener('keydown', handleKeyboardSave);
+        return () => window.removeEventListener('keydown', handleKeyboardSave);
+    }, [save]);
+
+    return {
+        ...state,
+        draft: state.draft,
+        isDirty: isCatalogAdminFormDirty(state.baseline, state.draft),
+        patch,
+        hydrate,
+        reset,
+        save,
+        requestClose
+    };
+};

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -485,6 +485,68 @@
     background: linear-gradient(180deg, var(--catalog-admin-panel-alt) 0%, #deded6 100%);
 }
 
+.nitro-catalog-admin-savebar {
+    display: flex;
+    flex-shrink: 0;
+    gap: 10px;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 52px;
+    padding: 8px 12px;
+    border-top: 1px solid #c9c9c0;
+    background: linear-gradient(180deg, var(--catalog-admin-panel-alt) 0%, #deded6 100%);
+}
+
+.nitro-catalog-admin-savebar-status {
+    display: flex;
+    flex-direction: column;
+    min-width: 112px;
+    color: #53606a;
+    font-size: 11px;
+    line-height: 1.15;
+}
+
+.nitro-catalog-admin-savebar-status small {
+    margin-top: 3px;
+    color: #88929a;
+    font-size: 9px;
+}
+
+.nitro-catalog-admin-savebar.is-dirty .nitro-catalog-admin-savebar-status { color: #865a05; }
+.nitro-catalog-admin-savebar.is-saving .nitro-catalog-admin-savebar-status { color: #296786; }
+.nitro-catalog-admin-savebar.is-error .nitro-catalog-admin-savebar-status,
+.nitro-catalog-admin-savebar.is-conflict .nitro-catalog-admin-savebar-status { color: #a83232; }
+.nitro-catalog-admin-savebar.is-saved .nitro-catalog-admin-savebar-status { color: #397046; }
+
+.nitro-catalog-admin-savebar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.nitro-catalog-admin-field-error {
+    color: #a83232;
+    font-size: 10px;
+    line-height: 1.2;
+}
+
+@media (max-width: 520px) {
+    .nitro-catalog-admin-savebar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .nitro-catalog-admin-savebar-actions {
+        justify-content: stretch;
+    }
+
+    .nitro-catalog-admin-savebar-actions .nitro-catalog-admin-button {
+        flex: 1 1 auto;
+    }
+}
+
 .nitro-catalog-admin-form .nitro-catalog-admin-input,
 .nitro-catalog-admin-form-sheet .nitro-catalog-admin-input {
     min-height: 28px;


### PR DESCRIPTION
## Summary
- correlate Catalog Admin saves by operation ID and apply committed Studio deltas without broad refreshes
- add lossless page and offer form state with in-flight snapshots, queued saves, three-way response merges, reset, and conflict feedback
- keep editors open after Save, support Save and close and Ctrl/Cmd+S, and guard dirty closes
- acquire the correct page and offer locks, including create-to-edit transitions
- retain broad refresh behavior for genuinely legacy operations

## Why
Catalog Studio editors could close or refresh broadly after every save, losing edits made while a response was in flight and making validation feedback difficult to recover from.

## User impact
Page and offer editing now behaves like a professional editor: saves are incremental, later typing is preserved, errors stay beside the relevant field, and normal saves do not close the modal.

## Validation
- Catalog Admin and Studio test suite
- `yarn typecheck`
- `yarn lint`
- `yarn lint:hooks`
- `yarn build`

## Companion PRs
- Emulator: https://github.com/duckietm/Polaris-Emulator/pull/566
- Renderer: https://github.com/duckietm/Nitro_Render_V3/pull/164
- UI: https://github.com/duckietm/Nitro-V3/pull/371
