### PR TITLE
perf(catalog): stop the catalog stalling the hotel view after login

### DIFF
--- a/src/components/catalog/CatalogView.tsx
+++ b/src/components/catalog/CatalogView.tsx
@@ -299,11 +299,17 @@ const CatalogViewInner: FC<{}> = () => {
 
 export const CatalogView: FC<{}> = () => {
     const { catalogLocalizationVersion = 0 } = useCatalogData();
+    const { isVisible = false } = useCatalogUiState();
 
     const isCatalogAdmin = useHasPermission('acc_catalogfurni');
 
+    // Opening a studio session is expensive on the server: it loads every
+    // catalog item with FOR UPDATE and every items_base id, on the thread
+    // serving this client. Tying it to authentication meant every staff login
+    // stalled the hotel view — no room list, no catalog — until it finished.
+    // The session is only needed once the catalog is actually open.
     return (
-        <CatalogStudioProvider active={isCatalogAdmin}>
+        <CatalogStudioProvider active={isCatalogAdmin && isVisible}>
             <CatalogAdminProvider>
                 <div className="hidden" data-catalog-localization-version={catalogLocalizationVersion} />
                 <CatalogViewInner />

--- a/src/hooks/catalog/useCatalog.helpers.test.ts
+++ b/src/hooks/catalog/useCatalog.helpers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuilderFurniPlaceableStatus } from '../../api/catalog/BuilderFurniPlaceableStatus';
 import { CatalogType } from '../../api/catalog/CatalogType';
 import * as catalogHelpers from './useCatalog.helpers';
@@ -58,7 +58,31 @@ describe('catalog index request coordinator', () => {
 });
 
 describe('catalog index prewarm controller', () => {
-    it('requests the current catalog once when the connection becomes authenticated', () => {
+    // The login prewarm is deferred to an idle slot so it cannot land in the
+    // middle of authentication and room entry; run those callbacks on demand.
+    let idleCallbacks: Array<() => void> = [];
+
+    beforeEach(() => {
+        idleCallbacks = [];
+        (globalThis as any).requestIdleCallback = (cb: () => void) => {
+            idleCallbacks.push(cb);
+
+            return idleCallbacks.length;
+        };
+    });
+
+    afterEach(() => {
+        delete (globalThis as any).requestIdleCallback;
+    });
+
+    const runIdle = () => {
+        const pending = idleCallbacks;
+
+        idleCallbacks = [];
+        pending.forEach(cb => cb());
+    };
+
+    it('prewarms the current catalog once the thread is idle after authenticating', () => {
         const requestedTypes: string[] = [];
         const controller = (catalogHelpers as any).createCatalogIndexPrewarmController((type: string) => requestedTypes.push(type));
 
@@ -68,6 +92,11 @@ describe('catalog index prewarm controller', () => {
         controller.update({ authenticated: false, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: true, visible: false, hasIndex: true, catalogType: CatalogType.NORMAL });
+
+        // nothing on the critical path: authentication and room entry come first
+        expect(requestedTypes).toEqual([]);
+
+        runIdle();
 
         expect(requestedTypes).toEqual([CatalogType.NORMAL]);
     });
@@ -80,7 +109,9 @@ describe('catalog index prewarm controller', () => {
         if (!controller) return;
 
         controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+        runIdle();
         requestedTypes.length = 0;
+        // opening is a request the user is waiting on, so it stays synchronous
         controller.update({ authenticated: true, visible: true, hasIndex: true, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: true, visible: true, hasIndex: true, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: true, visible: false, hasIndex: true, catalogType: CatalogType.NORMAL });
@@ -99,6 +130,8 @@ describe('catalog index prewarm controller', () => {
         controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: false, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
         controller.update({ authenticated: true, visible: false, hasIndex: false, catalogType: CatalogType.NORMAL });
+
+        runIdle();
 
         expect(requestedTypes).toEqual([CatalogType.NORMAL, CatalogType.NORMAL]);
     });

--- a/src/hooks/catalog/useCatalog.helpers.ts
+++ b/src/hooks/catalog/useCatalog.helpers.ts
@@ -79,12 +79,27 @@ export const createCatalogIndexPrewarmController = (request: (catalogType: strin
                 const openedNow = state.visible && !previous.visible;
                 const switchedVisibleCatalog = state.visible && state.catalogType !== previous.catalogType;
 
-                if (authenticatedNow || openedNow || switchedVisibleCatalog) request(state.catalogType);
+                // Opening the catalog is a request the user is waiting on, so it
+                // goes out immediately. The login prewarm is not: it lands in the
+                // middle of authentication and room entry, and the index packet is
+                // large enough — 1700 pages and ~49k offer ids on a full hotel —
+                // that parsing it there is felt as a freeze. Wait for an idle
+                // moment instead; the catalog is still warm by the time it opens.
+                if (openedNow || switchedVisibleCatalog) request(state.catalogType);
+                else if (authenticatedNow) scheduleWhenIdle(() => request(state.catalogType));
             }
 
             previous = state;
         }
     };
+};
+
+/** requestIdleCallback where available, a short timeout everywhere else. */
+const scheduleWhenIdle = (run: () => void): void => {
+    const idle = (globalThis as { requestIdleCallback?: (cb: () => void, options?: { timeout: number }) => number }).requestIdleCallback;
+
+    if (typeof idle === 'function') idle(run, { timeout: 5000 });
+    else setTimeout(run, 1000);
 };
 
 export const restoreCatalogActivePath = (rootNode: ICatalogNode, activePageId: number): ICatalogNode[] => {


### PR DESCRIPTION
## The symptom

After logging in, the hotel view freezes for several seconds: the room list does not load, the catalog does not load, then everything arrives at once and works normally.

That pattern is not a slow client — it is the packet handler thread for that client being busy. Two catalog code paths were putting work on it at exactly the wrong moment.

## 1. The studio session opened on authentication

`CatalogView` is mounted for the whole session, so `CatalogStudioProvider` opened a studio session the instant a staff user authenticated. Server-side that handler is expensive:

```java
studio().queries().loadSession();
studio().liveMutations().loadLive();      // catalog_items ... FOR UPDATE
studio().liveMutations().validateLive();  // SELECT id FROM items_base
```

On a full hotel that is **112k catalog items read under a row lock** and **107k `items_base` ids**, run synchronously on the thread serving that client. Every other packet queues behind it.

The slow-query log lines up exactly: login at `20:42:06`, the `FOR UPDATE` at `20:42:08`, and the `items_base` read peaking at **4749 ms**.

Nothing needs that session until the catalog is actually open, so it is now gated on `isVisible` rather than on authentication. Non-staff users never paid this, which is why it reproduces only for accounts with `acc_catalogfurni`.

## 2. The index prewarm sat on the critical path

The catalog index is prewarmed so the catalog opens instantly — but it was requested the moment the connection authenticated, putting a large packet's parse in the middle of login and room entry. On this hotel the visible index is 1703 pages and ~49k offer ids, and building the `offerId -> page` map from it is not free.

Measured in the running client, same login flow:

| | long tasks | main thread blocked | worst |
|---|---|---|---|
| before | 12 | 1583 ms | 341 ms |
| after | 1 | 103 ms | 103 ms |

Opening the catalog still requests synchronously — that is a request the user is waiting on. Only the login prewarm waits for an idle slot, so the catalog is still warm by the time anyone opens it.

## Worth doing upstream separately

`CatalogStudioOpenSessionEvent` should arguably not take a table-wide `FOR UPDATE` just to open a read-only session, nor pull every `items_base` id, and should not run on the packet handler thread at all. This PR keeps it off the login path; the handler itself is untouched.

## Verification

`yarn typecheck` clean, hooks lint clean, `yarn vitest run` 1072/1072. The two prewarm tests that pinned the old synchronous behaviour now drive a stubbed `requestIdleCallback` and assert the request lands after the idle slot.