### PR TITLE
fix(catalog): keep expanded previews and grids responsive

### DIFF
--- a/src/common/AutoGrid.test.tsx
+++ b/src/common/AutoGrid.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AutoGrid } from './AutoGrid';
+
+describe('AutoGrid responsive columns', () => {
+    it('preserves the template tile width while distributing the remaining row space', () => {
+        const { getByRole } = render(
+            <AutoGrid aria-label="Template offers" className="nitro-catalog-grid" columnCount={6} columnMinWidth={55} role="listbox" />
+        );
+        const grid = getByRole('listbox');
+
+        expect(grid.style.getPropertyValue('--nitro-grid-column-min-width')).toBe('55px');
+        expect(grid.style.gridTemplateColumns).toBe('repeat(auto-fill, minmax(55px, 1fr))');
+    });
+});

--- a/src/common/AutoGrid.tsx
+++ b/src/common/AutoGrid.tsx
@@ -13,6 +13,7 @@ export const AutoGrid: FC<AutoGridProps> = (props) => {
         let newStyle: CSSProperties = {};
 
         newStyle['--nitro-grid-column-min-height'] = columnMinHeight + 'px';
+        newStyle['--nitro-grid-column-min-width'] = columnMinWidth + 'px';
 
         if (columnCount > 1) newStyle.gridTemplateColumns = `repeat(auto-fill, minmax(${columnMinWidth}px, 1fr))`;
 

--- a/src/common/layout/LayoutRoomPreviewerView.test.tsx
+++ b/src/common/layout/LayoutRoomPreviewerView.test.tsx
@@ -4,6 +4,7 @@ import { LayoutRoomPreviewerView } from './LayoutRoomPreviewerView';
 
 const previewMocks = vi.hoisted(() => ({
     add: vi.fn(),
+    createRenderTexture: vi.fn((_width: number, _height: number) => ({ destroy: vi.fn() })),
     remove: vi.fn(),
     destroy: vi.fn()
 }));
@@ -15,10 +16,16 @@ vi.mock('@nitrots/nitro-renderer', () => ({
     }),
     GetTicker: () => ({ add: previewMocks.add, remove: previewMocks.remove }),
     NitroLogger: { error: vi.fn() },
-    TextureUtils: { createRenderTexture: () => ({ destroy: previewMocks.destroy }) }
+    TextureUtils: { createRenderTexture: previewMocks.createRenderTexture }
 }));
 
+let resizeCallback: ResizeObserverCallback;
+
 class ResizeObserverMock {
+    public constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+    }
+
     public observe = vi.fn();
     public disconnect = vi.fn();
 }
@@ -28,6 +35,24 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 afterEach(cleanup);
 
 describe('LayoutRoomPreviewerView interactions', () => {
+    it('recreates its render target when the preview width changes', () => {
+        const roomPreviewer = {
+            changeRoomObjectState: vi.fn(),
+            getRenderingCanvas: vi.fn(() => null),
+            getRoomCanvas: vi.fn(),
+            modifyRoomCanvas: vi.fn(),
+            updatePreviewRoomView: vi.fn()
+        } as any;
+
+        const view = render(<LayoutRoomPreviewerView height={240} roomPreviewer={roomPreviewer} />);
+        const preview = view.container.querySelector('.shadow-room-previewer')!;
+
+        Object.defineProperty(preview.parentElement, 'offsetWidth', { configurable: true, value: 680 });
+        resizeCallback([], {} as ResizeObserver);
+
+        expect(previewMocks.createRenderTexture).toHaveBeenLastCalledWith(680, 240);
+    });
+
     it('keeps furniture state on a single click', () => {
         const roomPreviewer = {
             changeRoomObjectDirection: vi.fn(),

--- a/src/common/layout/LayoutRoomPreviewerView.tsx
+++ b/src/common/layout/LayoutRoomPreviewerView.tsx
@@ -30,7 +30,8 @@ export const LayoutRoomPreviewerView: FC<{
         renderFailuresRef.current = 0;
 
         const width = elementRef.current.parentElement.clientWidth;
-        const texture = TextureUtils.createRenderTexture(width, height);
+        let textureWidth = width;
+        let texture = TextureUtils.createRenderTexture(width, height);
 
         const noteFailure = (label: string, error: unknown) => {
             renderFailuresRef.current += 1;
@@ -97,6 +98,14 @@ export const LayoutRoomPreviewerView: FC<{
             if (!roomPreviewer || !elementRef.current) return;
 
             const width = elementRef.current.parentElement.offsetWidth;
+
+            if (width > 0 && width !== textureWidth) {
+                const previousTexture = texture;
+
+                texture = TextureUtils.createRenderTexture(width, height);
+                textureWidth = width;
+                previousTexture?.destroy(true);
+            }
 
             roomPreviewer.modifyRoomCanvas(width, height);
 

--- a/src/components/catalog/views/page/layout/CatalogLayoutDefaultView.test.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutDefaultView.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCatalogData, useCatalogDisplayPreferences } from '../../../../../hooks';
+import { CatalogLayoutDefaultView } from './CatalogLayoutDefaultView';
+
+vi.mock('../../../../../api', () => ({
+    GetConfigurationValue: () => false,
+    LocalizeText: (key: string) => key,
+    ProductTypeEnum: { BADGE: 'b', FLOOR: 's' },
+    SanitizeHtml: (value: string) => value
+}));
+
+vi.mock('../../../../../common', () => ({ Text: () => null }));
+
+vi.mock('../../../../../hooks', () => ({
+    getCatalogGridMetrics: () => ({}),
+    useCatalogData: vi.fn(),
+    useCatalogDisplayPreferences: vi.fn()
+}));
+
+vi.mock('../../catalog-header/CatalogHeaderView', () => ({ CatalogHeaderView: () => null }));
+vi.mock('../widgets/CatalogAddOnBadgeWidgetView', () => ({ CatalogAddOnBadgeWidgetView: () => null }));
+vi.mock('../widgets/CatalogItemGridWidgetView', () => ({ CatalogItemGridWidgetView: () => null }));
+vi.mock('../widgets/CatalogLimitedItemWidgetView', () => ({ CatalogLimitedItemWidgetView: () => null }));
+vi.mock('../widgets/CatalogPreviewControls', () => ({ CatalogPreviewControls: () => null }));
+vi.mock('../widgets/CatalogProductDetailsView', () => ({ CatalogProductDetailsView: () => null }));
+vi.mock('../widgets/CatalogPurchaseSelectionPrompt', () => ({ CatalogPurchaseSelectionPrompt: () => null }));
+vi.mock('../widgets/CatalogPurchaseWidgetView', () => ({ CatalogPurchaseWidgetView: () => null }));
+vi.mock('../widgets/CatalogSpinnerWidgetView', () => ({ CatalogSpinnerWidgetView: () => null }));
+vi.mock('../widgets/CatalogTotalPriceWidget', () => ({ CatalogTotalPriceWidget: () => null }));
+vi.mock('../widgets/CatalogViewProductWidgetView', () => ({ CatalogViewProductWidgetView: () => null }));
+
+const page = {
+    localization: {
+        getImage: () => '',
+        getText: () => ''
+    }
+};
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    vi.mocked(useCatalogDisplayPreferences).mockReturnValue({ density: 'standard', showTilePrices: true } as any);
+    vi.mocked(useCatalogData).mockReturnValue({
+        currentOffer: { product: { productType: 's' } },
+        currentPage: page,
+        roomPreviewer: null
+    } as any);
+});
+
+describe('default catalog layout', () => {
+    it('lets the product preview fill an expanded catalog panel', () => {
+        const view = render(<CatalogLayoutDefaultView hideNavigation={() => undefined} page={page as any} />);
+        const preview = view.container.querySelector<HTMLElement>('.nitro-catalog-offer-preview');
+
+        expect(preview).not.toBeNull();
+        expect(preview.style.width).toBe('100%');
+        expect(preview.style.minWidth).toBe('0px');
+        expect(preview.style.flexGrow).toBe('1');
+    });
+});

--- a/src/components/catalog/views/page/layout/CatalogLayoutDefaultView.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutDefaultView.tsx
@@ -31,6 +31,7 @@ export const CatalogLayoutDefaultView: FC<CatalogLayoutProps> = (props) => {
                     <div className="nitro-catalog-offer-panel flex gap-0">
                         <div
                             className={`nitro-catalog-offer-preview relative flex items-center justify-center ${currentOffer.product.productType === ProductTypeEnum.BADGE ? 'is-badge' : ''}`}
+                            style={{ flex: '1 1 auto', minWidth: 0, width: '100%' }}
                         >
                             <div className="nitro-catalog-preview-details">
                                 <CatalogProductDetailsView offer={currentOffer} />

--- a/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.responsive.test.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.responsive.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CatalogItemGridWidgetView } from './CatalogItemGridWidgetView';
+
+const catalogState = vi.hoisted(() => ({
+    currentPage: { offers: [], pageId: 1 }
+}));
+
+vi.mock('../../../../../hooks', () => ({
+    useCatalogActions: () => ({ selectCatalogOffer: vi.fn() }),
+    useCatalogData: () => ({ currentOffer: null, currentPage: catalogState.currentPage }),
+    useCatalogUiState: () => ({ setCurrentPage: vi.fn() })
+}));
+
+describe('CatalogItemGridWidgetView responsive grid ownership', () => {
+    beforeEach(() => {
+        catalogState.currentPage = { offers: [], pageId: 1 };
+    });
+
+    afterEach(cleanup);
+
+    it('applies the shared auto-fill grid class to every multi-column offer template', () => {
+        render(<CatalogItemGridWidgetView columnCount={6} />);
+
+        expect(screen.getByRole('listbox', { name: 'Catalog items' })).toHaveClass('nitro-catalog-grid');
+    });
+
+    it('does not turn a specialized single-column selector into an auto-fill grid', () => {
+        render(<CatalogItemGridWidgetView columnCount={1} />);
+
+        expect(screen.getByRole('listbox', { name: 'Catalog items' })).not.toHaveClass('nitro-catalog-grid');
+    });
+});

--- a/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogItemGridWidgetView.tsx
@@ -23,6 +23,8 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
     const elementRef = useRef<HTMLDivElement>(null);
     const [dragIndex, setDragIndex] = useState<number | null>(null);
     const [dropIndex, setDropIndex] = useState<number | null>(null);
+    const gridClassName =
+        columnCount > 1 && !className.split(/\s+/).includes('nitro-catalog-grid') ? `${className} nitro-catalog-grid`.trim() : className;
 
     const offers = currentPage?.offers ?? [];
     const useVirtualGrid = shouldVirtualizeCatalogOffers(offers.length, adminMode);
@@ -100,7 +102,7 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
 
     if (useVirtualGrid) {
         return (
-            <div aria-label="Catalog items" className={`nitro-catalog-grid-virtual h-full min-h-0 ${className}`.trim()} role="listbox">
+            <div aria-label="Catalog items" className={`nitro-catalog-grid-virtual h-full min-h-0 ${gridClassName}`.trim()} role="listbox">
                 <InfiniteGrid
                     classicScrollbar
                     columnCount={columnCount}
@@ -119,7 +121,7 @@ export const CatalogItemGridWidgetView: FC<CatalogItemGridWidgetViewProps> = (pr
         <ClassicScrollAreaView className="nitro-catalog-item-grid-scroll-area h-full min-h-0" viewportRef={elementRef}>
             <AutoGrid
                 aria-label="Catalog items"
-                className={className}
+                className={gridClassName}
                 columnCount={columnCount}
                 columnMinHeight={columnMinHeight}
                 columnMinWidth={columnMinWidth}

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -141,7 +141,7 @@
 
 .nitro-catalog-pet-customization-layout {
     position: relative;
-    width: 360px;
+    width: 100%;
     height: 460px;
     overflow: hidden;
 }
@@ -149,7 +149,7 @@
 .nitro-catalog-pet-customization-preview {
     position: absolute;
     inset: 0 0 auto;
-    width: 360px;
+    width: 100%;
     height: 240px;
     overflow: hidden;
 }
@@ -179,7 +179,7 @@
     position: absolute;
     top: 245px;
     left: 0;
-    width: 360px;
+    width: 100%;
     height: 180px;
     overflow: auto;
 }
@@ -191,7 +191,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    width: 360px;
+    width: 100%;
     height: 30px;
     font-size: 11px;
 }

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -96,15 +96,15 @@
 }
 
 .nitro-catalog-grid.nitro-catalog-grid-density-standard {
-    grid-template-columns: repeat(6, 53px) !important;
+    --nitro-grid-column-min-width: 53px;
 }
 
 .nitro-catalog-grid.nitro-catalog-grid-density-compact {
-    grid-template-columns: repeat(7, 45px) !important;
+    --nitro-grid-column-min-width: 45px;
 }
 
 .nitro-catalog-grid.nitro-catalog-grid-density-large {
-    grid-template-columns: repeat(5, minmax(0, 1fr)) !important;
+    --nitro-grid-column-min-width: 68px;
 }
 
 .nitro-catalog-default-layout .nitro-catalog-grid-shell {
@@ -417,6 +417,11 @@
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+}
+
+.nitro-catalog-item-grid-scroll-area:has(> .nitro-classic-scrollbar[data-visible='true']) > .nitro-classic-scroll-area-viewport,
+.nitro-catalog-grid-virtual .nitro-classic-scroll-area:has(> .nitro-classic-scrollbar[data-visible='true']) > .nitro-classic-scroll-area-viewport {
+    padding-right: 17px;
 }
 
 .nitro-classic-scrollbar {

--- a/src/css/catalog/CatalogResponsiveGrid.test.ts
+++ b/src/css/catalog/CatalogResponsiveGrid.test.ts
@@ -23,7 +23,9 @@ describe('responsive catalog item grid', () => {
         const style = getComputedStyle(grid);
 
         expect(style.getPropertyValue('--nitro-grid-column-min-width').trim()).toBe('53px');
-        expect(style.gridTemplateColumns.replaceAll(' ', '')).toBe('repeat(auto-fill,var(--nitro-grid-column-min-width,53px))');
+        expect(style.gridTemplateColumns.replaceAll(' ', '')).toBe(
+            'repeat(auto-fill,minmax(var(--nitro-grid-column-min-width,53px),1fr))'
+        );
     });
 
     it('keeps the last column clear of the visible classic scrollbar', () => {

--- a/src/css/catalog/CatalogResponsiveGrid.test.ts
+++ b/src/css/catalog/CatalogResponsiveGrid.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const catalogCss = readFileSync(resolve(process.cwd(), 'src/css/catalog/CatalogView.css'), 'utf8');
+const experienceCss = readFileSync(resolve(process.cwd(), 'src/css/catalog/CatalogExperience.css'), 'utf8');
+
+afterEach(() => {
+    document.body.replaceChildren();
+    document.head.replaceChildren();
+});
+
+describe('responsive catalog item grid', () => {
+    it('uses the selected tile width to add columns when the catalog expands', () => {
+        const stylesheet = document.createElement('style');
+        const grid = document.createElement('div');
+
+        stylesheet.textContent = `${catalogCss}\n${experienceCss}`;
+        grid.className = 'nitro-catalog-grid nitro-catalog-grid-density-standard';
+        document.head.append(stylesheet);
+        document.body.append(grid);
+
+        const style = getComputedStyle(grid);
+
+        expect(style.getPropertyValue('--nitro-grid-column-min-width').trim()).toBe('53px');
+        expect(style.gridTemplateColumns.replaceAll(' ', '')).toBe('repeat(auto-fill,var(--nitro-grid-column-min-width,53px))');
+    });
+
+    it('keeps the last column clear of the visible classic scrollbar', () => {
+        const stylesheet = document.createElement('style');
+        const scrollArea = document.createElement('div');
+        const viewport = document.createElement('div');
+        const scrollbar = document.createElement('div');
+
+        stylesheet.textContent = `${catalogCss}\n${experienceCss}`;
+        scrollArea.className = 'nitro-classic-scroll-area nitro-catalog-item-grid-scroll-area';
+        viewport.className = 'nitro-classic-scroll-area-viewport';
+        scrollbar.className = 'nitro-classic-scrollbar';
+        scrollbar.dataset.visible = 'true';
+        scrollArea.append(viewport, scrollbar);
+        document.head.append(stylesheet);
+        document.body.append(scrollArea);
+
+        expect(getComputedStyle(viewport).paddingRight).toBe('17px');
+    });
+
+    it('keeps virtualized catalog columns clear of the visible classic scrollbar', () => {
+        const stylesheet = document.createElement('style');
+        const virtualGrid = document.createElement('div');
+        const scrollArea = document.createElement('div');
+        const viewport = document.createElement('div');
+        const scrollbar = document.createElement('div');
+
+        stylesheet.textContent = `${catalogCss}\n${experienceCss}`;
+        virtualGrid.className = 'nitro-catalog-grid-virtual';
+        scrollArea.className = 'nitro-classic-scroll-area';
+        viewport.className = 'nitro-classic-scroll-area-viewport';
+        scrollbar.className = 'nitro-classic-scrollbar';
+        scrollbar.dataset.visible = 'true';
+        scrollArea.append(viewport, scrollbar);
+        virtualGrid.append(scrollArea);
+        document.head.append(stylesheet);
+        document.body.append(virtualGrid);
+
+        expect(getComputedStyle(viewport).paddingRight).toBe('17px');
+    });
+});

--- a/src/css/catalog/CatalogResponsiveGrid.test.ts
+++ b/src/css/catalog/CatalogResponsiveGrid.test.ts
@@ -66,4 +66,34 @@ describe('responsive catalog item grid', () => {
 
         expect(getComputedStyle(viewport).paddingRight).toBe('17px');
     });
+
+    it('keeps auto-fill active at the compact catalog breakpoint', () => {
+        const compactRule = catalogCss.match(/@media \(max-width: 640px\)[\s\S]*?\.nitro-catalog-grid\s*\{([^}]*)\}/)?.[1] ?? '';
+
+        expect(compactRule.replaceAll(' ', '')).toContain(
+            'grid-template-columns:repeat(auto-fill,minmax(var(--nitro-grid-column-min-width,47px),1fr))'
+        );
+    });
+
+    it('lets fixed-coordinate offer templates expose the full catalog width to auto-fill', () => {
+        const stylesheet = document.createElement('style');
+        const layout = document.createElement('div');
+        const preview = document.createElement('div');
+        const grid = document.createElement('div');
+        const purchase = document.createElement('div');
+
+        stylesheet.textContent = `${catalogCss}\n${experienceCss}`;
+        layout.className = 'nitro-catalog-pet-customization-layout';
+        preview.className = 'nitro-catalog-pet-customization-preview';
+        grid.className = 'nitro-catalog-pet-customization-grid';
+        purchase.className = 'nitro-catalog-pet-customization-purchase';
+        layout.append(preview, grid, purchase);
+        document.head.append(stylesheet);
+        document.body.append(layout);
+
+        expect(getComputedStyle(layout).width).toBe('100%');
+        expect(getComputedStyle(preview).width).toBe('100%');
+        expect(getComputedStyle(grid).width).toBe('100%');
+        expect(getComputedStyle(purchase).width).toBe('100%');
+    });
 });

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -1398,7 +1398,7 @@
 }
 
 .nitro-catalog-grid {
-    grid-template-columns: repeat(auto-fill, var(--nitro-grid-column-min-width, 53px)) !important;
+    grid-template-columns: repeat(auto-fill, minmax(var(--nitro-grid-column-min-width, 53px), 1fr)) !important;
     grid-auto-rows: var(--nitro-grid-column-min-height, 70px);
     align-content: start;
     justify-content: start;

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -1398,7 +1398,7 @@
 }
 
 .nitro-catalog-grid {
-    grid-template-columns: repeat(6, 1fr) !important;
+    grid-template-columns: repeat(auto-fill, var(--nitro-grid-column-min-width, 53px)) !important;
     grid-auto-rows: var(--nitro-grid-column-min-height, 70px);
     align-content: start;
     justify-content: start;

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -2286,7 +2286,7 @@
     }
 
     .nitro-catalog-grid {
-        grid-template-columns: repeat(auto-fill, minmax(47px, 47px)) !important;
+        grid-template-columns: repeat(auto-fill, minmax(var(--nitro-grid-column-min-width, 47px), 1fr)) !important;
     }
 }
 

--- a/src/hooks/catalog/useCatalogDisplayPreferences.test.ts
+++ b/src/hooks/catalog/useCatalogDisplayPreferences.test.ts
@@ -14,11 +14,11 @@ describe('catalog grid personalization', () => {
         expect(getCatalogGridMetrics('invalid' as any)).toEqual({ columnCount: 6, columnMinHeight: 74, columnMinWidth: 53 });
     });
 
-    it('keeps the standard tile width while allowing the React density variants', () => {
+    it('keeps each density tile width while allowing responsive column counts', () => {
         const css = readFileSync(resolve(process.cwd(), 'src/css/catalog/CatalogExperience.css'), 'utf8');
 
-        expect(css).toContain('grid-template-columns: repeat(6, 53px)');
-        expect(css).toContain('nitro-catalog-grid-density-compact');
-        expect(css).toContain('nitro-catalog-grid-density-large');
+        expect(css).toContain('--nitro-grid-column-min-width: 53px');
+        expect(css).toContain('--nitro-grid-column-min-width: 45px');
+        expect(css).toContain('--nitro-grid-column-min-width: 68px');
     });
 });

--- a/src/layout/InfiniteGrid.test.tsx
+++ b/src/layout/InfiniteGrid.test.tsx
@@ -1,0 +1,45 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InfiniteGrid } from './InfiniteGrid';
+
+vi.mock('@tanstack/react-virtual', () => ({
+    useVirtualizer: () => ({
+        getTotalSize: () => 700,
+        getVirtualItems: () => [{ index: 0, key: 0, size: 70, start: 0 }],
+        measureElement: vi.fn(),
+        scrollToIndex: vi.fn()
+    })
+}));
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('InfiniteGrid responsive columns', () => {
+    it('excludes scrollbar padding when calculating virtualized columns', async () => {
+        vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(580);
+        vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(200);
+        vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(800);
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            paddingLeft: '0px',
+            paddingRight: '17px'
+        } as CSSStyleDeclaration);
+
+        const { container } = render(
+            <InfiniteGrid
+                classicScrollbar
+                columnCount={6}
+                estimateSize={70}
+                itemMinWidth={53}
+                items={Array.from({ length: 100 }, (_, index) => index + 1)}
+                itemRender={(item) => <span>{item}</span>}
+            />
+        );
+
+        await waitFor(() => {
+            const firstRow = container.querySelector('[data-index="0"]');
+
+            expect(firstRow?.children).toHaveLength(9);
+        });
+    });
+});

--- a/src/layout/InfiniteGrid.test.tsx
+++ b/src/layout/InfiniteGrid.test.tsx
@@ -37,9 +37,10 @@ describe('InfiniteGrid responsive columns', () => {
         );
 
         await waitFor(() => {
-            const firstRow = container.querySelector('[data-index="0"]');
+            const firstRow = container.querySelector<HTMLElement>('[data-index="0"]');
 
             expect(firstRow?.children).toHaveLength(9);
+            expect(firstRow?.style.gridTemplateColumns).toBe('repeat(auto-fill, minmax(53px, 1fr))');
         });
     });
 });

--- a/src/layout/InfiniteGrid.tsx
+++ b/src/layout/InfiniteGrid.tsx
@@ -30,7 +30,9 @@ const useColumnMeasure = (itemMinWidth: number | null, columnCountProp: number):
         if (!element) return;
 
         const recompute = () => {
-            const width = element.clientWidth;
+            const computedStyle = window.getComputedStyle(element);
+            const horizontalPadding = Number.parseFloat(computedStyle.paddingLeft) + Number.parseFloat(computedStyle.paddingRight);
+            const width = element.clientWidth - horizontalPadding;
             const cols = Math.max(1, Math.floor((width + GRID_GAP_PX) / (itemMinWidth + GRID_GAP_PX)));
             setMeasuredColumnCount((prev) => (prev === cols ? prev : cols));
         };
@@ -113,7 +115,7 @@ const InfiniteGridVirtualized = <T,>(props: Props<T>) => {
         const checkAndApplyPadding = () => {
             if (!element) return;
 
-            element.style.paddingRight = element.scrollHeight > element.clientHeight ? '0.25rem' : '0';
+            element.style.paddingRight = element.scrollHeight > element.clientHeight ? (classicScrollbar ? '17px' : '0.25rem') : '0';
         };
 
         checkAndApplyPadding();
@@ -123,7 +125,7 @@ const InfiniteGridVirtualized = <T,>(props: Props<T>) => {
         return () => {
             window.removeEventListener('resize', checkAndApplyPadding);
         };
-    }, [items, parentRef]);
+    }, [items, parentRef, classicScrollbar]);
 
     useEffect(() => {
         if (!items || !items.length) return;

--- a/src/layout/InfiniteGrid.tsx
+++ b/src/layout/InfiniteGrid.tsx
@@ -54,7 +54,7 @@ const InfiniteGridSquare = <T,>(props: Props<T>) => {
     const { items = [], columnCount: columnCountProp = 4, itemMinWidth = null, itemRender = null, classicScrollbar = false } = props;
     const { parentRef } = useColumnMeasure(itemMinWidth, columnCountProp);
 
-    const autoFillStyle = itemMinWidth && itemMinWidth > 0 ? { gridTemplateColumns: `repeat(auto-fill, ${itemMinWidth}px)` } : null;
+    const autoFillStyle = itemMinWidth && itemMinWidth > 0 ? { gridTemplateColumns: `repeat(auto-fill, minmax(${itemMinWidth}px, 1fr))` } : null;
     const fixedColsClass = itemMinWidth && itemMinWidth > 0 ? '' : `grid-cols-${columnCountProp}`;
 
     const content = (
@@ -97,7 +97,7 @@ const InfiniteGridVirtualized = <T,>(props: Props<T>) => {
 
     const rowsContainerClassName = rowGap !== null ? 'flex flex-col w-full relative' : 'flex flex-col w-full *:pb-1 relative';
 
-    const autoFillStyle = itemMinWidth && itemMinWidth > 0 ? { gridTemplateColumns: `repeat(auto-fill, ${itemMinWidth}px)` } : null;
+    const autoFillStyle = itemMinWidth && itemMinWidth > 0 ? { gridTemplateColumns: `repeat(auto-fill, minmax(${itemMinWidth}px, 1fr))` } : null;
     const fixedColsClass = itemMinWidth && itemMinWidth > 0 ? '' : `grid-cols-${columnCountProp}`;
 
     const virtualizer = useVirtualizer({


### PR DESCRIPTION
## Summary
- expand catalog product previews with the window and resize the room render texture
- add fixed-width responsive item columns for every density
- reserve the classic scrollbar width in regular and virtualized grids so the last column stays visible

## Verification
- yarn test: 184 files, 1002 tests passed
- yarn typecheck
- yarn build
- git diff --check