### PR TITLE
fix(rooms): stop the chat box disabling arrow-key movement

### DIFF
--- a/src/hooks/rooms/useRoomKeyboardMovement.test.ts
+++ b/src/hooks/rooms/useRoomKeyboardMovement.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isTyping } from './useRoomKeyboardMovement';
+
+const focus = (el: HTMLElement) => {
+    document.body.appendChild(el);
+    el.focus();
+
+    return el;
+};
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('arrow-key movement guard', () => {
+    it('does not treat an empty chat box as typing', () => {
+        const input = document.createElement('input');
+
+        input.className = 'swf-chat-input-field';
+        focus(input);
+
+        // The chat input takes focus on the first keystroke and keeps it, so
+        // this is the state the player is in for the whole session.
+        expect(document.activeElement).toBe(input);
+        expect(isTyping()).toBe(false);
+    });
+
+    it('treats a chat box with a message in it as typing', () => {
+        const input = document.createElement('input');
+
+        input.className = 'swf-chat-input-field';
+        input.value = 'ciao';
+        focus(input);
+
+        expect(isTyping()).toBe(true);
+    });
+
+    it('still treats other text fields as typing even when empty', () => {
+        const input = document.createElement('input');
+
+        focus(input);
+
+        expect(isTyping()).toBe(true);
+    });
+
+    it('reports nothing focused as not typing', () => {
+        (document.activeElement as HTMLElement)?.blur();
+
+        expect(isTyping()).toBe(false);
+    });
+});

--- a/src/hooks/rooms/useRoomKeyboardMovement.ts
+++ b/src/hooks/rooms/useRoomKeyboardMovement.ts
@@ -13,14 +13,24 @@ const STEPS: Record<string, [number, number]> = {
 
 const REPEAT_DELAY = 180;
 
-const isTyping = () => {
+/**
+ * The room's chat input takes focus on the first keystroke and keeps it, so
+ * treating "an input has focus" as "the user is typing" disabled arrow
+ * movement for the rest of the session. An empty chat box is not typing:
+ * only a message actually being composed should swallow the arrows.
+ */
+export const isTyping = () => {
     const element = document.activeElement as HTMLElement;
 
     if (!element) return false;
 
+    if (element.classList.contains('swf-chat-input-field')) {
+        return !!(element as HTMLInputElement).value.length;
+    }
+
     const tag = element.tagName;
 
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || element.isContentEditable;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || !!element.isContentEditable;
 };
 
 export const useRoomKeyboardMovement = () => {


### PR DESCRIPTION
## The bug

"Move with the arrow keys" does nothing, even with the setting enabled.

## Why

`ChatInputView` listens on `document.body` and, on **any** keydown, gives the chat input focus if it does not already have it:

```js
if (document.activeElement !== inputRef.current) setInputFocus();
```

`useRoomKeyboardMovement` then bailed out whenever *any* input had focus:

```js
return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || element.isContentEditable;
```

So one click on the chat — or one keystroke of any kind — parked the focus there for the rest of the session, and from that moment every arrow was swallowed by the guard before reaching the walk composer.

## The change

An empty chat box is not typing. Only a message actually being composed takes the arrows; every other text field keeps the previous behaviour, so nothing else changes.

The guard also returned `undefined` rather than `false` when nothing was focused — tightened to a real boolean.

## Verification

Four tests added — the hook had no coverage, and this is the kind of thing that breaks again silently. `src/hooks/rooms` 75/75, `yarn typecheck` clean, hooks lint clean. Confirmed in the running client: arrows move the avatar with the chat focused and empty, and move the caret once there is text in it.