### PR TITLE
chore(ci): use Node 24 action runtimes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,12 +42,12 @@ jobs:
 
     steps:
       - name: Checkout client
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: Nitro-V3
 
       - name: Checkout renderer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: duckethotel/ducket-render
           ref: main
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.DUCKET_REPO_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       # Mirror that here by checking the client into <workspace>/Nitro-V3
       # and the renderer into <workspace>/Nitro_Render_V3.
       - name: Checkout Nitro-V3
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: Nitro-V3
 
@@ -158,14 +158,14 @@ jobs:
           echo "Resolved renderer pairing: $REPO @ $REF (client ctx: $CTX, event: ${GITHUB_EVENT_NAME})"
 
       - name: Checkout Nitro_Render_V3 (sibling)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ steps.renderer.outputs.repo }}
           ref: ${{ steps.renderer.outputs.ref }}
           path: Nitro_Render_V3
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- upgrade the remaining `actions/checkout` usages from v4 to v7
- upgrade the remaining `actions/setup-node` usages from v4 to v6
- keep the project Node.js version and existing workflow behavior unchanged

## Why
The updated actions run natively on Node.js 24 and remove the non-blocking Node.js 20 action-runtime warning.

## Validation
- parsed all 3 workflow YAML files
- verified no legacy checkout v4, setup-node v4, or always-auth references remain

## Companion
- Renderer: https://github.com/duckietm/Nitro_Render_V3/pull/173