### PR TITLE
fix(notifications): style the command list and split it into two columns

### DIFF
--- a/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
+++ b/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
@@ -18,7 +18,9 @@ const COMMAND_LINE_PATTERN = /^\s*:[\w.-]+(?:\s.*)?$/;
 
 interface CommandTemplateEntry {
     command: string;
+    args: string;
     description: string;
+    raw: string;
 }
 
 export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps> = (props) => {
@@ -41,7 +43,14 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
             if (!text.length) continue;
 
             if (COMMAND_LINE_PATTERN.test(text)) {
-                commands.push({ command: text, description: '' });
+                const separatorIndex = text.search(/\s/);
+
+                commands.push({
+                    command: separatorIndex === -1 ? text : text.substring(0, separatorIndex),
+                    args: separatorIndex === -1 ? '' : text.substring(separatorIndex + 1).trim(),
+                    description: '',
+                    raw: text
+                });
                 continue;
             }
 
@@ -106,10 +115,13 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
                                     key={`${entry.command}-${index}`}
                                     className="notification-command-row"
                                     type="button"
-                                    onClick={() => copyCommandToChatInput(entry.command)}
+                                    onClick={() => copyCommandToChatInput(entry.raw)}
                                 >
                                     <span className="notification-command-name">{entry.command}</span>
-                                    {entry.description && <span className="notification-command-description">{entry.description}</span>}
+                                    <span className="notification-command-detail">
+                                        {entry.args && <span className="notification-command-args">{entry.args}</span>}
+                                        {entry.description && <span className="notification-command-description">{entry.description}</span>}
+                                    </span>
                                 </button>
                             ))}
                         </div>

--- a/src/css/notification/NotificationCenterView.css
+++ b/src/css/notification/NotificationCenterView.css
@@ -716,3 +716,103 @@
     background-position: center 34% !important;
     background-repeat: no-repeat !important;
 }
+
+/* Command list produced by ":commands". NotificationDefaultAlertView tags the alert
+   with .nitro-alert-command-list and renders one button per command; without these
+   rules the buttons stay inline and several commands share a visual line. */
+.nitro-alert.nitro-alert-command-list {
+    width: 430px;
+    max-height: 470px;
+}
+
+.notification-command-template {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 370px;
+    padding-right: 4px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.notification-command-heading {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    margin-bottom: 4px;
+    padding: 5px 8px;
+    background: linear-gradient(180deg, #4a72b8 0%, #2d4a82 100%);
+    border-bottom: 2px solid #1c2a4a;
+    border-radius: 4px 4px 0 0;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    color: #fff;
+    font-weight: 700;
+    font-size: 12px;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+}
+
+.notification-command-copy {
+    padding: 0 8px 4px 8px;
+    color: #4b5563;
+    font-size: 11px;
+    line-height: 1.35;
+}
+
+.notification-command-row {
+    display: grid;
+    grid-template-columns: minmax(0, 150px) minmax(0, 1fr);
+    align-items: baseline;
+    gap: 2px 10px;
+    width: 100%;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.55);
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.notification-command-row:nth-child(even) {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+.notification-command-row:hover {
+    background: #fff6d6;
+    border-color: #d8a72a;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.notification-command-row:active {
+    background: #ffe9a8;
+}
+
+.notification-command-name {
+    min-width: 0;
+    color: #2d4a82;
+    font-weight: 700;
+    font-size: 12px;
+    font-family: 'Consolas', 'Courier New', monospace;
+    overflow-wrap: anywhere;
+}
+
+.notification-command-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+}
+
+.notification-command-args {
+    color: #7a6a35;
+    font-size: 11px;
+    font-family: 'Consolas', 'Courier New', monospace;
+    overflow-wrap: anywhere;
+}
+
+.notification-command-description {
+    color: #6b7280;
+    font-size: 11px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Problem

`:commands` rendered as one run-together block: several commands shared a visual
line and each command name ran straight into its description
(`:emustatsAllows viewing room information in the moderation tool.`).

The cause is not the text the emulator sends. `NotificationDefaultAlertView`
already detects the listing, tags the alert with `nitro-alert-command-list` and
renders one `<button>` per command with `notification-command-name` /
`notification-command-description` spans — but **no stylesheet ever defined those
class names**. Unstyled buttons stay `inline-block`, so they flow together, and
the two spans sit side by side with no separator.

## Change

- Adds the missing rules to `NotificationCenterView.css`: the list becomes a
  scrollable column with a sticky heading, one row per command, alternating row
  tint and a hover state that shows the row is clickable.
- Splits each entry at the first space, so the command name occupies its own
  column and the argument hint lines up beside it with the description under it.
  With a stock text table most commands carry a usage line rather than prose, so
  the second column stays populated either way.
- Clicking a row still copies the full original line into the chat input; the
  entry keeps the raw text for that.

## Verification

- `yarn typecheck` — clean.
- `yarn lint:hooks` — clean.
- `yarn test --run` — 1072 tests in 201 files, all passing.

Visual check was done against a static page built from the real markup and the
real CSS; the live alert needs a client attached to a running emulator.
