### PR TITLE
feat: consume the effects and first-login packets

### DIFF
--- a/src/components/avatar-effects/AvatarEffectsView.tsx
+++ b/src/components/avatar-effects/AvatarEffectsView.tsx
@@ -1,7 +1,6 @@
 import {
     AddLinkEventTracker,
     AvatarDirectionAngle,
-    AvatarEffectActivatedComposer,
     GetConfiguration,
     GetSessionDataManager,
     ILinkEventTracker,
@@ -10,7 +9,8 @@ import {
 } from '@nitrots/nitro-renderer';
 import { ChangeEvent, FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FaChevronLeft, FaChevronRight, FaSearch } from 'react-icons/fa';
-import { LocalizeText, SendMessageComposer } from '../../api';
+import { LocalizeText } from '../../api';
+import { useAvatarEffects } from '../../hooks';
 import { Button, Column, NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../common';
 import { AvatarEffectPreviewView } from './AvatarEffectPreviewView';
 
@@ -94,6 +94,9 @@ export const AvatarEffectsView: FC<{}> = () => {
         };
     }, [isVisible, effects.length, loadError]);
 
+    const { effects: ownedEffects, activeEffectType, activateEffect, isOwned } = useAvatarEffects();
+    const [ownedOnly, setOwnedOnly] = useState(false);
+
     const session = GetSessionDataManager();
     const figure = session?.figure ?? '';
     const gender = session?.gender ?? 'M';
@@ -109,23 +112,30 @@ export const AvatarEffectsView: FC<{}> = () => {
 
     const applySelectedEffect = useCallback(() => {
         if (!selectedId) return;
-        SendMessageComposer(new AvatarEffectActivatedComposer(selectedId));
+        activateEffect(selectedId);
         setIsVisible(false);
-    }, [selectedId]);
+    }, [selectedId, activateEffect]);
 
     const removeCurrentEffect = useCallback(() => {
-        SendMessageComposer(new AvatarEffectActivatedComposer(0));
+        activateEffect(0);
         setSelectedId(0);
         setIsVisible(false);
-    }, []);
+    }, [activateEffect]);
 
     const onClose = useCallback(() => setIsVisible(false), []);
 
+    // The server is the authority on what is currently running: follow it
+    // whenever the window is opened without an explicit pick.
+    useEffect(() => {
+        if (isVisible && !selectedId && activeEffectType) setSelectedId(activeEffectType);
+    }, [isVisible, selectedId, activeEffectType]);
+
     const filteredEffects = useMemo(() => {
         const trimmed = query.trim().toLowerCase();
-        if (!trimmed) return effects;
-        return effects.filter((e) => e.id.toLowerCase().includes(trimmed) || e.lib.toLowerCase().includes(trimmed));
-    }, [effects, query]);
+        const pool = ownedOnly ? effects.filter((e) => isOwned(parseInt(e.id, 10))) : effects;
+        if (!trimmed) return pool;
+        return pool.filter((e) => e.id.toLowerCase().includes(trimmed) || e.lib.toLowerCase().includes(trimmed));
+    }, [effects, query, ownedOnly, isOwned]);
 
     const onQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
         setQuery(event.target.value);
@@ -216,6 +226,12 @@ export const AvatarEffectsView: FC<{}> = () => {
                         <span>
                             {filteredEffects.length === effects.length ? `${effects.length} effects` : `${filteredEffects.length} of ${effects.length}`}
                         </span>
+                        {!!ownedEffects.length && (
+                            <label className="flex cursor-pointer items-center gap-1 normal-case font-semibold text-[#3a78c4]">
+                                <input type="checkbox" checked={ownedOnly} onChange={(event) => setOwnedOnly(event.target.checked)} />
+                                {LocalizeText('inventory.effects.owned.only') || `owned (${ownedEffects.length})`}
+                            </label>
+                        )}
                         {selectedId > 0 && (
                             <button
                                 type="button"
@@ -240,6 +256,8 @@ export const AvatarEffectsView: FC<{}> = () => {
                                 {visibleEffects.map((effect, index) => {
                                     const id = parseInt(effect.id, 10);
                                     const isSelected = id === selectedId;
+                                    const owned = isOwned(id);
+                                    const isActive = id === activeEffectType;
                                     return (
                                         <li key={effect.id}>
                                             <button
@@ -257,6 +275,16 @@ export const AvatarEffectsView: FC<{}> = () => {
                                                     #{id}
                                                 </span>
                                                 <span className="truncate font-semibold">{effect.lib}</span>
+                                                {isActive && (
+                                                    <span className="ml-auto shrink-0 rounded bg-[#2f7d32] px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+                                                        {LocalizeText('inventory.effects.active') || 'active'}
+                                                    </span>
+                                                )}
+                                                {owned && !isActive && (
+                                                    <span className="ml-auto shrink-0 rounded bg-[#3a78c4] px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+                                                        {LocalizeText('inventory.effects.owned') || 'owned'}
+                                                    </span>
+                                                )}
                                             </button>
                                         </li>
                                     );

--- a/src/hooks/avatar-effects/index.ts
+++ b/src/hooks/avatar-effects/index.ts
@@ -1,0 +1,1 @@
+export * from './useAvatarEffects';

--- a/src/hooks/avatar-effects/useAvatarEffects.ts
+++ b/src/hooks/avatar-effects/useAvatarEffects.ts
@@ -1,0 +1,121 @@
+import {
+    AvatarEffectActivatedComposer,
+    AvatarEffectActivatedEvent,
+    AvatarEffectAddedEvent,
+    AvatarEffectExpiredEvent,
+    AvatarEffectSelectedEvent,
+    AvatarEffectsEvent
+} from '@nitrots/nitro-renderer';
+import { useCallback, useState } from 'react';
+import { registerSharedHook, useSharedHook } from '@/state/useSharedHook';
+import { SendMessageComposer } from '../../api';
+import { useMessageEvent } from '../events';
+
+/**
+ * One effect the user actually owns, as reported by the server.
+ *
+ * `secondsLeft` is only meaningful while the effect is running: the
+ * emulator sends `elapsed + duration` for the active one and 0 for the
+ * others, so it is stored verbatim and interpreted by the view.
+ */
+export interface OwnedAvatarEffect {
+    type: number;
+    subType: number;
+    duration: number;
+    inactiveCount: number;
+    secondsLeft: number;
+    isPermanent: boolean;
+}
+
+/**
+ * Tracks the avatar effects the user owns.
+ *
+ * The server pushes the full list once, right after login
+ * (`UserEffectsListComposer`, header 340), then deltas as effects are
+ * won, activated or expire. This hook is registered as a shared source
+ * so its subscriptions are alive from app start — a hook that only
+ * mounted with the effects window would miss the login packet entirely.
+ */
+const useAvatarEffectsState = () => {
+    const [effects, setEffects] = useState<OwnedAvatarEffect[]>([]);
+    const [activeEffectType, setActiveEffectType] = useState(0);
+
+    const upsertEffect = useCallback((effect: OwnedAvatarEffect) => {
+        setEffects(prev => {
+            const index = prev.findIndex(existing => existing.type === effect.type);
+
+            if (index === -1) return [ ...prev, effect ];
+
+            const next = [ ...prev ];
+
+            next[index] = effect;
+
+            return next;
+        });
+    }, []);
+
+    useMessageEvent<AvatarEffectsEvent>(AvatarEffectsEvent, event => {
+        const parsed = event.getParser().effects.map<OwnedAvatarEffect>(effect => ({
+            type: effect.type,
+            subType: effect.subType,
+            duration: effect.duration,
+            inactiveCount: effect.inactiveEffectsInInventory,
+            secondsLeft: effect.secondsLeftIfActive,
+            isPermanent: effect.isPermanent
+        }));
+
+        setEffects(parsed);
+
+        // A running effect is the only one the server reports time for.
+        const running = parsed.find(effect => !effect.isPermanent && effect.secondsLeft > 0);
+
+        setActiveEffectType(running ? running.type : 0);
+    });
+
+    useMessageEvent<AvatarEffectAddedEvent>(AvatarEffectAddedEvent, event => {
+        const parser = event.getParser();
+
+        upsertEffect({
+            type: parser.type,
+            subType: parser.subType,
+            duration: parser.duration,
+            inactiveCount: 1,
+            secondsLeft: 0,
+            isPermanent: parser.isPermanent
+        });
+    });
+
+    useMessageEvent<AvatarEffectExpiredEvent>(AvatarEffectExpiredEvent, event => {
+        const type = event.getParser().type;
+
+        setEffects(prev => prev.filter(effect => effect.type !== type));
+        setActiveEffectType(prev => (prev === type ? 0 : prev));
+    });
+
+    useMessageEvent<AvatarEffectActivatedEvent>(AvatarEffectActivatedEvent, event => {
+        const parser = event.getParser();
+
+        setActiveEffectType(parser.type);
+
+        setEffects(prev => prev.map(effect => (effect.type === parser.type
+            ? { ...effect, duration: parser.duration, secondsLeft: parser.duration, isPermanent: parser.isPermanent }
+            : effect)));
+    });
+
+    useMessageEvent<AvatarEffectSelectedEvent>(AvatarEffectSelectedEvent, event => {
+        setActiveEffectType(event.getParser().type);
+    });
+
+    const activateEffect = useCallback((type: number) => {
+        setActiveEffectType(type);
+        SendMessageComposer(new AvatarEffectActivatedComposer(type));
+    }, []);
+
+    const isOwned = useCallback((type: number) => effects.some(effect => effect.type === type), [ effects ]);
+
+    return { effects, activeEffectType, activateEffect, isOwned };
+};
+
+export const useAvatarEffects = () => useSharedHook(useAvatarEffectsState);
+
+registerSharedHook(useAvatarEffectsState);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './achievements';
 export * from './avatar-editor';
+export * from './avatar-effects';
 export * from './buildheight/useBuildHeight';
 export * from './camera';
 export * from './catalog';

--- a/src/hooks/session/index.ts
+++ b/src/hooks/session/index.ts
@@ -1,2 +1,3 @@
+export * from './useFirstLoginOfDay';
 export * from './useSessionInfo';
 export * from './useSessionSnapshots';

--- a/src/hooks/session/useFirstLoginOfDay.ts
+++ b/src/hooks/session/useFirstLoginOfDay.ts
@@ -1,0 +1,27 @@
+import { IsFirstLoginOfDayEvent } from '@nitrots/nitro-renderer';
+import { useState } from 'react';
+import { registerSharedHook, useSharedHook } from '@/state/useSharedHook';
+import { useMessageEvent } from '../events';
+
+/**
+ * Consumes `IsFirstLoginOfDayComposer` (header 793), pushed once during
+ * the login handshake.
+ *
+ * The flag is what the quest engine and daily-reward flows key off. No
+ * such flow exists in this client yet, so the hook simply makes the
+ * answer available: `isFirstLoginOfDay` is null until the server has
+ * spoken, then true or false.
+ */
+const useFirstLoginOfDayState = () => {
+    const [isFirstLoginOfDay, setIsFirstLoginOfDay] = useState<boolean>(null);
+
+    useMessageEvent<IsFirstLoginOfDayEvent>(IsFirstLoginOfDayEvent, event => {
+        setIsFirstLoginOfDay(event.getParser().isFirstLoginOfDay);
+    });
+
+    return { isFirstLoginOfDay };
+};
+
+export const useFirstLoginOfDay = () => useSharedHook(useFirstLoginOfDayState);
+
+registerSharedHook(useFirstLoginOfDayState);

--- a/src/nitro-renderer.mock.ts
+++ b/src/nitro-renderer.mock.ts
@@ -271,6 +271,12 @@ export class FavouritesEvent extends MessageEvent {}
 export class FlatCreatedEvent extends MessageEvent {}
 export class NavigatorHomeRoomEvent extends MessageEvent {}
 export class NavigatorMetadataEvent extends MessageEvent {}
+export class AvatarEffectsEvent extends MessageEvent {}
+export class AvatarEffectAddedEvent extends MessageEvent {}
+export class AvatarEffectExpiredEvent extends MessageEvent {}
+export class AvatarEffectActivatedEvent extends MessageEvent {}
+export class AvatarEffectSelectedEvent extends MessageEvent {}
+export class IsFirstLoginOfDayEvent extends MessageEvent {}
 export class NavigatorOpenRoomCreatorEvent extends MessageEvent {}
 export class NavigatorSearchesEvent extends MessageEvent {}
 export class NavigatorSearchEvent extends MessageEvent {}
@@ -378,6 +384,7 @@ export class HabboWebTools extends StubClass {}
 // Composers — symbol-only constructors; only their identity matters in the
 // codebase ("did the SUT call SendMessageComposer(new FooComposer(args))").
 export class AddFavouriteRoomMessageComposer extends StubClass {}
+export class AvatarEffectActivatedComposer extends StubClass {}
 export class DeleteFavouriteRoomMessageComposer extends StubClass {}
 export class FollowFriendMessageComposer extends StubClass {}
 export class GetUserEventCatsMessageComposer extends StubClass {}


### PR DESCRIPTION
## Problem

Two packets the emulator pushes during login had no subscriber, so every session logs them as unhandled:

```
[Nitro] IncomingMessage 340 UNREGISTERED   UserEffectsList
[Nitro] IncomingMessage 793 UNREGISTERED   IsFirstLoginOfDay
```

Worth being precise about what that log means: `UNREGISTERED` comes from `SocketConnection.getMessagesForWrapper`, which reads `MessageClassManager._messageInstancesById` — a map populated only by `registerMessageEvent`, i.e. by a **mounted** `useMessageEvent`. The event class for 340 already exists and the renderer decodes it correctly; nothing in the client was listening.

Both arrive once, immediately after login. So each consumer is a shared hook registered at module load — a hook that only mounted alongside its window would still miss the packet.

## Changes

**340 — owned avatar effects.** `useAvatarEffects` keeps the list the server sends and folds in the `AvatarEffectAdded` / `Expired` / `Activated` / `Selected` deltas. `AvatarEffectsView` still lists every effect from `avatar.effectmap.url`, but now:
- marks which effects are actually owned and which one is running,
- offers an owned-only filter (shown only when the user owns something),
- preselects the running effect when the window is opened,
- routes activation through the hook so shared state and server stay in step.

**793 — first login of day.** `useFirstLoginOfDay` exposes the flag, null until the server answers. No daily-reward flow exists in this client yet; this makes the answer available rather than dropping it.

## Scope change since the first revision

This PR originally also consumed **518 (NewNavigatorSettings)**. That part has been **dropped**: `Dev` has since grown its own consumer in `NavigatorView.tsx`, with an `applyServerSettings` that goes further than mine did — it applies the window geometry and adds `persistWindowSettings` to save it back. Keeping my version would have been a straight regression, so the branch was rebuilt on top of current `Dev` with only the 340 and 793 work.

## Pairing

Needs duckietm/Octane-Renderer#187 for the 793 parser — **merge that one first**. The `IsFirstLoginOfDayEvent` type-check failure on this PR is exactly that dependency and clears on its own once the renderer lands.

## Verification

Rebuilt on `Dev` @ `67c67842`. `yarn typecheck` clean, `yarn lint:hooks` clean, `yarn vitest run` 1061/1062. The one failure, `src/css/common/ClassicScrollbar.test.ts`, reproduces on a clean checkout of `Dev` with no changes applied — it is inherited, not from this branch.