### PR TITLE
Match own-avatar menu to classic client

### DIFF
--- a/src/components/room/widgets/avatar-info/menu/AvatarInfoWidgetOwnAvatarView.classic.test.tsx
+++ b/src/components/room/widgets/avatar-info/menu/AvatarInfoWidgetOwnAvatarView.classic.test.tsx
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AvatarInfoWidgetOwnAvatarView } from './AvatarInfoWidgetOwnAvatarView';
+
+const { createLinkEventMock } = vi.hoisted(() => ({ createLinkEventMock: vi.fn() }));
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+vi.mock('@nitrots/nitro-renderer', () => ({
+    AvatarAction: { POSTURE_STAND: 'std' },
+    AvatarExpressionEnum: {
+        BLOW: { ordinal: 2 },
+        IDLE: { ordinal: 3 },
+        LAUGH: { ordinal: 4 },
+        WAVE: { ordinal: 1 }
+    },
+    CreateLinkEvent: createLinkEventMock,
+    RoomControllerLevel: { GUEST: 0 },
+    RoomObjectCategory: { UNIT: 100 },
+    RoomUnitDropHandItemComposer: class {}
+}));
+
+vi.mock('../../../../../api', () => ({
+    DispatchUiEvent: vi.fn(),
+    GetCanStandUp: () => false,
+    GetCanUseExpression: () => true,
+    GetOwnPosture: () => 'std',
+    GetUserProfile: vi.fn(),
+    HasHabboClub: () => true,
+    HasHabboVip: () => true,
+    IsRidingHorse: () => false,
+    LocalizeText: (key: string) => key,
+    PostureTypeEnum: { POSTURE_SIT: 'sit', POSTURE_STAND: 'stand' },
+    SendMessageComposer: vi.fn()
+}));
+
+vi.mock('../../../../../events', () => ({ HelpNameChangeEvent: class {} }));
+
+vi.mock('../../../../../hooks', () => ({
+    useRoom: () => ({
+        roomSession: {
+            sendDanceMessage: vi.fn(),
+            sendExpressionMessage: vi.fn(),
+            sendPostureMessage: vi.fn(),
+            sendSignMessage: vi.fn()
+        }
+    }),
+    useWiredTools: () => ({ openInspectionForUser: vi.fn(), showInspectButton: false })
+}));
+
+vi.mock('../../context-menu/ContextMenuView', () => ({
+    ContextMenuView: ({ children, classNames = [] }: { children: ReactNode; classNames?: string[] }) => <div className={classNames.join(' ')}>{children}</div>
+}));
+
+describe('AvatarInfoWidgetOwnAvatarView classic menu', () => {
+    it('keeps the classic actions without the custom nickname and badge leaderboard entries', () => {
+        render(
+            <AvatarInfoWidgetOwnAvatarView
+                avatarInfo={
+                    {
+                        allowNameChange: false,
+                        amIAnyRoomController: false,
+                        amIOwner: true,
+                        carryItem: 0,
+                        name: 'tester',
+                        roomControllerLevel: 0,
+                        roomIndex: 7,
+                        userType: 1,
+                        webID: 42
+                    } as any
+                }
+                isDancing={false}
+                setIsDecorating={vi.fn()}
+                onClose={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText('widget.avatar.decorate')).toBeInTheDocument();
+        expect(screen.getByText('widget.memenu.myclothes')).toBeInTheDocument();
+        expect(screen.getByText('product.type.effect')).toBeInTheDocument();
+        expect(screen.getByText('widget.memenu.dance')).toBeInTheDocument();
+        expect(screen.getByText('infostand.link.expressions')).toBeInTheDocument();
+        expect(screen.getByText('infostand.show.signs')).toBeInTheDocument();
+        expect(screen.queryByText('Nick Custom')).not.toBeInTheDocument();
+        expect(screen.queryByText('badge_leaderboard.title.total_badges')).not.toBeInTheDocument();
+    });
+
+    it('keeps retained actions wired and removes forbidden actions from the handler', () => {
+        const setIsDecorating = vi.fn();
+
+        render(
+            <AvatarInfoWidgetOwnAvatarView
+                avatarInfo={
+                    {
+                        allowNameChange: false,
+                        amIAnyRoomController: false,
+                        amIOwner: true,
+                        carryItem: 0,
+                        name: 'tester',
+                        roomControllerLevel: 0,
+                        roomIndex: 7,
+                        userType: 1,
+                        webID: 42
+                    } as any
+                }
+                isDancing={false}
+                setIsDecorating={setIsDecorating}
+                onClose={vi.fn()}
+            />
+        );
+
+        fireEvent.click(screen.getByText('widget.avatar.decorate'));
+        fireEvent.click(screen.getByText('widget.memenu.myclothes'));
+        fireEvent.click(screen.getByText('product.type.effect'));
+
+        expect(setIsDecorating).toHaveBeenCalledWith(true);
+        expect(createLinkEventMock).toHaveBeenCalledWith('avatar-editor/show');
+        expect(createLinkEventMock).toHaveBeenCalledWith('avatar-effects/show');
+
+        const source = readFileSync(resolve(process.cwd(), 'src/components/room/widgets/avatar-info/menu/AvatarInfoWidgetOwnAvatarView.tsx'), 'utf8');
+        expect(source).not.toContain('customize_nick');
+        expect(source).not.toContain('badge_leaderboard');
+    });
+});

--- a/src/components/room/widgets/avatar-info/menu/AvatarInfoWidgetOwnAvatarView.tsx
+++ b/src/components/room/widgets/avatar-info/menu/AvatarInfoWidgetOwnAvatarView.tsx
@@ -70,12 +70,6 @@ export const AvatarInfoWidgetOwnAvatarView: FC<AvatarInfoWidgetOwnAvatarViewProp
                     case 'avatar_effect':
                         CreateLinkEvent('avatar-effects/show');
                         break;
-                    case 'customize_nick':
-                        CreateLinkEvent('customize/show');
-                        break;
-                    case 'badge_leaderboard':
-                        CreateLinkEvent('badge-leaderboard/show');
-                        break;
                     case 'expressions':
                         hideMenu = false;
                         setMode(MODE_EXPRESSIONS);
@@ -167,10 +161,6 @@ export const AvatarInfoWidgetOwnAvatarView: FC<AvatarInfoWidgetOwnAvatarViewProp
                         {LocalizeText('widget.memenu.myclothes')}
                     </ContextMenuListItemView>
                     <ContextMenuListItemView onClick={(event) => processAction('avatar_effect')}>{LocalizeText('product.type.effect')}</ContextMenuListItemView>
-                    <ContextMenuListItemView onClick={(event) => processAction('customize_nick')}>Nick Custom</ContextMenuListItemView>
-                    <ContextMenuListItemView onClick={(event) => processAction('badge_leaderboard')}>
-                        {LocalizeText('badge_leaderboard.title.total_badges')}
-                    </ContextMenuListItemView>
                     {HasHabboClub() && !isRidingHorse && (
                         <ContextMenuListItemView onClick={(event) => processAction('dance_menu')}>
                             <FaChevronRight className="right fa-icon" />

--- a/src/css/room/AvatarActionMenuClassic.test.ts
+++ b/src/css/room/AvatarActionMenuClassic.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('Classic avatar action menu geometry', () => {
-    it('matches the classic menu shell, rows and minimize footer', () => {
+    it('matches the rendered classic menu shell, rows and footer', () => {
         const stylesheet = document.createElement('style');
         const menu = document.createElement('div');
         const header = document.createElement('div');
@@ -38,22 +38,25 @@ describe('Classic avatar action menu geometry', () => {
         const splitItemStyle = getComputedStyle(splitItem);
         const footerStyle = getComputedStyle(footer);
 
-        expect(menuStyle.width).toBe('115px');
-        expect(menuStyle.minWidth).toBe('115px');
-        expect(menuStyle.padding).toBe('7px 3px 5px');
-        expect(menuStyle.backgroundColor).toBe('rgb(110, 107, 103)');
-        expect(headerStyle.width).toBe('107px');
-        expect(headerStyle.height).toBe('16px');
-        expect(itemStyle.width).toBe('103px');
-        expect(itemStyle.height).toBe('26px');
-        expect(itemStyle.backgroundColor).toBe('rgb(45, 42, 39)');
-        expect(splitStyle.width).toBe('103px');
+        expect(menuStyle.width).toBe('101px');
+        expect(menuStyle.minWidth).toBe('101px');
+        expect(menuStyle.padding).toBe('1px 0px 0px');
+        expect(menuStyle.backgroundColor).toBe('rgb(42, 39, 37)');
+        expect(menuStyle.boxShadow).toBe('none');
+        expect(headerStyle.width).toBe('99px');
+        expect(headerStyle.height).toBe('25px');
+        expect(headerStyle.backgroundColor).toBe('rgb(109, 106, 102)');
+        expect(headerStyle.borderBottomColor).toBe('rgb(0, 0, 0)');
+        expect(itemStyle.width).toBe('99px');
+        expect(itemStyle.height).toBe('27px');
+        expect(itemStyle.backgroundColor).toBe('rgb(42, 39, 37)');
+        expect(itemStyle.borderBottomColor).toBe('rgb(79, 76, 72)');
+        expect(splitStyle.width).toBe('99px');
         expect(splitItemStyle.width).toBe('calc(33.3333%)');
         expect(splitItemStyle.margin).toBe('0px');
-        expect(footerStyle.width).toBe('100px');
-        expect(footerStyle.height).toBe('18px');
-        expect(footerStyle.backgroundColor).toBe('rgb(110, 107, 103)');
-        expect(roomWidgetsCss).toMatch(/\.nitro-avatar-action-menu:not\(\.menu-hidden\)::after[\s\S]*border-top:\s*6px solid #6e6b67/);
+        expect(footerStyle.width).toBe('99px');
+        expect(footerStyle.height).toBe('23px');
+        expect(footerStyle.backgroundColor).toBe('rgb(79, 76, 72)');
     });
 
     it('matches the classic minimized bubble and region geometry', () => {

--- a/src/css/room/AvatarActionMenuClassic.test.ts
+++ b/src/css/room/AvatarActionMenuClassic.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roomWidgetsCss = readFileSync(resolve(process.cwd(), 'src/css/room/RoomWidgets.css'), 'utf8');
+
+afterEach(() => {
+    document.body.replaceChildren();
+    document.head.replaceChildren();
+});
+
+describe('Classic avatar action menu geometry', () => {
+    it('matches the classic menu shell, rows and minimize footer', () => {
+        const stylesheet = document.createElement('style');
+        const menu = document.createElement('div');
+        const header = document.createElement('div');
+        const item = document.createElement('div');
+        const split = document.createElement('div');
+        const splitItem = document.createElement('div');
+        const footer = document.createElement('div');
+
+        stylesheet.textContent = roomWidgetsCss;
+        menu.className = 'nitro-context-menu nitro-avatar-action-menu';
+        header.className = 'nitro-context-menu-header';
+        item.className = 'nitro-context-menu-item';
+        split.className = 'menu-list-split-3';
+        splitItem.className = 'nitro-context-menu-item';
+        split.append(splitItem);
+        footer.className = 'nitro-context-menu-footer';
+        menu.append(header, item, split, footer);
+        document.head.append(stylesheet);
+        document.body.append(menu);
+
+        const menuStyle = getComputedStyle(menu);
+        const headerStyle = getComputedStyle(header);
+        const itemStyle = getComputedStyle(item);
+        const splitStyle = getComputedStyle(split);
+        const splitItemStyle = getComputedStyle(splitItem);
+        const footerStyle = getComputedStyle(footer);
+
+        expect(menuStyle.width).toBe('115px');
+        expect(menuStyle.minWidth).toBe('115px');
+        expect(menuStyle.padding).toBe('7px 3px 5px');
+        expect(menuStyle.backgroundColor).toBe('rgb(110, 107, 103)');
+        expect(headerStyle.width).toBe('107px');
+        expect(headerStyle.height).toBe('16px');
+        expect(itemStyle.width).toBe('103px');
+        expect(itemStyle.height).toBe('26px');
+        expect(itemStyle.backgroundColor).toBe('rgb(45, 42, 39)');
+        expect(splitStyle.width).toBe('103px');
+        expect(splitItemStyle.width).toBe('calc(33.3333%)');
+        expect(splitItemStyle.margin).toBe('0px');
+        expect(footerStyle.width).toBe('100px');
+        expect(footerStyle.height).toBe('18px');
+        expect(footerStyle.backgroundColor).toBe('rgb(110, 107, 103)');
+        expect(roomWidgetsCss).toMatch(/\.nitro-avatar-action-menu:not\(\.menu-hidden\)::after[\s\S]*border-top:\s*6px solid #6e6b67/);
+    });
+
+    it('matches the classic minimized bubble and region geometry', () => {
+        const stylesheet = document.createElement('style');
+        const menu = document.createElement('div');
+        const footer = document.createElement('div');
+
+        stylesheet.textContent = roomWidgetsCss;
+        menu.className = 'nitro-context-menu nitro-avatar-action-menu menu-hidden';
+        footer.className = 'nitro-context-menu-footer';
+        menu.append(footer);
+        document.head.append(stylesheet);
+        document.body.append(menu);
+
+        const menuStyle = getComputedStyle(menu);
+        const footerStyle = getComputedStyle(footer);
+
+        expect(menuStyle.width).toBe('45px');
+        expect(menuStyle.minWidth).toBe('45px');
+        expect(menuStyle.height).toBe('35px');
+        expect(menuStyle.minHeight).toBe('35px');
+        expect(menuStyle.backgroundColor).toBe('rgb(110, 107, 103)');
+        expect(footerStyle.width).toBe('38px');
+        expect(footerStyle.height).toBe('30px');
+        expect(footerStyle.backgroundColor).toBe('rgb(110, 107, 103)');
+    });
+});

--- a/src/css/room/RoomWidgets.css
+++ b/src/css/room/RoomWidgets.css
@@ -862,42 +862,46 @@
 
 .nitro-avatar-action-menu {
     box-sizing: border-box;
-    width: 115px;
-    min-width: 115px;
-    padding: 7px 3px 5px;
+    width: 101px;
+    min-width: 101px;
+    padding: 1px 0 0;
     border: 1px solid #050505;
-    border-radius: 4px;
-    background: #6e6b67;
-    box-shadow: 1px 2px 0 rgba(0, 0, 0, 0.58);
+    border-radius: 3px;
+    background: #2a2725;
+    box-shadow: none;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-header {
-    width: 107px;
-    height: 16px;
-    margin: 0 0 5px;
-    padding: 0 6px;
+    width: 99px;
+    height: 25px;
+    margin: 0;
+    padding: 0 5px;
     border: 0;
-    border-radius: 0;
-    background: transparent;
+    border-bottom: 1px solid #000000;
+    border-radius: 2px 2px 0 0;
+    background-color: #6d6a66;
+    background-image: linear-gradient(to bottom, #6d6a66 0%, #4f4c48 100%);
     font-size: 11px;
-    line-height: 16px;
+    line-height: 24px;
     text-align: center;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item {
-    width: 103px;
-    height: 26px;
-    min-height: 26px;
-    margin: 0 2px;
+    width: 99px;
+    height: 27px;
+    min-height: 27px;
+    margin: 0;
     padding: 0 4px;
-    background: #2d2a27;
+    border-bottom: 1px solid #4f4c48;
+    background-color: #2a2725;
+    background-image: linear-gradient(to bottom, #2a2725 0%, #262321 100%);
     color: #ffffff;
     font-size: 11px;
     line-height: 26px;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item + .nitro-context-menu-item {
-    border-top: 1px solid #151515;
+    border-top: 0;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item:hover {
@@ -905,8 +909,8 @@
 }
 
 .nitro-avatar-action-menu .menu-list-split-3 {
-    width: 103px;
-    margin: 0 2px;
+    width: 99px;
+    margin: 0;
 }
 
 .nitro-avatar-action-menu .menu-list-split-3 .nitro-context-menu-item {
@@ -926,26 +930,17 @@
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-footer {
-    width: 100px;
-    height: 18px;
-    margin: 0 auto;
+    width: 99px;
+    height: 23px;
+    margin: 0;
     border: 0;
     border-radius: 0 0 2px 2px;
-    background: #6e6b67;
+    background: #4f4c48;
 }
 
 .nitro-avatar-action-menu:not(.menu-hidden)::after {
-    position: absolute;
-    bottom: -6px;
-    left: calc(50% - 6px);
-    width: 0;
-    height: 0;
     content: '';
-    border-top: 6px solid #6e6b67;
-    border-right: 6px solid transparent;
-    border-left: 6px solid transparent;
-    filter: drop-shadow(0 1px 0 #050505);
-    pointer-events: none;
+    display: none;
 }
 
 .nitro-avatar-action-menu.menu-hidden {

--- a/src/css/room/RoomWidgets.css
+++ b/src/css/room/RoomWidgets.css
@@ -861,43 +861,62 @@
 }
 
 .nitro-avatar-action-menu {
-    width: 112px;
-    min-width: 112px;
-    padding: 1px 0 0;
+    box-sizing: border-box;
+    width: 115px;
+    min-width: 115px;
+    padding: 7px 3px 5px;
     border: 1px solid #050505;
     border-radius: 4px;
-    background: rgba(39, 40, 37, 0.94);
+    background: #6e6b67;
     box-shadow: 1px 2px 0 rgba(0, 0, 0, 0.58);
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-header {
-    height: 25px;
-    margin: 0;
-    padding: 0 5px;
+    width: 107px;
+    height: 16px;
+    margin: 0 0 5px;
+    padding: 0 6px;
     border: 0;
-    border-radius: 3px 3px 0 0;
-    background: #6d6c67;
+    border-radius: 0;
+    background: transparent;
     font-size: 11px;
-    line-height: 25px;
+    line-height: 16px;
     text-align: center;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item {
-    height: 25px;
-    min-height: 25px;
-    padding: 0 5px;
-    background: transparent;
+    width: 103px;
+    height: 26px;
+    min-height: 26px;
+    margin: 0 2px;
+    padding: 0 4px;
+    background: #2d2a27;
     color: #ffffff;
     font-size: 11px;
-    line-height: 25px;
+    line-height: 26px;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item + .nitro-context-menu-item {
-    border-top: 1px solid #4a4a46;
+    border-top: 1px solid #151515;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item:hover {
-    background: #3d3d39;
+    background: #45413d;
+}
+
+.nitro-avatar-action-menu .menu-list-split-3 {
+    width: 103px;
+    margin: 0 2px;
+}
+
+.nitro-avatar-action-menu .menu-list-split-3 .nitro-context-menu-item {
+    width: calc(100% / 3);
+    margin: 0;
+}
+
+.nitro-avatar-action-menu .menu-list-split-3 .nitro-context-menu-item + .nitro-context-menu-item {
+    border-top: 0;
+    border-left: 1px solid #151515;
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-item .right.fa-icon,
@@ -907,11 +926,12 @@
 }
 
 .nitro-avatar-action-menu .nitro-context-menu-footer {
-    height: 22px;
-    margin: 0;
-    border-top: 1px solid #4a4a46;
-    border-radius: 0 0 3px 3px;
-    background: #676762;
+    width: 100px;
+    height: 18px;
+    margin: 0 auto;
+    border: 0;
+    border-radius: 0 0 2px 2px;
+    background: #6e6b67;
 }
 
 .nitro-avatar-action-menu:not(.menu-hidden)::after {
@@ -921,7 +941,7 @@
     width: 0;
     height: 0;
     content: '';
-    border-top: 6px solid #292a27;
+    border-top: 6px solid #6e6b67;
     border-right: 6px solid transparent;
     border-left: 6px solid transparent;
     filter: drop-shadow(0 1px 0 #050505);
@@ -929,22 +949,22 @@
 }
 
 .nitro-avatar-action-menu.menu-hidden {
-    width: 32px;
-    min-width: 32px;
-    height: 23px;
-    min-height: 23px;
-    padding: 1px;
+    width: 45px;
+    min-width: 45px;
+    height: 35px;
+    min-height: 35px;
+    padding: 1px 2px 2px;
     border-radius: 4px;
-    background: #292a27;
+    background: #6e6b67;
     box-shadow: 1px 2px 0 rgba(0, 0, 0, 0.58);
 }
 
 .nitro-avatar-action-menu.menu-hidden .nitro-context-menu-footer {
-    width: 28px;
-    height: 19px;
+    width: 38px;
+    height: 30px;
     border: 0;
     border-radius: 3px;
-    background: #454640;
+    background: #6e6b67;
 }
 
 .nitro-avatar-action-menu.menu-hidden .nitro-context-menu-footer:hover {


### PR DESCRIPTION
## Summary
- match the compact classic own-avatar menu geometry and styling
- preserve the supported avatar actions while removing Nick Custom and the badge leaderboard
- cover expanded and collapsed layouts plus action wiring

## Verification
- yarn test (183 files, 1000 tests)
- yarn typecheck
- yarn build
- targeted classic menu tests (4 tests)