### PR TITLE
feat(soundboard): resolve pads from the asset manifest

### DIFF
--- a/public/configuration/housekeeping-texts-en.example
+++ b/public/configuration/housekeeping-texts-en.example
@@ -162,6 +162,7 @@
     "housekeeping.soundboard.filter.enabled": "Enabled",
     "housekeeping.soundboard.filter.disabled": "Disabled",
     "housekeeping.soundboard.name": "Name",
+    "housekeeping.soundboard.classname": "Sound (classname)",
     "housekeeping.soundboard.url": "URL",
     "housekeeping.soundboard.min_rank": "Minimum rank",
     "housekeeping.soundboard.enabled": "Enabled",

--- a/public/configuration/housekeeping-texts-it.example
+++ b/public/configuration/housekeeping-texts-it.example
@@ -162,6 +162,7 @@
     "housekeeping.soundboard.filter.enabled": "Attivi",
     "housekeeping.soundboard.filter.disabled": "Disattivati",
     "housekeeping.soundboard.name": "Nome",
+    "housekeeping.soundboard.classname": "Suono (classname)",
     "housekeeping.soundboard.url": "URL",
     "housekeeping.soundboard.min_rank": "Rank minimo",
     "housekeeping.soundboard.enabled": "Attivo",

--- a/public/configuration/renderer-config.json.example.json
+++ b/public/configuration/renderer-config.json.example.json
@@ -10,6 +10,8 @@
     "images.url": "https://hotel.example.com/client/nitro/images",
     "gamedata.url": "https://nitro.example.com:2096/nitro-sec/file?kind=gamedata&file=",
     "sounds.url": "${asset.url}/sounds/%sample%.mp3",
+    "soundboard.asset.url": "${asset.url}/sounds/soundboard/%file%",
+    "soundboard.manifest.url": "${gamedata.url}/SoundData.json?t=%timestamp%",
     "external.texts.url": [
         "${gamedata.url}/ExternalTexts.json?t=%timestamp%",
         "${gamedata.url}/UITexts.jsonc?t=%timestamp%"

--- a/src/components/housekeeping/views/soundboard/HousekeepingSoundboardTab.test.tsx
+++ b/src/components/housekeeping/views/soundboard/HousekeepingSoundboardTab.test.tsx
@@ -55,6 +55,12 @@ vi.mock('../../../../hooks', () => ({
         request: mocks.request,
         upsert: mocks.upsert,
         reorder: mocks.reorder
+    }),
+    useSoundboardManifest: () => ({
+        manifest: { categories: [], byClassname: new Map() },
+        manifestRef: { current: { categories: [], byClassname: new Map() } },
+        classnames: [],
+        loaded: true
     })
 }));
 

--- a/src/components/housekeeping/views/soundboard/HousekeepingSoundboardTab.tsx
+++ b/src/components/housekeeping/views/soundboard/HousekeepingSoundboardTab.tsx
@@ -1,7 +1,7 @@
 import { GetSoundManager, ISoundboardCatalogSound } from '@nitrots/nitro-renderer';
 import { DragEvent, FC, useEffect, useMemo, useState } from 'react';
 import { LocalizeText } from '../../../../api';
-import { useSoundboardCatalog } from '../../../../hooks';
+import { useSoundboardCatalog, useSoundboardManifest } from '../../../../hooks';
 import {
     filterCatalogSounds,
     reorderCatalog,
@@ -9,9 +9,9 @@ import {
     SoundboardCatalogFilter,
     validateCatalogDraft
 } from '../../../../hooks/soundboard/soundboardCatalogState';
-import { resolveSoundboardUrl } from '../../../../hooks/soundboard/soundboardUrl';
+import { resolveSoundboardSoundUrl } from '../../../../hooks/soundboard/soundboardUrl';
 
-const EMPTY_DRAFT: SoundboardCatalogDraft = { id: 0, name: '', url: '', minRank: 1, enabled: true };
+const EMPTY_DRAFT: SoundboardCatalogDraft = { id: 0, name: '', classname: '', url: '', minRank: 1, enabled: true };
 const RESULT_KEYS = [
     'success',
     'forbidden',
@@ -26,6 +26,7 @@ const RESULT_KEYS = [
 
 export const HousekeepingSoundboardTab: FC = () => {
     const { sounds, lastResult, pendingOperation, request, upsert, reorder } = useSoundboardCatalog();
+    const { manifest, classnames: knownClassnames } = useSoundboardManifest();
     const [query, setQuery] = useState('');
     const [filter, setFilter] = useState<SoundboardCatalogFilter>('all');
     const [draft, setDraft] = useState<SoundboardCatalogDraft>(EMPTY_DRAFT);
@@ -50,7 +51,14 @@ export const HousekeepingSoundboardTab: FC = () => {
     const draftLocked = pendingOperation !== null;
 
     const editSound = (sound: ISoundboardCatalogSound) => {
-        setDraft({ id: sound.id, name: sound.name, url: sound.url, minRank: sound.minRank, enabled: sound.enabled });
+        setDraft({
+            id: sound.id,
+            name: sound.name,
+            classname: sound.classname ?? '',
+            url: sound.url,
+            minRank: sound.minRank,
+            enabled: sound.enabled
+        });
     };
 
     const preview = (candidate: SoundboardCatalogDraft) => {
@@ -58,7 +66,7 @@ export const HousekeepingSoundboardTab: FC = () => {
 
         setPreviewFailed(false);
         void GetSoundManager()
-            .playSoundboard(resolveSoundboardUrl(candidate.url.trim()))
+            .playSoundboard(resolveSoundboardSoundUrl({ classname: candidate.classname?.trim() ?? '', url: candidate.url?.trim() ?? '' }, manifest))
             .then((played) => setPreviewFailed(!played));
     };
 
@@ -130,6 +138,23 @@ export const HousekeepingSoundboardTab: FC = () => {
                         onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
                         className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs font-normal normal-case"
                     />
+                </label>
+                <label className="flex flex-col gap-0.5 text-[10px] font-semibold uppercase tracking-wide">
+                    {LocalizeText('housekeeping.soundboard.classname')}
+                    <input
+                        aria-label={LocalizeText('housekeeping.soundboard.classname')}
+                        disabled={draftLocked}
+                        value={draft.classname}
+                        list="soundboard-classnames"
+                        placeholder={knownClassnames[0] ?? ''}
+                        onChange={(event) => setDraft((current) => ({ ...current, classname: event.target.value }))}
+                        className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs font-normal normal-case"
+                    />
+                    <datalist id="soundboard-classnames">
+                        {knownClassnames.map((classname) => (
+                            <option key={classname} value={classname} />
+                        ))}
+                    </datalist>
                 </label>
                 <label className="flex flex-col gap-0.5 text-[10px] font-semibold uppercase tracking-wide">
                     {LocalizeText('housekeeping.soundboard.url')}
@@ -217,7 +242,7 @@ export const HousekeepingSoundboardTab: FC = () => {
                                     {sound.name} <span className="font-normal text-zinc-400">#{sound.id}</span>
                                 </div>
                                 <div className="truncate text-[10px] text-zinc-500">
-                                    {sound.url} · rank {sound.minRank} ·{' '}
+                                    {sound.classname || sound.url} · rank {sound.minRank} ·{' '}
                                     {sound.enabled
                                         ? LocalizeText('housekeeping.soundboard.filter.enabled')
                                         : LocalizeText('housekeeping.soundboard.filter.disabled')}

--- a/src/components/soundboard/SoundboardPadView.test.tsx
+++ b/src/components/soundboard/SoundboardPadView.test.tsx
@@ -8,7 +8,7 @@ import { SoundboardPadView } from './SoundboardPadView';
 const sound: DisplaySoundboardSound = {
     id: 1,
     name: 'Campanella',
-    url: '/sounds/campanella.mp3',
+    url: '/sounds/campanella.mp3', classname: '',
     categoryId: 'effects',
     tone: 'gold',
     keywords: []

--- a/src/components/soundboard/SoundboardView.test.tsx
+++ b/src/components/soundboard/SoundboardView.test.tsx
@@ -27,6 +27,7 @@ const sounds: DisplaySoundboardSound[] = Array.from({ length: 11 }, (_, index) =
     id: index + 1,
     name: index === 1 ? 'Applauso' : `Sound ${index + 1}`,
     url: `/${index + 1}.mp3`,
+    classname: '',
     categoryId: index < 2 ? 'reactions' : 'effects',
     tone: index % 2 ? 'green' : 'blue',
     keywords: index === 1 ? ['cláp'] : []

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -28,6 +28,7 @@ export * from './rooms/widgets/furniture';
 export * from './session';
 export * from './soundboard/useSoundboard';
 export * from './soundboard/useSoundboardCatalog';
+export * from './soundboard/useSoundboardManifest';
 export * from './translation';
 export * from './traxeditor/useTraxEditor';
 export * from './useChatWindow';

--- a/src/hooks/soundboard/soundboardCatalogState.test.ts
+++ b/src/hooks/soundboard/soundboardCatalogState.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { filterCatalogSounds, reorderCatalog, validateCatalogDraft } from './soundboardCatalogState';
 
 const sounds = [
-    { id: 7, name: 'Campanella', url: '/bell.mp3', enabled: true, sortOrder: 10, minRank: 1 },
-    { id: 12, name: 'Applauso', url: 'https://cdn.example/clap.mp3', enabled: false, sortOrder: 20, minRank: 5 }
+    { id: 7, name: 'Campanella', classname: '', url: '/bell.mp3', enabled: true, sortOrder: 10, minRank: 1 },
+    { id: 12, name: 'Applauso', classname: '', url: 'https://cdn.example/clap.mp3', enabled: false, sortOrder: 20, minRank: 5 }
 ];
 
 describe('Soundboard catalog state', () => {
@@ -15,13 +15,13 @@ describe('Soundboard catalog state', () => {
     });
 
     it('validates server-compatible names, URLs, and ranks', () => {
-        expect(validateCatalogDraft({ id: 0, name: 'Bell', url: '/sounds/bell.mp3', minRank: 1, enabled: true }).valid).toBe(true);
-        expect(validateCatalogDraft({ id: 0, name: '', url: 'javascript:alert(1)', minRank: 0, enabled: true }).errors).toEqual({
+        expect(validateCatalogDraft({ id: 0, name: 'Bell', classname: '', url: '/sounds/bell.mp3', minRank: 1, enabled: true }).valid).toBe(true);
+        expect(validateCatalogDraft({ id: 0, name: '', classname: '', url: 'javascript:alert(1)', minRank: 0, enabled: true }).errors).toEqual({
             name: 'invalid_name',
             url: 'invalid_url',
             minRank: 'invalid_rank'
         });
-        expect(validateCatalogDraft({ id: 0, name: 'Bell', url: 'https://cdn.example/bell.mp3', minRank: 2.5, enabled: true }).valid).toBe(false);
+        expect(validateCatalogDraft({ id: 0, name: 'Bell', classname: '', url: 'https://cdn.example/bell.mp3', minRank: 2.5, enabled: true }).valid).toBe(false);
     });
 
     it('reorders without mutating the source and removes duplicate IDs', () => {

--- a/src/hooks/soundboard/soundboardCatalogState.ts
+++ b/src/hooks/soundboard/soundboardCatalogState.ts
@@ -3,6 +3,7 @@ export type SoundboardCatalogFilter = 'all' | 'enabled' | 'disabled';
 export interface SoundboardCatalogSoundLike {
     id: number;
     name: string;
+    classname?: string;
     url: string;
     enabled: boolean;
     sortOrder: number;
@@ -12,6 +13,7 @@ export interface SoundboardCatalogSoundLike {
 export interface SoundboardCatalogDraft {
     id: number;
     name: string;
+    classname: string;
     url: string;
     enabled: boolean;
     minRank: number;
@@ -37,6 +39,11 @@ export const filterCatalogSounds = <T extends SoundboardCatalogSoundLike>(
     });
 };
 
+/** Mirrors SoundboardClassnamePolicy on the emulator side. */
+const CLASSNAME_PATTERN = /^[a-z0-9_-]{1,64}$/;
+
+export const isAllowedCatalogClassname = (value: string): boolean => CLASSNAME_PATTERN.test(value?.trim().toLowerCase() ?? '');
+
 const isAllowedCatalogUrl = (value: string): boolean => {
     const url = value?.trim() ?? '';
     if (!url || url.length > 255 || /[\u0000-\u0020]/.test(url)) return false;
@@ -55,7 +62,16 @@ export const validateCatalogDraft = (draft: SoundboardCatalogDraft): SoundboardC
     const name = draft.name?.trim() ?? '';
 
     if (!name || name.length > 64) errors.name = 'invalid_name';
-    if (!isAllowedCatalogUrl(draft.url)) errors.url = 'invalid_url';
+
+    // A pad resolves through the asset manifest (classname) or through an
+    // explicit URL. Requiring both would block the normal case, where the
+    // audio lives in nitro-assets and has no URL of its own.
+    const classname = draft.classname?.trim() ?? '';
+    const url = draft.url?.trim() ?? '';
+
+    if (classname ? !isAllowedCatalogClassname(classname) : !isAllowedCatalogUrl(url)) {
+        errors.url = 'invalid_url';
+    }
     if (!Number.isInteger(draft.minRank) || draft.minRank < 1) errors.minRank = 'invalid_rank';
 
     return { valid: Object.keys(errors).length === 0, errors };

--- a/src/hooks/soundboard/soundboardManifest.ts
+++ b/src/hooks/soundboard/soundboardManifest.ts
@@ -1,0 +1,89 @@
+import { SOUNDBOARD_TONES, SoundboardCategory, SoundboardTone } from './soundboardPresentation';
+
+/**
+ * One entry of `gamedata/SoundData.json`.
+ *
+ * The manifest is the asset pipeline's view of a pad — which file it is, what
+ * it is called, how it presents — exactly as `FurnitureData.json` is for
+ * furniture. The database only decides whether a pad is enabled, who may press
+ * it and in what order it appears.
+ */
+export interface SoundboardManifestEntry {
+    classname: string;
+    name: string;
+    file: string;
+    categoryId: string | null;
+    tone: SoundboardTone;
+    keywords: string[];
+}
+
+export interface SoundboardManifest {
+    categories: SoundboardCategory[];
+    byClassname: Map<string, SoundboardManifestEntry>;
+}
+
+export const EMPTY_SOUNDBOARD_MANIFEST: SoundboardManifest = { categories: [], byClassname: new Map() };
+
+const isRecord = (value: unknown): value is Record<string, unknown> => !!value && typeof value === 'object' && !Array.isArray(value);
+
+const readKeywords = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? [...new Set(value.filter((keyword): keyword is string => typeof keyword === 'string').map((keyword) => keyword.trim()).filter(Boolean))]
+        : [];
+
+/**
+ * The classname reaches the DOM as a URL path segment, so the same narrow
+ * alphabet the emulator enforces is re-checked here rather than trusted.
+ */
+const CLASSNAME_PATTERN = /^[a-z0-9_-]{1,64}$/;
+
+export const normalizeSoundboardManifest = (input: unknown): SoundboardManifest => {
+    if (!isRecord(input)) return EMPTY_SOUNDBOARD_MANIFEST;
+
+    const categories: SoundboardCategory[] = [];
+    const categoryIds = new Set<string>();
+
+    if (Array.isArray(input.categories)) {
+        for (const candidate of input.categories) {
+            if (!isRecord(candidate) || typeof candidate.id !== 'string' || typeof candidate.label !== 'string') continue;
+
+            const id = candidate.id.trim();
+            const label = candidate.label.trim();
+
+            // `all` and `recent` are the two built-in tabs; a manifest may not shadow them.
+            if (!id || !label || id === 'all' || id === 'recent' || categoryIds.has(id)) continue;
+
+            categoryIds.add(id);
+            categories.push({ id, label });
+        }
+    }
+
+    const byClassname = new Map<string, SoundboardManifestEntry>();
+
+    if (Array.isArray(input.soundboard)) {
+        for (const candidate of input.soundboard) {
+            if (!isRecord(candidate)) continue;
+
+            const classname = typeof candidate.classname === 'string' ? candidate.classname.trim().toLowerCase() : '';
+            const file = typeof candidate.file === 'string' ? candidate.file.trim() : '';
+
+            if (!CLASSNAME_PATTERN.test(classname) || !file || file.includes('/') || file.includes('\\') || byClassname.has(classname)) continue;
+
+            const rawCategory = typeof candidate.category === 'string' ? candidate.category.trim() : '';
+            const tone = typeof candidate.tone === 'string' && (SOUNDBOARD_TONES as readonly string[]).includes(candidate.tone)
+                ? (candidate.tone as SoundboardTone)
+                : 'blue';
+
+            byClassname.set(classname, {
+                classname,
+                name: typeof candidate.name === 'string' && candidate.name.trim() ? candidate.name.trim() : classname,
+                file,
+                categoryId: categoryIds.has(rawCategory) ? rawCategory : null,
+                tone,
+                keywords: readKeywords(candidate.keywords)
+            });
+        }
+    }
+
+    return { categories, byClassname };
+};

--- a/src/hooks/soundboard/soundboardPresentation.test.ts
+++ b/src/hooks/soundboard/soundboardPresentation.test.ts
@@ -42,8 +42,8 @@ describe('soundboard presentation', () => {
         );
 
         expect(sounds).toEqual([
-            { id: 7, name: 'Server name', url: '/sounds/server.mp3', categoryId: 'fun', tone: 'purple', keywords: [] },
-            { id: 8, name: 'Server only', url: '/sounds/only.mp3', categoryId: null, tone: 'blue', keywords: [] }
+            { id: 7, name: 'Server name', url: '/sounds/server.mp3', classname: '', categoryId: 'fun', tone: 'purple', keywords: [] },
+            { id: 8, name: 'Server only', url: '/sounds/only.mp3', classname: '', categoryId: null, tone: 'blue', keywords: [] }
         ]);
     });
 

--- a/src/hooks/soundboard/soundboardPresentation.ts
+++ b/src/hooks/soundboard/soundboardPresentation.ts
@@ -1,4 +1,5 @@
 import { ISoundboardSound } from '@nitrots/nitro-renderer';
+import { EMPTY_SOUNDBOARD_MANIFEST, SoundboardManifest } from './soundboardManifest';
 
 export const SOUNDBOARD_TONES = ['blue', 'green', 'gold', 'purple'] as const;
 
@@ -22,6 +23,7 @@ export interface SoundboardLayout {
 }
 
 export interface DisplaySoundboardSound extends ISoundboardSound {
+    classname: string;
     categoryId: string | null;
     tone: SoundboardTone;
     keywords: string[];
@@ -81,22 +83,37 @@ export const normalizeSoundboardLayout = (input: unknown): SoundboardLayout => {
     return { categories, sounds };
 };
 
+/**
+ * Presentation comes from two places, in this order:
+ *
+ * 1. the asset manifest, keyed by classname — the pad's own metadata, which
+ *    travels with the file and survives a database reseed;
+ * 2. `soundboard-layout.jsonc`, keyed by the numeric database id — the hotel's
+ *    explicit override, which therefore wins.
+ *
+ * Keeping the id-keyed layout working is deliberate: existing installs have
+ * one, and their ids are whatever their emulator assigned.
+ */
 export const mergeSoundboardPresentation = (
     serverSounds: ISoundboardSound[],
-    layout: SoundboardLayout
+    layout: SoundboardLayout,
+    manifest: SoundboardManifest = EMPTY_SOUNDBOARD_MANIFEST
 ): DisplaySoundboardSound[] => {
     const presentationById = new Map(layout.sounds.map((sound) => [sound.id, sound]));
 
     return serverSounds.map((sound) => {
-        const presentation = presentationById.get(sound.id);
+        const override = presentationById.get(sound.id);
+        const classname = sound.classname?.trim().toLowerCase() ?? '';
+        const asset = classname ? manifest.byClassname.get(classname) : null;
 
         return {
             id: sound.id,
-            name: sound.name,
+            name: sound.name || asset?.name || '',
             url: sound.url,
-            categoryId: presentation?.categoryId ?? null,
-            tone: presentation?.tone ?? 'blue',
-            keywords: presentation?.keywords ?? []
+            classname,
+            categoryId: override?.categoryId ?? asset?.categoryId ?? null,
+            tone: override?.tone ?? asset?.tone ?? 'blue',
+            keywords: override?.keywords?.length ? override.keywords : (asset?.keywords ?? [])
         };
     });
 };

--- a/src/hooks/soundboard/soundboardUrl.ts
+++ b/src/hooks/soundboard/soundboardUrl.ts
@@ -1,6 +1,9 @@
 import { GetConfigurationValue } from '../../api';
+import { SoundboardManifest } from './soundboardManifest';
 
-export const resolveSoundboardUrl = (url: string): string => {
+const DEFAULT_ASSET_TEMPLATE = 'nitro-assets/sounds/soundboard/%file%';
+
+const applyBase = (url: string): string => {
     if (!url) return '';
 
     // Explicit schemes remain untouched so the renderer can enforce its URL policy.
@@ -10,3 +13,32 @@ export const resolveSoundboardUrl = (url: string): string => {
 
     return base ? `${base}/${url.replace(/^\/+/, '')}` : url;
 };
+
+/**
+ * Resolve a pad to a playable URL.
+ *
+ * A classname is the normal case: the asset manifest owns which file the pad
+ * is, and `soundboard.asset.url` says where that folder lives — the same
+ * split furniture uses (`furni.asset.url` + `FurnitureData.json`).
+ *
+ * The explicit `url` is the fallback, kept for clips hosted outside the asset
+ * tree and for servers that predate asset-backed sounds.
+ */
+export const resolveSoundboardSoundUrl = (
+    sound: { classname?: string; url?: string },
+    manifest: SoundboardManifest
+): string => {
+    const classname = sound.classname?.trim().toLowerCase();
+    const entry = classname ? manifest.byClassname.get(classname) : null;
+
+    if (entry) {
+        const template = GetConfigurationValue<string>('soundboard.asset.url') || DEFAULT_ASSET_TEMPLATE;
+
+        return applyBase(template.replace('%file%', entry.file));
+    }
+
+    return applyBase(sound.url ?? '');
+};
+
+/** Legacy single-string form, still used where only a URL is in hand. */
+export const resolveSoundboardUrl = (url: string): string => applyBase(url);

--- a/src/hooks/soundboard/useSoundboard.test.tsx
+++ b/src/hooks/soundboard/useSoundboard.test.tsx
@@ -53,6 +53,14 @@ vi.mock('../../api', () => ({
     setSoundboardRoomEnabled: vi.fn()
 }));
 
+// The manifest is its own shared source; this suite renders the soundboard
+// hook directly, without a SharedHookRegistry host to mount it.
+vi.mock('./useSoundboardManifest', () => {
+    const manifest = { categories: [], byClassname: new Map() };
+
+    return { useSoundboardManifest: () => ({ manifest, manifestRef: { current: manifest }, classnames: [], loaded: true }) };
+});
+
 vi.mock('../events', () => ({
     useMessageEvent: (type: unknown, handler: (event: any) => void) => mocks.handlers.set(type, handler)
 }));

--- a/src/hooks/soundboard/useSoundboard.ts
+++ b/src/hooks/soundboard/useSoundboard.ts
@@ -26,7 +26,8 @@ import {
     SoundboardLayout
 } from './soundboardPresentation';
 import { getRemainingCooldownSeconds, shouldStartOwnCooldown } from './soundboardUi.helpers';
-import { resolveSoundboardUrl } from './soundboardUrl';
+import { resolveSoundboardSoundUrl } from './soundboardUrl';
+import { useSoundboardManifest } from './useSoundboardManifest';
 
 export type ClientSoundboardSound = DisplaySoundboardSound & { local?: boolean };
 
@@ -41,6 +42,7 @@ export const useSoundboardState = () => {
     const cooldownUntilRef = useRef(0);
     const legacyLoadStartedRef = useRef(false);
     const { showSingleBubble } = useNotificationActions();
+    const { manifest, manifestRef } = useSoundboardManifest();
 
     const showCooldownBubble = useCallback(
         (remainingSeconds: number) => {
@@ -85,7 +87,7 @@ export const useSoundboardState = () => {
         (event: SoundboardPlayEvent) => {
             const parser = event.getParser();
             void GetSoundManager()
-                .playSoundboard(resolveSoundboardUrl(parser.url))
+                .playSoundboard(resolveSoundboardSoundUrl({ classname: parser.classname, url: parser.url }, manifestRef.current))
                 .then((played) => {
                     if (!played) showSingleBubble(LocalizeText('soundboard.error.audio'), NotificationBubbleType.SOUNDBOARD);
                 });
@@ -158,11 +160,18 @@ export const useSoundboardState = () => {
     }, [enabled, serverSounds.length]);
 
     const sounds = useMemo<ClientSoundboardSound[]>(() => {
-        if (serverSounds.length) return mergeSoundboardPresentation(serverSounds, layout);
+        if (serverSounds.length) return mergeSoundboardPresentation(serverSounds, layout, manifest);
 
-        return mergeSoundboardPresentation(legacySounds, layout).map((sound) => ({ ...sound, local: true }));
-    }, [serverSounds, legacySounds, layout]);
-    const categories = layout.categories as SoundboardCategory[];
+        return mergeSoundboardPresentation(legacySounds, layout, manifest).map((sound) => ({ ...sound, local: true }));
+    }, [serverSounds, legacySounds, layout, manifest]);
+
+    // Categories declared in the layout file win on label; the manifest fills
+    // in any the hotel has not named.
+    const categories = useMemo<SoundboardCategory[]>(() => {
+        const seen = new Set(layout.categories.map((category) => category.id));
+
+        return [...layout.categories, ...manifest.categories.filter((category) => !seen.has(category.id))];
+    }, [layout.categories, manifest.categories]);
 
     const play = useCallback(
         (sound: ClientSoundboardSound) => {
@@ -170,7 +179,7 @@ export const useSoundboardState = () => {
 
             if (sound.local) {
                 void GetSoundManager()
-                    .playSoundboard(resolveSoundboardUrl(sound.url))
+                    .playSoundboard(resolveSoundboardSoundUrl(sound, manifestRef.current))
                     .then((played) => {
                         if (!played) showSingleBubble(LocalizeText('soundboard.error.audio'), NotificationBubbleType.SOUNDBOARD);
                     });

--- a/src/hooks/soundboard/useSoundboardCatalog.test.tsx
+++ b/src/hooks/soundboard/useSoundboardCatalog.test.tsx
@@ -46,7 +46,7 @@ describe('useSoundboardCatalog', () => {
 
     it('stores the full catalog and explicitly refreshes after a successful mutation', () => {
         const { result } = renderHook(() => useSoundboardCatalog());
-        const sounds = [{ id: 7, name: 'Bell', url: '/bell.mp3', enabled: true, sortOrder: 10, minRank: 1 }];
+        const sounds = [{ id: 7, name: 'Bell', classname: '', url: '/bell.mp3', enabled: true, sortOrder: 10, minRank: 1 }];
 
         act(() => mocks.handlers.get(SoundboardCatalogEvent)?.({ getParser: () => ({ sounds }) }));
         expect(result.current.sounds).toEqual(sounds);
@@ -63,7 +63,7 @@ describe('useSoundboardCatalog', () => {
 
     it('blocks duplicate mutations until the server responds', () => {
         const { result } = renderHook(() => useSoundboardCatalog());
-        const draft = { id: 0, name: 'Bell', url: '/bell.mp3', minRank: 1, enabled: true };
+        const draft = { id: 0, name: 'Bell', classname: '', url: '/bell.mp3', minRank: 1, enabled: true };
 
         act(() => {
             expect(result.current.upsert(draft)).toBe(true);

--- a/src/hooks/soundboard/useSoundboardCatalog.ts
+++ b/src/hooks/soundboard/useSoundboardCatalog.ts
@@ -32,7 +32,14 @@ export const useSoundboardCatalog = () => {
 
         pendingOperationRef.current = 1;
         setPendingOperation(1);
-        SendMessageComposer(new SoundboardCatalogUpsertComposer(draft.id, draft.name.trim(), draft.url.trim(), draft.minRank, draft.enabled));
+        SendMessageComposer(new SoundboardCatalogUpsertComposer(
+            draft.id,
+            draft.name.trim(),
+            draft.url.trim(),
+            draft.minRank,
+            draft.enabled,
+            draft.classname?.trim().toLowerCase() ?? ''
+        ));
         return true;
     }, []);
 

--- a/src/hooks/soundboard/useSoundboardManifest.ts
+++ b/src/hooks/soundboard/useSoundboardManifest.ts
@@ -1,0 +1,53 @@
+import { loadGamedata } from '@nitrots/nitro-renderer';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { registerSharedHook, useSharedHook } from '@/state/useSharedHook';
+import { GetConfigurationValue } from '../../api';
+import { EMPTY_SOUNDBOARD_MANIFEST, normalizeSoundboardManifest, SoundboardManifest } from './soundboardManifest';
+
+const DEFAULT_MANIFEST_URL = 'nitro-assets/gamedata/SoundData.json';
+
+/**
+ * Loads `gamedata/SoundData.json`, the asset pipeline's view of the soundboard.
+ *
+ * Shared because two unrelated surfaces need it — the pads themselves and the
+ * Housekeeping editor — and neither should fetch it twice. It is loaded once
+ * per session: the manifest ships with the assets, so it only changes when the
+ * assets do.
+ */
+const useSoundboardManifestState = () => {
+    const [manifest, setManifest] = useState<SoundboardManifest>(EMPTY_SOUNDBOARD_MANIFEST);
+    const [loaded, setLoaded] = useState(false);
+
+    // Broadcast handlers need the manifest synchronously, outside the render
+    // that observed it.
+    const manifestRef = useRef<SoundboardManifest>(EMPTY_SOUNDBOARD_MANIFEST);
+
+    useEffect(() => {
+        let cancelled = false;
+        const url = GetConfigurationValue<string>('soundboard.manifest.url') || DEFAULT_MANIFEST_URL;
+
+        const apply = (value: SoundboardManifest) => {
+            if (cancelled) return;
+
+            manifestRef.current = value;
+            setManifest(value);
+            setLoaded(true);
+        };
+
+        void loadGamedata<unknown>(url)
+            .then((value) => apply(normalizeSoundboardManifest(value)))
+            .catch(() => apply(EMPTY_SOUNDBOARD_MANIFEST));
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const classnames = useMemo(() => [...manifest.byClassname.keys()].sort(), [manifest]);
+
+    return { manifest, manifestRef, classnames, loaded };
+};
+
+export const useSoundboardManifest = () => useSharedHook(useSoundboardManifestState);
+
+registerSharedHook(useSoundboardManifestState);


### PR DESCRIPTION
## Why

The soundboard is the only audio in this client that does not come from the asset pipeline:

- files live in `public/sounds/soundboard`, inside the client bundle
- the database stores a hand-typed URL per pad
- `soundboard-layout.jsonc` keys presentation by the **numeric database id** — its own example file warns this breaks as soon as the catalog is not freshly seeded

Everything else already follows the furniture convention: `sounds.url` resolves into `nitro-assets/sounds/%sample%.mp3`, and furniture resolves `furni.asset.url` against `FurnitureData.json`.

Pads now do the same. `gamedata/SoundData.json` owns which file a pad is, what it is called and how it presents; the database keeps only hotel policy. `classname` is the key between them.

## Changes

- **`soundboardManifest.ts`** parses the manifest, re-checking the same narrow classname alphabet the emulator enforces rather than trusting it — the value ends up in a URL path segment, so anything traversable is rejected outright instead of sanitised.
- **`useSoundboardManifest`** loads it once per session, shared between the pads and the Housekeeping editor so neither fetches it twice.
- **`resolveSoundboardSoundUrl`** prefers classname -> manifest entry -> `soundboard.asset.url`, falling back to the explicit URL for clips hosted outside the asset tree and for servers that predate this. The template keys on `%file%` rather than classname+extension because the folder mixes `.mp3` and `.ogg`.
- **Presentation** comes from the manifest by classname, with the id-keyed layout file kept working as an explicit **override**. Dropping it would have broken every install that has one, since their ids are whatever their emulator assigned.
- **Housekeeping** gains a classname field backed by a datalist of what the manifest actually offers; the URL field stays as the advanced override. A pad validates with a classname or a url, not both.

Nothing here removes the URL path, so a pad pointing at a CDN keeps working.

## Verification

`yarn typecheck` clean, `yarn lint:hooks` clean, and 99/99 across the 18 files covering `hooks/soundboard`, `components/soundboard`, `components/housekeeping` and `api/housekeeping`.

The type-check will fail on CI until the renderer PR lands — it imports the `classname` field from `ISoundboardSound`.

## Pairing

- duckietm/Octane-Renderer#191 — reads the classname off the wire (**merge first**)
- duckietm/Polaris-Emulator#604 — emits it and owns the migration

## Not included

The assets themselves — `SoundData.json`, the generator and the audio files — live outside these three repositories, in the local asset tree. They are hotel content, not code.