### PR TITLE
Fix build: alias pixi.js/advanced-blend-modes ahead of package dir

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -159,6 +159,11 @@ export default defineConfig({
             '@nitrots/sound': resolve(rendererRoot, 'packages/sound/src/index.ts'),
             '@nitrots/utils/src': resolve(rendererRoot, 'packages/utils/src'),
             '@nitrots/utils': resolve(rendererRoot, 'packages/utils/src/index.ts'),
+            // Keep Pixi's exported registration entries ahead of the broad
+            // package-directory alias, which would otherwise swallow those
+            // subpaths and resolve them to directories that do not exist
+            // (the alias bypasses pixi's package.json `exports` map).
+            'pixi.js/advanced-blend-modes': resolve(rendererRoot, 'node_modules/pixi.js/lib/advanced-blend-modes/init.mjs'),
             'pixi.js': resolve(rendererRoot, 'node_modules/pixi.js'),
             'pixi-filters': resolve(rendererRoot, 'node_modules/pixi-filters'),
             'howler': resolve(rendererRoot, 'node_modules/howler'),


### PR DESCRIPTION
## Problem

`yarn build` fails on `Dev`:

```
[UNLOADABLE_DEPENDENCY] Could not load ../Octane-Renderer/node_modules/pixi.js/advanced-blend-modes
   ╭─[ ../Octane-Renderer/packages/camera/src/RoomCameraWidgetManager.ts:5:8 ]
 5 │ import "pixi.js/advanced-blend-modes";
   │        ───────────────┬──────────────
   │                       ╰──────────────── No such file or directory (os error 2)
```

## Cause

Octane-Renderer imports the `pixi.js/advanced-blend-modes` **package-exports subpath** in `packages/camera/src/RoomCameraWidgetManager.ts` to register Pixi's advanced blend modes. pixi.js 8.19.0 does define it (`"./advanced-blend-modes" → "./lib/advanced-blend-modes/init.mjs"`), so the package is fine.

Alias matching is prefix-based, so the broad package-directory alias

```js
'pixi.js': resolve(rendererRoot, 'node_modules/pixi.js'),
```

also captured that specifier and rewrote it to `<renderer>/node_modules/pixi.js/advanced-blend-modes`. Once it is a filesystem path, pixi's `package.json` `exports` map is never consulted, nothing maps it to `lib/advanced-blend-modes/init.mjs`, and the directory does not exist on disk — hence the error.

The renderer builds fine standalone because it resolves `pixi.js` through node_modules, where `exports` does apply. Only the Octane build, with the directory alias, breaks.

## Change

`vite.config.mjs` — add an explicit alias for the subpath, ordered **before** the package-directory alias so it wins:

```js
'pixi.js/advanced-blend-modes': resolve(rendererRoot, 'node_modules/pixi.js/lib/advanced-blend-modes/init.mjs'),
'pixi.js': resolve(rendererRoot, 'node_modules/pixi.js'),
```

## Notes

- `advanced-blend-modes` is currently the only `pixi.js/*` subpath import in the renderer's `Dev` tree, so this one entry is sufficient today. Any future subpath import will need the same treatment (or the alias list can be generated from pixi's `exports` map).
- The equivalent fix already exists in the combined `Nitro-Cool-UI-Renderer` repo; it had not been pushed back here, which is why `git pull` on `Dev` reported "Already up to date" while the build stayed broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRLXzjBEHheQH4JfWhe59w)_