### PR TITLE
perf(catalog): prewarm catalog index on login

### DIFF
--- a/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.test.tsx
@@ -307,4 +307,21 @@ describe('CatalogStudioProvider', () => {
 
         expect(screen.getByTestId('locks')).toHaveTextContent('0');
     });
+    it('invalidates the live catalog cache after a successful publication', () => {
+        const refreshed: string[] = [];
+        const onIndexRefresh = () => refreshed.push('index');
+        const onPageRefresh = () => refreshed.push('page');
+        window.addEventListener('catalog-admin-refresh-index', onIndexRefresh);
+        window.addEventListener('catalog-admin-refresh-current-page', onPageRefresh);
+        render(<CatalogStudioProvider active><Probe /></CatalogStudioProvider>);
+
+        emit('CatalogStudioPublishEvent', {
+            operationId: 'publish-refresh', success: true, code: 'PUBLISHED', message: '',
+            revision: 8, changedEntities: []
+        });
+
+        expect(refreshed).toEqual(['index', 'page']);
+        window.removeEventListener('catalog-admin-refresh-index', onIndexRefresh);
+        window.removeEventListener('catalog-admin-refresh-current-page', onPageRefresh);
+    });
 });

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -166,6 +166,8 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
         if (event.getParser().success) {
             locksRef.current = {};
             setLocks({});
+            window.dispatchEvent(new Event('catalog-admin-refresh-index'));
+            window.dispatchEvent(new Event('catalog-admin-refresh-current-page'));
         }
         handleOperation(event);
     }, [handleOperation]);

--- a/src/hooks/catalog/useCatalog.helpers.test.ts
+++ b/src/hooks/catalog/useCatalog.helpers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BuilderFurniPlaceableStatus } from '../../api/catalog/BuilderFurniPlaceableStatus';
 import { CatalogType } from '../../api/catalog/CatalogType';
+import * as catalogHelpers from './useCatalog.helpers';
 import {
     buildCatalogNodeTree,
     createCatalogPageRequestCorrelation,
@@ -12,6 +13,117 @@ import {
     normalizeCatalogType,
     resolveBuilderFurniPlaceableStatus
 } from './useCatalog.helpers';
+
+describe('catalog index request coordinator', () => {
+    it('sends the first request and suppresses a duplicate while it is in flight', () => {
+        const sentTypes: string[] = [];
+        const coordinator = (catalogHelpers.createCatalogIndexRequestCoordinator as any)((type: string) => sentTypes.push(type), 10_000, () => 1_000);
+
+        expect(coordinator).toBeDefined();
+        if (!coordinator) return;
+
+        expect(coordinator.request(CatalogType.NORMAL)).toBe(true);
+        expect(coordinator.request(CatalogType.NORMAL)).toBe(false);
+        expect(sentTypes).toEqual([CatalogType.NORMAL]);
+    });
+
+    it('allows another request after the matching response completes', () => {
+        const sentTypes: string[] = [];
+        const coordinator = (catalogHelpers.createCatalogIndexRequestCoordinator as any)((type: string) => sentTypes.push(type), 10_000, () => 1_000);
+
+        expect(coordinator).toBeDefined();
+        if (!coordinator) return;
+
+        coordinator.request(CatalogType.NORMAL);
+        coordinator.complete(CatalogType.NORMAL);
+
+        expect(coordinator.request(CatalogType.NORMAL)).toBe(true);
+        expect(sentTypes).toEqual([CatalogType.NORMAL, CatalogType.NORMAL]);
+    });
+
+    it('retries an index request after the in-flight timeout', () => {
+        let now = 1_000;
+        const sentTypes: string[] = [];
+        const coordinator = (catalogHelpers.createCatalogIndexRequestCoordinator as any)((type: string) => sentTypes.push(type), 10_000, () => now);
+
+        expect(coordinator).toBeDefined();
+        if (!coordinator) return;
+
+        coordinator.request(CatalogType.NORMAL);
+        now = 11_000;
+
+        expect(coordinator.request(CatalogType.NORMAL)).toBe(true);
+        expect(sentTypes).toEqual([CatalogType.NORMAL, CatalogType.NORMAL]);
+    });
+});
+
+describe('catalog index prewarm controller', () => {
+    it('requests the current catalog once when the connection becomes authenticated', () => {
+        const requestedTypes: string[] = [];
+        const controller = (catalogHelpers as any).createCatalogIndexPrewarmController((type: string) => requestedTypes.push(type));
+
+        expect(controller).toBeDefined();
+        if (!controller) return;
+
+        controller.update({ authenticated: false, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: false, hasIndex: true, catalogType: CatalogType.NORMAL });
+
+        expect(requestedTypes).toEqual([CatalogType.NORMAL]);
+    });
+
+    it('refreshes once on each opening even when the prewarmed index is available', () => {
+        const requestedTypes: string[] = [];
+        const controller = (catalogHelpers as any).createCatalogIndexPrewarmController((type: string) => requestedTypes.push(type));
+
+        expect(controller).toBeDefined();
+        if (!controller) return;
+
+        controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        requestedTypes.length = 0;
+        controller.update({ authenticated: true, visible: true, hasIndex: true, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: true, hasIndex: true, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: false, hasIndex: true, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: true, hasIndex: true, catalogType: CatalogType.NORMAL });
+
+        expect(requestedTypes).toEqual([CatalogType.NORMAL, CatalogType.NORMAL]);
+    });
+
+    it('prewarms again after reconnecting', () => {
+        const requestedTypes: string[] = [];
+        const controller = (catalogHelpers as any).createCatalogIndexPrewarmController((type: string) => requestedTypes.push(type));
+
+        expect(controller).toBeDefined();
+        if (!controller) return;
+
+        controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: false, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+
+        expect(requestedTypes).toEqual([CatalogType.NORMAL, CatalogType.NORMAL]);
+    });
+});
+
+describe('restoreCatalogActivePath', () => {
+    it('rebinds the active path to nodes from a refreshed catalog tree', () => {
+        const restore = (catalogHelpers as any).restoreCatalogActivePath;
+        expect(restore).toBeTypeOf('function');
+        if (!restore) return;
+
+        const root: any = { pageId: -1, pageName: 'root', children: [] };
+        const parent: any = { pageId: 10, pageName: 'parent', parent: root, children: [], activate: vi.fn(), open: vi.fn() };
+        const child: any = { pageId: 11, pageName: 'child', parent, children: [], activate: vi.fn(), open: vi.fn() };
+        root.children = [parent];
+        parent.children = [child];
+
+        const restored = restore(root, 11);
+
+        expect(restored).toEqual([parent, child]);
+        expect(parent.activate).toHaveBeenCalledOnce();
+        expect(child.activate).toHaveBeenCalledOnce();
+        expect(parent.open).toHaveBeenCalledOnce();
+    });
+});
 
 describe('catalog page request correlation', () => {
     afterEach(() => vi.useRealTimers());

--- a/src/hooks/catalog/useCatalog.helpers.ts
+++ b/src/hooks/catalog/useCatalog.helpers.ts
@@ -23,6 +23,90 @@ export const normalizeCatalogType = (type?: string): string => {
     return CatalogType.NORMAL;
 };
 
+export interface CatalogIndexRequestCoordinator {
+    request: (catalogType: string) => boolean;
+    complete: (catalogType: string) => void;
+    reset: () => void;
+}
+
+export interface CatalogIndexPrewarmState {
+    authenticated: boolean;
+    visible: boolean;
+    hasIndex: boolean;
+    catalogType: string;
+}
+
+export interface CatalogIndexPrewarmController {
+    update: (state: CatalogIndexPrewarmState) => void;
+}
+
+export const createCatalogIndexRequestCoordinator = (
+    send: (catalogType: string) => void,
+    timeoutMs: number = 10_000,
+    now: () => number = Date.now
+): CatalogIndexRequestCoordinator => {
+    const requestedAt = new Map<string, number>();
+
+    return {
+        request: (catalogType) => {
+            const requested = requestedAt.get(catalogType);
+            const currentTime = now();
+
+            if (requested !== undefined && currentTime - requested < timeoutMs) return false;
+
+            requestedAt.set(catalogType, currentTime);
+            send(catalogType);
+
+            return true;
+        },
+        complete: (catalogType) => requestedAt.delete(catalogType),
+        reset: () => requestedAt.clear()
+    };
+};
+
+export const createCatalogIndexPrewarmController = (request: (catalogType: string) => void): CatalogIndexPrewarmController => {
+    let previous: CatalogIndexPrewarmState = {
+        authenticated: false,
+        visible: false,
+        hasIndex: false,
+        catalogType: CatalogType.NORMAL
+    };
+
+    return {
+        update: (state) => {
+            if (state.authenticated) {
+                const authenticatedNow = !previous.authenticated;
+                const openedNow = state.visible && !previous.visible;
+                const switchedVisibleCatalog = state.visible && state.catalogType !== previous.catalogType;
+
+                if (authenticatedNow || openedNow || switchedVisibleCatalog) request(state.catalogType);
+            }
+
+            previous = state;
+        }
+    };
+};
+
+export const restoreCatalogActivePath = (rootNode: ICatalogNode, activePageId: number): ICatalogNode[] => {
+    const target = findNodeById(activePageId, rootNode, rootNode);
+    if (!target) return [];
+
+    const path: ICatalogNode[] = [];
+    let node: ICatalogNode | null = target;
+
+    while (node && node !== rootNode) {
+        path.unshift(node);
+        node = node.parent;
+    }
+
+    for (const activeNode of path) {
+        activeNode.activate();
+        activeNode.open();
+    }
+
+    return path;
+};
+
 export const isCurrentCatalogPageResponse = (requestedPageId: number, responsePageId: number): boolean => requestedPageId === responsePageId;
 
 export interface CatalogPageRequestCorrelation {

--- a/src/hooks/catalog/useCatalog.ts
+++ b/src/hooks/catalog/useCatalog.ts
@@ -69,16 +69,19 @@ import {
     CatalogPurchaseSoldOutEvent,
     InventoryFurniAddedEvent
 } from '../../events';
-import { useMessageEvent, useNitroEvent, useUiEvent } from '../events';
+import { useConnectionState, useMessageEvent, useNitroEvent, useUiEvent } from '../events';
 import { useNotification } from '../notification';
 import {
     buildCatalogNodeTree,
+    createCatalogIndexPrewarmController,
+    createCatalogIndexRequestCoordinator,
     createCatalogPageRequestCorrelation,
     findNodeById,
     findNodeByName,
     getNodesByOfferIdFromMap,
     getOfferProductKeys,
     normalizeCatalogType,
+    restoreCatalogActivePath,
     RoomControllerLevel,
     RoomObjectCategory,
     RoomObjectType,
@@ -139,6 +142,19 @@ const useCatalogStore = () => {
     const pageRequestCorrelation = useRef(createCatalogPageRequestCorrelation());
     const { simpleAlert = null, showConfirm = null } = useNotification();
     const requestedPage = useRef(new RequestedPage());
+    const connectionState = useConnectionState();
+    const catalogIndexRequests = useRef<ReturnType<typeof createCatalogIndexRequestCoordinator>>(null);
+    const catalogIndexPrewarm = useRef<ReturnType<typeof createCatalogIndexPrewarmController>>(null);
+
+    if (!catalogIndexRequests.current) {
+        catalogIndexRequests.current = createCatalogIndexRequestCoordinator((catalogType) => {
+            SendMessageComposer(new GetCatalogIndexComposer(catalogType));
+        });
+    }
+
+    if (!catalogIndexPrewarm.current) {
+        catalogIndexPrewarm.current = createCatalogIndexPrewarmController((catalogType) => catalogIndexRequests.current.request(catalogType));
+    }
 
     const resetState = useCallback(() => {
         pageRequestCorrelation.current.reset();
@@ -631,12 +647,16 @@ const useCatalogStore = () => {
         const parser = event.getParser();
         const parserCatalogType = normalizeCatalogType(parser.catalogType);
 
+        catalogIndexRequests.current.complete(parserCatalogType);
+
         if (parserCatalogType !== currentType) return;
 
         const { rootNode: builtRoot, offersToNodes: builtOffers } = buildCatalogNodeTree(parser.root);
+        const activePageId = activeNodes[activeNodes.length - 1]?.pageId ?? -1;
 
         setRootNode(builtRoot);
         setOffersToNodes(builtOffers);
+        if (activePageId > -1) setActiveNodes(restoreCatalogActivePath(builtRoot, activePageId));
     });
 
     useMessageEvent<CatalogPageMessageEvent>(CatalogPageMessageEvent, (event) => {
@@ -835,7 +855,10 @@ const useCatalogStore = () => {
         const wasVisible = isVisible;
 
         importedFurnidataMerged.current = false;
+        catalogIndexRequests.current.reset();
         resetState();
+
+        if (connectionState.authenticated) catalogIndexRequests.current.request(currentType);
 
         if (wasVisible)
             simpleAlert(
@@ -1135,7 +1158,7 @@ const useCatalogStore = () => {
         };
 
         const refreshCatalogIndex = () => {
-            SendMessageComposer(new GetCatalogIndexComposer(currentType));
+            catalogIndexRequests.current.request(currentType);
         };
 
         window.addEventListener('catalog-admin-refresh-current-page', refreshCurrentPage);
@@ -1158,14 +1181,21 @@ const useCatalogStore = () => {
     }, [secondsLeft]);
 
     useEffect(() => {
-        if (!isVisible || rootNode) return;
+        if (!connectionState.authenticated) catalogIndexRequests.current.reset();
 
-        // Always fetch a fresh index — a persisted snapshot here kept serving
-        // a stale tree (e.g. one recorded while the server sent no offer ids)
-        // for the whole browser session and masked catalog updates.
-        SendMessageComposer(new GetCatalogIndexComposer(currentType));
+        catalogIndexPrewarm.current.update({
+            authenticated: connectionState.authenticated,
+            visible: isVisible,
+            hasIndex: !!rootNode,
+            catalogType: currentType
+        });
+    }, [connectionState.authenticated, isVisible, rootNode, currentType]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
         SendMessageComposer(new BuildersClubQueryFurniCountMessageComposer());
-    }, [isVisible, rootNode, currentType]);
+    }, [isVisible, currentType]);
 
     useEffect(() => {
         setRoomPreviewer(new RoomPreviewer(GetRoomEngine(), ++RoomPreviewer.PREVIEW_COUNTER));


### PR DESCRIPTION
## Summary
- prewarm the normal catalog index as soon as the session authenticates
- deduplicate in-flight index requests while retaining retry behavior
- refresh safely on catalog open and rebind the active navigation path
- invalidate the live catalog index and current page after a successful Catalog Studio publication

## Verification
- yarn test (1002 tests passed)
- yarn typecheck
- yarn build
- Biome lint on changed files