### PR TITLE
Catalog Studio: automate live reconciliation on publish

### DIFF
--- a/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
@@ -59,6 +59,7 @@ describe('Catalog Studio essential panels', () => {
             validationCurrent
             issues={[]}
             history={[ historyGroup ]}
+            publishResult={null}
             loading={false}
             publish={vi.fn()}
             undo={undo}
@@ -72,7 +73,7 @@ describe('Catalog Studio essential panels', () => {
         expect(undo).toHaveBeenCalledWith(1);
     });
 
-    it('shows publish only for pending changes and confirms before publishing', () => {
+    it('can check and publish external-only changes and confirms before publishing', () => {
         const publish = vi.fn();
         const view = render(<CatalogStudioPublishReview
             phase="clean"
@@ -80,12 +81,16 @@ describe('Catalog Studio essential panels', () => {
             validationCurrent
             issues={[]}
             history={[]}
+            publishResult={null}
             loading={false}
             publish={publish}
             undo={vi.fn()}
         />);
 
-        expect(screen.queryByRole('button', { name: /Publish/ })).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Check & publish' }));
+        expect(screen.getByText('Check live catalog and publish?')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Publish now' }));
+        expect(publish).toHaveBeenCalledTimes(1);
 
         view.rerender(<CatalogStudioPublishReview
             phase="ready"
@@ -93,6 +98,7 @@ describe('Catalog Studio essential panels', () => {
             validationCurrent
             issues={[]}
             history={[ historyGroup ]}
+            publishResult={null}
             loading={false}
             publish={publish}
             undo={vi.fn()}
@@ -100,8 +106,45 @@ describe('Catalog Studio essential panels', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Publish 3 changes' }));
         expect(screen.getByText('Publish 3 changes?')).toBeInTheDocument();
-        expect(publish).not.toHaveBeenCalled();
-        fireEvent.click(screen.getByRole('button', { name: 'Publish now' }));
         expect(publish).toHaveBeenCalledTimes(1);
+        fireEvent.click(screen.getByRole('button', { name: 'Publish now' }));
+        expect(publish).toHaveBeenCalledTimes(2);
+    });
+
+    it('shows automatically imported changes and field conflicts', () => {
+        const view = render(<CatalogStudioPublishReview
+            phase="clean"
+            pendingCount={0}
+            validationCurrent
+            issues={[]}
+            history={[]}
+            publishResult={{
+                operationId: 'publish-1', success: true, code: 'PUBLISHED', revision: 8,
+                message: 'Catalog published with 2 external database change(s)', importedChanges: 2, conflicts: []
+            }}
+            loading={false}
+            publish={vi.fn()}
+            undo={vi.fn()}
+        />);
+
+        expect(screen.getByText('2 external database changes imported automatically.')).toBeInTheDocument();
+
+        view.rerender(<CatalogStudioPublishReview
+            phase="clean"
+            pendingCount={0}
+            validationCurrent
+            issues={[]}
+            history={[]}
+            publishResult={{
+                operationId: 'publish-2', success: false, code: 'LIVE_SYNC_CONFLICT', revision: 8,
+                message: '1 external database conflict(s) block publication', importedChanges: 0,
+                conflicts: [ { catalogType: 'NORMAL', entityType: 'OFFER', entityId: 77, field: 'costCredits' } ]
+            }}
+            loading={false}
+            publish={vi.fn()}
+            undo={vi.fn()}
+        />);
+
+        expect(screen.getByText('OFFER #77 · costCredits')).toBeInTheDocument();
     });
 });

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
@@ -31,6 +31,9 @@ const Probe = () => {
             <span data-testid="error">{studio.lastError ?? ''}</span>
             <span data-testid="page-caption">{studio.session?.pages.find(page => page.pageId === 42)?.caption ?? ''}</span>
             <span data-testid="history-count">{studio.historyTotalCount}</span>
+            <span data-testid="publish-message">{studio.publishResult?.message ?? ''}</span>
+            <span data-testid="publish-imported">{studio.publishResult?.importedChanges ?? 0}</span>
+            <span data-testid="publish-conflicts">{studio.publishResult?.conflicts.length ?? 0}</span>
             <button onClick={() => studio.acquireLock('PAGE', 44)}>lock</button>
             <button onClick={() => studio.releaseLock('PAGE', 44)}>release</button>
             <button onClick={() => studio.publish()}>publish</button>
@@ -306,5 +309,28 @@ describe('CatalogStudioProvider', () => {
         });
 
         expect(screen.getByTestId('locks')).toHaveTextContent('0');
+    });
+
+    it('exposes automatic live imports and publish conflicts', () => {
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+
+        emit('CatalogStudioPublishEvent', {
+            operationId: 'publish-success', success: true, code: 'PUBLISHED',
+            message: 'Catalog published with 2 external database change(s)', revision: 8,
+            changedEntities: [], importedChanges: 2, conflicts: []
+        });
+
+        expect(screen.getByTestId('publish-message')).toHaveTextContent('Catalog published with 2 external database change(s)');
+        expect(screen.getByTestId('publish-imported')).toHaveTextContent('2');
+
+        emit('CatalogStudioPublishEvent', {
+            operationId: 'publish-conflict', success: false, code: 'LIVE_SYNC_CONFLICT',
+            message: '1 external database conflict(s) block publication', revision: 8,
+            changedEntities: [ { entityType: 'OFFER', entityId: 77 } ], importedChanges: 0,
+            conflicts: [ { catalogType: 'NORMAL', entityType: 'OFFER', entityId: 77, field: 'costCredits' } ]
+        });
+
+        expect(screen.getByTestId('publish-conflicts')).toHaveTextContent('1');
+        expect(screen.getByTestId('error')).toHaveTextContent('1 external database conflict(s) block publication');
     });
 });

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -165,14 +165,18 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
 
     const handleLifecycleOperation = useCallback((event: CatalogStudioPublishEvent) => {
         const parser = event.getParser();
+        const reconciliation = parser as typeof parser & {
+            importedChanges?: number;
+            conflicts?: Array<{ catalogType: string; entityType: string; entityId: number; field: string }>;
+        };
         setPublishResult({
             operationId: parser.operationId,
             success: parser.success,
             code: parser.code,
             message: parser.message,
             revision: parser.revision,
-            importedChanges: parser.importedChanges ?? 0,
-            conflicts: (parser.conflicts ?? []).map(conflict => ({
+            importedChanges: reconciliation.importedChanges ?? 0,
+            conflicts: (reconciliation.conflicts ?? []).map(conflict => ({
                 ...conflict,
                 catalogType: conflict.catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL'
             }))

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -23,7 +23,7 @@ import {
 import { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SendMessageComposer } from '../../../../api';
 import { useConnectionState, useMessageEvent } from '../../../../hooks';
-import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioPublishResult, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
 import { applyCatalogStudioMutation } from './CatalogStudioMutationState';
 import { nextCatalogStudioOperationId } from './CatalogStudioOperationId';
 import { CatalogStudioContext, CatalogStudioContextValue } from './useCatalogStudio';
@@ -46,6 +46,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
     const [historyTotalCount, setHistoryTotalCount] = useState(0);
     const [validation, setValidation] = useState<CatalogStudioValidationState | null>(null);
     const [documentResult, setDocumentResult] = useState<CatalogStudioDocumentResult | null>(null);
+    const [publishResult, setPublishResult] = useState<CatalogStudioPublishResult | null>(null);
     const [locks, setLocks] = useState<Record<string, CatalogStudioLock>>({});
     const [loading, setLoading] = useState(false);
     const [lastError, setLastError] = useState<string | null>(null);
@@ -163,7 +164,20 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
     }, [refresh, updateRevision]);
 
     const handleLifecycleOperation = useCallback((event: CatalogStudioPublishEvent) => {
-        if (event.getParser().success) {
+        const parser = event.getParser();
+        setPublishResult({
+            operationId: parser.operationId,
+            success: parser.success,
+            code: parser.code,
+            message: parser.message,
+            revision: parser.revision,
+            importedChanges: parser.importedChanges ?? 0,
+            conflicts: (parser.conflicts ?? []).map(conflict => ({
+                ...conflict,
+                catalogType: conflict.catalogType === 'BUILDER' ? 'BUILDER' : 'NORMAL'
+            }))
+        });
+        if (parser.code === 'PUBLISHED') {
             locksRef.current = {};
             setLocks({});
         }
@@ -356,6 +370,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         historyTotalCount,
         validation,
         documentResult,
+        publishResult,
         locks,
         loading,
         lastError,
@@ -370,7 +385,7 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         dryRunDocument,
         applyDocument,
         applyMutation
-    }), [session, history, historyTotalCount, validation, documentResult, locks, loading, lastError, refresh, acquireLock, releaseLock, loadHistory, undo, revisionAction, exportDocument, dryRunDocument, applyDocument, applyMutation]);
+    }), [session, history, historyTotalCount, validation, documentResult, publishResult, locks, loading, lastError, refresh, acquireLock, releaseLock, loadHistory, undo, revisionAction, exportDocument, dryRunDocument, applyDocument, applyMutation]);
 
     return <CatalogStudioContext value={value}>{children}</CatalogStudioContext>;
 };

--- a/src/components/catalog/admin/studio/CatalogStudioPublishReview.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioPublishReview.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 import { FaCloudUploadAlt, FaExclamationTriangle, FaHistory, FaUndo } from 'react-icons/fa';
 import { CatalogStudioCommandState } from './CatalogStudioCommandCenter';
-import { CatalogStudioHistoryGroup, CatalogStudioValidationIssue } from './CatalogStudioTypes';
+import { CatalogStudioHistoryGroup, CatalogStudioPublishResult, CatalogStudioValidationIssue } from './CatalogStudioTypes';
 
 interface CatalogStudioPublishReviewProps {
     phase: CatalogStudioCommandState['phase'];
@@ -9,6 +9,7 @@ interface CatalogStudioPublishReviewProps {
     validationCurrent: boolean;
     issues: CatalogStudioValidationIssue[];
     history: CatalogStudioHistoryGroup[];
+    publishResult: CatalogStudioPublishResult | null;
     loading: boolean;
     publish: () => void;
     undo: (groupId: number) => void;
@@ -20,13 +21,14 @@ export const CatalogStudioPublishReview: FC<CatalogStudioPublishReviewProps> = (
     validationCurrent,
     issues,
     history,
+    publishResult,
     loading,
     publish,
     undo
 }) => {
     const [publishConfirmationOpen, setPublishConfirmationOpen] = useState(false);
     const [revertCandidate, setRevertCandidate] = useState<CatalogStudioHistoryGroup | null>(null);
-    const canPublish = phase === 'ready' && validationCurrent && issues.length === 0 && pendingCount > 0 && !loading;
+    const canPublish = (phase === 'clean' || (phase === 'ready' && validationCurrent)) && issues.length === 0 && !loading;
     const visibleHistory = pendingCount > 0 ? history : [];
 
     const publishNow = () => {
@@ -43,6 +45,26 @@ export const CatalogStudioPublishReview: FC<CatalogStudioPublishReviewProps> = (
     };
 
     return <div className="nitro-catalog-admin-publish">
+        {!!publishResult?.importedChanges && <div className="nitro-catalog-admin-validation-list">
+            <div className="nitro-catalog-admin-publish-changes-head">
+                {publishResult.importedChanges} external database {publishResult.importedChanges === 1 ? 'change' : 'changes'} imported automatically.
+            </div>
+        </div>}
+
+        {!!publishResult?.conflicts.length && <div className="nitro-catalog-admin-validation-list">
+            <div className="nitro-catalog-admin-publish-changes-head">External database conflicts</div>
+            {publishResult.conflicts.map((conflict, index) => <div
+                key={`${conflict.catalogType}-${conflict.entityType}-${conflict.entityId}-${conflict.field}-${index}`}
+                className="nitro-catalog-admin-validation-row"
+            >
+                <FaExclamationTriangle />
+                <div>
+                    <strong>{conflict.entityType} #{conflict.entityId} &middot; {conflict.field}</strong>
+                    <span>{conflict.catalogType} catalog changed both live and in the draft.</span>
+                </div>
+            </div>)}
+        </div>}
+
         {!!issues.length && <div className="nitro-catalog-admin-validation-list">
             <div className="nitro-catalog-admin-publish-changes-head">Resolve before publishing</div>
             {issues.map((issue, index) => <div
@@ -78,21 +100,25 @@ export const CatalogStudioPublishReview: FC<CatalogStudioPublishReviewProps> = (
             </div>)}
         </div>
 
-        {pendingCount > 0 && <div className="nitro-catalog-admin-publish-actions">
+        <div className="nitro-catalog-admin-publish-actions">
             <button
                 className={`nitro-catalog-admin-btn is-publish ${canPublish ? 'has-pending' : ''}`}
                 disabled={!canPublish}
                 onClick={() => setPublishConfirmationOpen(true)}
             >
-                <FaCloudUploadAlt /> Publish {pendingCount} {pendingCount === 1 ? 'change' : 'changes'}
+                <FaCloudUploadAlt /> {pendingCount > 0
+                    ? `Publish ${pendingCount} ${pendingCount === 1 ? 'change' : 'changes'}`
+                    : 'Check & publish'}
             </button>
-        </div>}
+        </div>
 
         {publishConfirmationOpen && <div className="nitro-catalog-admin-publish-confirmation" role="dialog" aria-modal="true" aria-label="Confirm catalog publication">
             <FaCloudUploadAlt />
             <div>
-                <strong>Publish {pendingCount} {pendingCount === 1 ? 'change' : 'changes'}?</strong>
-                <span>The validated draft will replace the live catalog.</span>
+                <strong>{pendingCount > 0
+                    ? `Publish ${pendingCount} ${pendingCount === 1 ? 'change' : 'changes'}?`
+                    : 'Check live catalog and publish?'}</strong>
+                <span>External database changes will be imported automatically unless they conflict with the draft.</span>
             </div>
             <div className="nitro-catalog-admin-publish-actions">
                 <button className="nitro-catalog-admin-btn" onClick={() => setPublishConfirmationOpen(false)}>Cancel</button>

--- a/src/components/catalog/admin/studio/CatalogStudioTypes.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioTypes.ts
@@ -119,6 +119,23 @@ export interface CatalogStudioValidationState {
     issues: CatalogStudioValidationIssue[];
 }
 
+export interface CatalogStudioPublishConflict {
+    catalogType: CatalogStudioCatalogType;
+    entityType: string;
+    entityId: number;
+    field: string;
+}
+
+export interface CatalogStudioPublishResult {
+    operationId: string;
+    success: boolean;
+    code: string;
+    message: string;
+    revision: number;
+    importedChanges: number;
+    conflicts: CatalogStudioPublishConflict[];
+}
+
 export interface CatalogStudioDocumentResult {
     operationId: string;
     success: boolean;

--- a/src/components/catalog/admin/studio/useCatalogStudio.ts
+++ b/src/components/catalog/admin/studio/useCatalogStudio.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
+import { CatalogStudioDocumentResult, CatalogStudioHistoryGroup, CatalogStudioLock, CatalogStudioMutationResult, CatalogStudioPublishResult, CatalogStudioSession, CatalogStudioValidationState } from './CatalogStudioTypes';
 
 export interface CatalogStudioContextValue {
     session: CatalogStudioSession | null;
@@ -9,6 +9,7 @@ export interface CatalogStudioContextValue {
     historyTotalCount: number;
     validation: CatalogStudioValidationState | null;
     documentResult: CatalogStudioDocumentResult | null;
+    publishResult: CatalogStudioPublishResult | null;
     locks: Readonly<Record<string, CatalogStudioLock>>;
     loading: boolean;
     lastError: string | null;

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -615,6 +615,7 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                 validationCurrent={validationCurrent}
                 issues={studio.validation?.issues ?? []}
                 history={studio.history}
+                publishResult={studio.publishResult}
                 loading={studio.loading}
                 publish={() => catalogAdmin.publishCatalog()}
                 undo={studio.undo}


### PR DESCRIPTION
Allows Check & publish even when the Studio draft has zero pending changes, displays automatically imported live database changes, and lists entity/field conflicts when live and draft changed the same field differently. NO_CHANGES responses preserve current locks and do not create redundant versions. Companion PRs: emulator https://github.com/duckietm/Polaris-Emulator/pull/594 and renderer https://github.com/duckietm/Nitro_Render_V3/pull/179. Verification: yarn test (184 files, 1004 tests passed); yarn typecheck passed.