### PR TITLE
fix: keep ClassicScrollbar.css as the last stylesheet import

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,8 +82,8 @@ import './css/widgets/FurnitureWidgets.css';
 import './css/WiredView.css';
 import './css/camera/CameraWidget.css';
 import './css/catalog/CatalogGiftView.css';
-import './css/common/ClassicScrollbar.css';
 import './css/navigator/NavigatorView.css';
+import './css/common/ClassicScrollbar.css';
 
 document.documentElement.classList.add('has-classic-scrollbar');
 


### PR DESCRIPTION
## Problem

`Dev` is red, and so is every PR opened against it:

```
FAIL  src/css/common/ClassicScrollbar.test.ts
  > is the final interface stylesheet and has no competing global scrollbar theme
AssertionError: expected './css/navigator/NavigatorView.css' to be './css/common/ClassicScrollbar.css'
```

`8b4feda4` ("feat: align navigator UX with AIR client") appended `css/navigator/NavigatorView.css` after `css/common/ClassicScrollbar.css` in `src/index.tsx`, breaking the invariant the test guards: the scrollbar theme must be the **last** stylesheet so nothing can outrank it in the cascade.

Reproduces on a clean checkout of `Dev` with no changes applied — it is not coming from any open branch.

## Change

One line: the two imports swap places, putting `ClassicScrollbar.css` back at the end.

## Why it went unnoticed

The reorder is behaviour-neutral today — `NavigatorView.css` does not declare a single scrollbar rule in its 1290 lines, so nothing was actually being overridden. The test is positional on purpose: it protects the *next* stylesheet that does declare one. Worth keeping it that way rather than relaxing the assertion.

## Verification

`yarn vitest run src/css` — 32/32 across 13 files.