### PR TITLE
translation

### DIFF
--- a/public/configuration/renderer-config..jsonc.example.json
+++ b/public/configuration/renderer-config..jsonc.example.json
@@ -15,6 +15,7 @@
     "${gamedata.url}/ExternalTexts.json",
     "${gamedata.url}/UITexts.jsonc"
   ],
+  "base.locale": "en",
   "external.texts.translation.url": "${gamedata.url}/UITexts_%locale%.json?t=%timestamp%",
   "external.samples.url": "${hof.furni.url}/mp3/sound_machine_sample_%sample%.mp3",
   "furnidata.url": "${gamedata.url}/FurnitureData.json?t=%timestamp%",

--- a/public/configuration/renderer-config.json.example.json
+++ b/public/configuration/renderer-config.json.example.json
@@ -14,6 +14,7 @@
         "${gamedata.url}/ExternalTexts.json?t=%timestamp%",
         "${gamedata.url}/UITexts.jsonc?t=%timestamp%"
     ],
+	  "base.locale": "en",
     "external.texts.translation.url": "${gamedata.url}/text_translate/ExternalTexts_%locale%.json?t=%timestamp%",
     "external.samples.url": "${hof.furni.url}/mp3/sound_machine_sample_%sample%.mp3",
     "furnidata.url": "${gamedata.url}/FurnitureData.json?t=%timestamp%",

--- a/src/hooks/translation/useTranslation.ts
+++ b/src/hooks/translation/useTranslation.ts
@@ -202,9 +202,13 @@ export const applyTextTranslationLocale = async (languageCode: string): Promise<
         return;
     }
 
-    // English is already provided by the base ExternalTexts/UITexts files.
-    // Some local asset packs do not ship a redundant English override file.
-    if(selectedLocale.file === 'en')
+      // The base ExternalTexts/UITexts files are already written in one language,
+    // so loading an override pack for that same language would be redundant.
+    // Which language that is depends on the hotel: set `base.locale` in
+    // renderer-config.json (defaults to English).
+    const baseLocale = normalizeLanguageCode(GetConfiguration().getValue<string>('base.locale') || 'en') || 'en';
+
+    if(selectedLocale.file === baseLocale)
     {
         localizationManager.clearOverrideValues();
         sessionDataManager.clearFurnitureDataOverrides();


### PR DESCRIPTION
The client treated English as the base language. Picking "English" in the translation panel didn't load a pack — it just cleared the overrides and fell back to UITexts.json.

That works for an English hotel. Mine is French, so UITexts.json is French too, and selecting English kept showing French.
The line in useTranslation.ts:

if(selectedLocale.file === 'en') (L 204 i think)

I made it configurable instead:
const baseLocale = normalizeLanguageCode(GetConfiguration().getValue<string>('base.locale')  'en') 
 'en';
if(selectedLocale.file === baseLocale)

Then added to renderer-config.json: "base.locale": "fr" (for me)

French is now the base, and picking English properly loads UITexts_en.jsonc.example. Without the key nothing changes, so it's backwards compatible if you don't have the key in renderer, but inglish is only file read by default 