### PR TITLE
fix(achievements): align the category tile title and counter

### DIFF
--- a/src/css/achievements/AchievementsView.css
+++ b/src/css/achievements/AchievementsView.css
@@ -182,13 +182,14 @@
     pointer-events: none;
 }
 
-/* The ribbon is centred at x 54.5 of the tile, so the counter is centred too:
-   left-aligning it in a 30px box parked "1/10" 5px left of centre and let
-   "0/234" spill out on the right. Vertical placement is unchanged - 70..84
-   already matches the ribbon body at 70..85. */
+/* Centred on the banner the art draws, which sits at x 22..87 / y 77..92 of
+   the tile: left-aligning in a 30px box parked "1/10" 5px left of centre, and
+   top: 70px straddled the banner's upper edge so the digits half overlapped
+   the badge. The banner's raised end caps reach higher than its middle - the
+   middle is what the text has to line up with. */
 .air-achievements-category-completion {
     position: absolute;
-    top: 70px;
+    top: 78px;
     left: 25px;
     z-index: 2;
     width: 60px;

--- a/src/css/achievements/AchievementsView.css
+++ b/src/css/achievements/AchievementsView.css
@@ -150,19 +150,23 @@
     transform: none;
 }
 
+/* Centred on the badge art (box 12..98) rather than left-anchored at 23px:
+   the longest category name, "Learn about Habbo", is 109px at 12px bold and
+   ran off the 112px tile, which clips its children. */
 .air-achievements-category-title {
     position: absolute;
     top: 7px;
-    left: 23px;
+    left: 0;
     z-index: 1;
-    width: 65px;
+    width: 110px;
     height: 17px;
-    overflow: visible;
+    overflow: hidden;
     color: #000000;
     font-size: 12px;
     font-weight: 700;
     line-height: 17px;
-    text-align: left;
+    text-align: center;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 
@@ -178,19 +182,23 @@
     pointer-events: none;
 }
 
+/* The ribbon is centred at x 54.5 of the tile, so the counter is centred too:
+   left-aligning it in a 30px box parked "1/10" 5px left of centre and let
+   "0/234" spill out on the right. Vertical placement is unchanged - 70..84
+   already matches the ribbon body at 70..85. */
 .air-achievements-category-completion {
     position: absolute;
     top: 70px;
-    left: 40px;
+    left: 25px;
     z-index: 2;
-    width: 30px;
+    width: 60px;
     height: 14px;
     overflow: visible;
     color: #ffffff;
     font-size: 12px;
     font-weight: 700;
     line-height: 14px;
-    text-align: left;
+    text-align: center;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## The bug

On the achievements category grid the tile title was cut mid-word and the
progress counter drifted around the banner:

- `quests.tools.name` — "Learn about Habbo" — rendered as "Learn about Habb".
- A short "6/9" sat left of the banner's centre while a long "0/234" spilled
  past its box, and both floated above the banner instead of sitting on it.

## Why

Three separate mismatches between the CSS boxes and the artwork.

**Title.** It was left-anchored at `left: 23px` in a `width: 65px` box, on a
tile that is 112px wide and sets `overflow: hidden`. Measured in the browser
with the window's own `Ubuntu-b.ttf` at 12px bold, "Learn about Habbo" is
**109px**, so it ran to x=132 and the tile clipped it.

**Counter, horizontally.** `left: 40px; width: 30px; text-align: left` centres
nothing: "6/9" (18.9px) landed 5px left of the banner's centre, "0/234"
(32.5px) overflowed the box on the right.

**Counter, vertically.** This one is the subtle one. The banner drawn by the
category art has **raised end caps**: sampled at its left or right edge it
occupies art rows 36..55, but its middle — the part the text actually sits on
— is rows 46..61, i.e. y 77..92 of the tile. `top: 70px` put the 14px line box
at 70..84, so the digits straddled the banner's upper edge and half overlapped
the badge.

## The change

Both texts now centre on the badge art (its box is x 12..98, centre 55; the
banner's centre is 54.5), with enough width for the longest string, and the
counter drops to `top: 78px` so the digits sit at 80..89 — inside the banner.

The title also gains `text-overflow: ellipsis`, so a longer localized name
degrades to an ellipsis instead of being cut mid-glyph by the tile.

## Verification

Measured in a browser against the real stylesheet, the real font and the real
`c_images/Quests` art: all eight category titles now fit with none ellipsised,
and title and counter both centre at x=56 against a banner centre of 55.5. The
banner geometry was measured out of the art PNGs themselves (`achcategory_*`,
68x64, drawn centred in the 86x72 box), and the result re-rendered pixel for
pixel to confirm the digits land inside the banner.

`yarn typecheck` clean, `yarn test --run` 1066/1066.