### PR TITLE
fix(settings): stop the AIR settings window rendering at the default size

### DIFF
--- a/src/css/user-settings/UserSettingsView.css
+++ b/src/css/user-settings/UserSettingsView.css
@@ -16,7 +16,11 @@
 
     position: relative;
     box-sizing: border-box;
-    width: var(--air-settings-width);
+    /* The chrome is a 9-slice border-image, so the frame can take any size:
+       the declared width is a floor, not a cage. Longer translations widen
+       the window instead of clipping their own labels. */
+    width: max-content;
+    min-width: var(--air-settings-width);
     height: var(--air-settings-height);
     max-width: 100vw;
     max-height: calc(100vh - 8px);
@@ -34,25 +38,25 @@
     image-rendering: pixelated;
 }
 
-.air-settings-window--audio {
+.user-settings-window.air-settings-window--audio {
     --air-settings-width: 312px;
     --air-settings-height: 198px;
     --air-settings-back-top: 160px;
 }
 
-.air-settings-window--chat {
+.user-settings-window.air-settings-window--chat {
     --air-settings-width: 257px;
     --air-settings-height: 150px;
     --air-settings-back-top: 112px;
 }
 
-.air-settings-window--other {
+.user-settings-window.air-settings-window--other {
     --air-settings-width: 242px;
     --air-settings-height: 249px;
     --air-settings-back-top: 211px;
 }
 
-.air-settings-window--privacy {
+.user-settings-window.air-settings-window--privacy {
     --air-settings-width: 270px;
     --air-settings-height: 245px;
     --air-settings-back-top: 207px;
@@ -80,41 +84,31 @@
 .air-settings-window__title {
     top: 5px;
     left: 20px;
-    width: 141px;
+    right: 20px;
     height: 17px;
     margin: 0;
-    overflow: hidden;
     color: #ffffff;
     cursor: move;
     font: 400 12px/17px UbuntuRegular, Ubuntu, sans-serif;
     text-align: left;
-    text-overflow: ellipsis;
     text-shadow: none;
     white-space: nowrap;
     user-select: none;
 }
 
 .air-settings-window--audio .air-settings-window__title {
-    left: 93px;
-    width: 126px;
     text-align: center;
 }
 
 .air-settings-window--chat .air-settings-window__title {
-    left: 56px;
-    width: 144px;
     text-align: center;
 }
 
 .air-settings-window--other .air-settings-window__title {
-    left: 45px;
-    width: 153px;
     text-align: center;
 }
 
 .air-settings-window--privacy .air-settings-window__title {
-    left: 55px;
-    width: 160px;
     text-align: center;
 }
 
@@ -220,51 +214,48 @@
 
 .air-settings-audio__heading {
     top: 32px;
-    left: 82px;
-    width: 148px;
+    left: 0;
+    right: 0;
     height: 17px;
-    overflow: hidden;
     color: #ffffff;
     line-height: 17px;
     text-align: center;
-    text-overflow: ellipsis;
     white-space: nowrap;
 }
 
 .air-settings-audio__rows {
     top: 48px;
     left: 14px;
-    display: flex;
-    width: 285px;
+    /* One shared grid rather than four independent rows: the label column is
+       sized by the longest translation, so every slider stays in the same
+       column instead of drifting row by row. */
+    display: grid;
+    width: max-content;
+    min-width: 285px;
     height: 112px;
-    flex-direction: column;
+    grid-auto-rows: 28px;
+    grid-template-columns: max-content 29px 144px 29px;
+    align-items: start;
 }
 
 .air-settings-volume-row {
-    position: relative;
-    width: 285px;
-    height: 28px;
-    min-height: 28px;
-    flex: 0 0 28px;
+    display: contents;
     color: #ffffff;
 }
 
 .air-settings-volume-row__label {
-    position: absolute;
-    top: 6px;
-    left: 0;
-    width: 60px;
     height: 18px;
-    overflow: hidden;
+    margin-top: 6px;
+    /* 60px keeps the English layout pixel-identical to the AIR client; a
+       longer translation grows the column instead of being clipped. */
+    min-width: 60px;
+    padding-right: 4px;
     color: #ffffff;
     font: 400 12px/18px UbuntuRegular, Ubuntu, sans-serif;
-    text-overflow: ellipsis;
     white-space: nowrap;
 }
 
 .air-settings-volume-row__speaker {
-    position: absolute;
-    top: 0;
     width: 29px;
     height: 30px;
     margin: 0;
@@ -280,7 +271,6 @@
 }
 
 .air-settings-volume-row__speaker--off {
-    left: 60px;
     background-image: url('../../assets/images/user-settings/air/sounds-off-white.png');
 }
 
@@ -290,7 +280,7 @@
 }
 
 .air-settings-volume-row__speaker--on {
-    left: 251px;
+    margin-left: 9px;
     background-image: url('../../assets/images/user-settings/air/sounds-on-white.png');
 }
 
@@ -300,11 +290,10 @@
 }
 
 .air-settings-volume-row__slider {
-    position: absolute;
-    top: 0;
-    left: 98px;
+    position: relative;
     width: 144px;
     height: 24px;
+    margin-left: 9px;
 }
 
 .air-settings-volume-row__slider::before {


### PR DESCRIPTION
## The bug

Every AIR settings section renders at the **180×225 default**, whatever section it is. The audio panel is meant to be 312×198, so its own frame clips the title, the labels and the right end of the sliders.

## Root cause

A specificity mismatch, not a sizing mistake. The per-section sizes are declared from one class:

```css
.air-settings-window--audio { --air-settings-width: 312px; ... }
```

while the base declares them from two:

```css
.user-settings-window.air-settings-window { --air-settings-width: 180px; ... }
```

Custom properties follow the normal cascade, so the base wins every time and the variant is dead code. Measured on a clean `Dev` checkout, `getComputedStyle(win).getPropertyValue('--air-settings-width')` returns `180px` on the audio window; with the selectors matched it returns `312px`.

The same applies to `--air-settings-height` and `--air-settings-back-top`, so chat / other / privacy were mis-sized too.

## Two clips that survive the resize

**Labels.** Each row reserved a hard `width: 60px` with `text-overflow: ellipsis`. `Soundboard` does not fit in 60px at 12px Ubuntu and became `Soundb…` — in English as much as anywhere else. The rows now share one grid whose label column is `max-content` with a 60px floor, so the column is as wide as the longest translation and no wider.

Sharing the column matters: sizing each row independently lets the sliders drift apart row by row. With one grid they stay in a single column — verified, all four sliders at the same offset, row pitch unchanged at 28px.

**Title and heading.** Both were pinned to pixel boxes measured for the English strings (`left: 93px; width: 126px`). They are now centred within the frame's own 20px insets, so a longer string widens rather than truncates.

## Fidelity

The window chrome is a `border-image` 9-slice (`border-image-slice: 16 fill`), so the frame takes any size without distorting the artwork — nothing was resampled or redrawn.

One deviation worth naming: in English the sliders shift 9px right, because `Soundboard` is the longest label there too and now sizes the column instead of being cut off. The soundboard row is a local addition the original AIR layout never had, so the 60px column was never measured for it.

## Verification

Layout measured in the browser against the real stylesheet and sprites, before and after, in English and Italian: no clipped label in either locale, sliders aligned, content ending 13px inside the frame. `yarn typecheck` clean, `yarn vitest run` 1062/1062.