### PR TITLE
fix(notifications): head the command list with the card header and let it filter

### DIFF
--- a/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
+++ b/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
@@ -26,6 +26,7 @@ interface CommandTemplateEntry {
 export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps> = (props) => {
     const { item = null, title = (props.item && props.item.title) || '', onClose = null, classNames = [], ...rest } = props;
     const [imageFailed, setImageFailed] = useState<boolean>(false);
+    const [commandFilter, setCommandFilter] = useState<string>('');
 
     const alertLines = useMemo(() => item.messages.flatMap((message) => message.split(/\r\n|\r|\n/g)), [item.messages]);
     const hasCommandTemplate = useMemo(() => {
@@ -82,9 +83,35 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
     const hasFrank = item.alertType === NotificationAlertType.DEFAULT;
     const alertClassNames = hasCommandTemplate ? [...classNames, 'nitro-alert-command-list'] : classNames;
 
+    // The listing arrives on the MOTD channel, so the window would be headed
+    // "Messages for you". Its own first line names it better - promote that to
+    // the card header instead of drawing a second heading inside the body.
+    const commandTitle = useMemo(() => {
+        if (!hasCommandTemplate) return null;
+
+        const heading = commandTemplateContent.intro[0];
+
+        if (!heading) return null;
+
+        return heading.replace(/:\s*$/, '').replace(/\s*\(\s*/, ' (');
+    }, [hasCommandTemplate, commandTemplateContent]);
+
+    const visibleCommands = useMemo(() => {
+        const needle = commandFilter.trim().toLowerCase();
+
+        if (!needle.length) return commandTemplateContent.commands;
+
+        return commandTemplateContent.commands.filter(
+            (entry) =>
+                entry.command.toLowerCase().includes(needle) ||
+                entry.args.toLowerCase().includes(needle) ||
+                entry.description.toLowerCase().includes(needle)
+        );
+    }, [commandFilter, commandTemplateContent]);
+
     return (
         <LayoutNotificationAlertView
-            title={title}
+            title={commandTitle ?? title}
             onClose={onClose}
             classNames={alertClassNames}
             {...rest}
@@ -105,12 +132,21 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
                 <div className={['notification-text overflow-y-auto flex flex-col w-full', item.clickUrl && !hasFrank ? 'justify-center' : ''].join(' ')}>
                     {hasCommandTemplate && (
                         <div className="notification-command-template">
-                            {commandTemplateContent.intro.map((text, index) => (
-                                <div key={index} className={index === 0 ? 'notification-command-heading' : 'notification-command-copy'}>
+                            {commandTemplateContent.intro.slice(commandTitle ? 1 : 0).map((text, index) => (
+                                <div key={index} className="notification-command-copy">
                                     {text}
                                 </div>
                             ))}
-                            {commandTemplateContent.commands.map((entry, index) => (
+                            <input
+                                className="notification-command-search"
+                                type="text"
+                                value={commandFilter}
+                                spellCheck={false}
+                                placeholder={LocalizeText('generic.search')}
+                                onChange={(event) => setCommandFilter(event.target.value)}
+                            />
+                            {!visibleCommands.length && <div className="notification-command-copy">{LocalizeText('generic.no_results_found')}</div>}
+                            {visibleCommands.map((entry, index) => (
                                 <button
                                     key={`${entry.command}-${index}`}
                                     className="notification-command-row"

--- a/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
+++ b/src/components/notification-center/views/alert-layouts/NotificationDefaultAlertView.tsx
@@ -15,6 +15,7 @@ interface NotificationDefaultAlertViewProps extends LayoutNotificationAlertViewP
 }
 
 const COMMAND_LINE_PATTERN = /^\s*:[\w.-]+(?:\s.*)?$/;
+const COMMAND_HEADING_PATTERN = /^Your Commands\s*\(\d+\)\s*:?$/i;
 
 interface CommandTemplateEntry {
     command: string;
@@ -22,6 +23,22 @@ interface CommandTemplateEntry {
     description: string;
     raw: string;
 }
+
+interface CommandFilterInputProps {
+    value: string;
+    onChange: (value: string) => void;
+}
+
+const CommandFilterInput: FC<CommandFilterInputProps> = ({ value, onChange }) => (
+    <input
+        className="notification-command-search"
+        type="text"
+        value={value}
+        spellCheck={false}
+        placeholder={LocalizeText('generic.search')}
+        onChange={(event) => onChange(event.target.value)}
+    />
+);
 
 export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps> = (props) => {
     const { item = null, title = (props.item && props.item.title) || '', onClose = null, classNames = [], ...rest } = props;
@@ -32,7 +49,7 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
     const hasCommandTemplate = useMemo(() => {
         const commandLines = alertLines.filter((line) => COMMAND_LINE_PATTERN.test(line));
 
-        return commandLines.length >= 4 || alertLines.some((line) => /^Your Commands\(\d+\):?/i.test(line.trim()));
+        return commandLines.length >= 4 || alertLines.some((line) => COMMAND_HEADING_PATTERN.test(line.trim()));
     }, [alertLines]);
     const commandTemplateContent = useMemo(() => {
         const intro: string[] = [];
@@ -86,15 +103,7 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
     // The listing arrives on the MOTD channel, so the window would be headed
     // "Messages for you". Its own first line names it better - promote that to
     // the card header instead of drawing a second heading inside the body.
-    const commandTitle = useMemo(() => {
-        if (!hasCommandTemplate) return null;
-
-        const heading = commandTemplateContent.intro[0];
-
-        if (!heading) return null;
-
-        return heading.replace(/:\s*$/, '').replace(/\s*\(\s*/, ' (');
-    }, [hasCommandTemplate, commandTemplateContent]);
+    const hasCommandHeading = hasCommandTemplate && COMMAND_HEADING_PATTERN.test(commandTemplateContent.intro[0] ?? '');
 
     const visibleCommands = useMemo(() => {
         const needle = commandFilter.trim().toLowerCase();
@@ -108,6 +117,19 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
                 entry.description.toLowerCase().includes(needle)
         );
     }, [commandFilter, commandTemplateContent]);
+
+    // Only promote the heading when it really is the "Your Commands(n):" line;
+    // an alert that merely contains several :command lines keeps its own title.
+    // The count tracks the filter so the header reflects what is on screen.
+    const commandTitle = useMemo(() => {
+        if (!hasCommandHeading) return null;
+
+        const heading = commandTemplateContent.intro[0].replace(/:\s*$/, '');
+        const total = commandTemplateContent.commands.length;
+        const shown = visibleCommands.length;
+
+        return heading.replace(/\s*\(\s*\d+\s*\)/, shown === total ? ` (${total})` : ` (${shown}/${total})`);
+    }, [hasCommandHeading, commandTemplateContent, visibleCommands]);
 
     return (
         <LayoutNotificationAlertView
@@ -132,19 +154,12 @@ export const NotificationDefaultAlertView: FC<NotificationDefaultAlertViewProps>
                 <div className={['notification-text overflow-y-auto flex flex-col w-full', item.clickUrl && !hasFrank ? 'justify-center' : ''].join(' ')}>
                     {hasCommandTemplate && (
                         <div className="notification-command-template">
-                            {commandTemplateContent.intro.slice(commandTitle ? 1 : 0).map((text, index) => (
+                            {commandTemplateContent.intro.slice(hasCommandHeading ? 1 : 0).map((text, index) => (
                                 <div key={index} className="notification-command-copy">
                                     {text}
                                 </div>
                             ))}
-                            <input
-                                className="notification-command-search"
-                                type="text"
-                                value={commandFilter}
-                                spellCheck={false}
-                                placeholder={LocalizeText('generic.search')}
-                                onChange={(event) => setCommandFilter(event.target.value)}
-                            />
+                            <CommandFilterInput value={commandFilter} onChange={setCommandFilter} />
                             {!visibleCommands.length && <div className="notification-command-copy">{LocalizeText('generic.no_results_found')}</div>}
                             {visibleCommands.map((entry, index) => (
                                 <button

--- a/src/css/notification/NotificationCenterView.css
+++ b/src/css/notification/NotificationCenterView.css
@@ -738,14 +738,18 @@
 /* The listing names itself on its first line; that line becomes the card header,
    so the body carries no heading of its own. */
 .notification-command-search {
+    --notification-command-search-bg: #fff;
+    --notification-command-search-border: #a8a8a8;
+    --notification-command-search-border-focus: #4a72b8;
+
     position: sticky;
     top: 0;
     z-index: 1;
     width: 100%;
     margin-bottom: 4px;
     padding: 3px 7px;
-    background: #fff;
-    border: 1px solid #a8a8a8;
+    background: var(--notification-command-search-bg);
+    border: 1px solid var(--notification-command-search-border);
     border-radius: 3px;
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
     color: inherit;
@@ -754,7 +758,7 @@
 }
 
 .notification-command-search:focus {
-    border-color: #4a72b8;
+    border-color: var(--notification-command-search-border-focus);
     outline: none;
 }
 

--- a/src/css/notification/NotificationCenterView.css
+++ b/src/css/notification/NotificationCenterView.css
@@ -735,20 +735,27 @@
     overflow-x: hidden;
 }
 
-.notification-command-heading {
+/* The listing names itself on its first line; that line becomes the card header,
+   so the body carries no heading of its own. */
+.notification-command-search {
     position: sticky;
     top: 0;
     z-index: 1;
+    width: 100%;
     margin-bottom: 4px;
-    padding: 5px 8px;
-    background: linear-gradient(180deg, #4a72b8 0%, #2d4a82 100%);
-    border-bottom: 2px solid #1c2a4a;
-    border-radius: 4px 4px 0 0;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
-    color: #fff;
-    font-weight: 700;
-    font-size: 12px;
-    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
+    padding: 3px 7px;
+    background: #fff;
+    border: 1px solid #a8a8a8;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+    color: inherit;
+    font-family: inherit;
+    font-size: 11px;
+}
+
+.notification-command-search:focus {
+    border-color: #4a72b8;
+    outline: none;
 }
 
 .notification-command-copy {


### PR DESCRIPTION
Follow-up to #433, addressing both review comments on it.

## The window header now matches the rest of the UI

The listing was already inside the window component — `LayoutNotificationAlertView`
wraps every alert in `NitroCardView` + `NitroCardHeaderView`. What was wrong is
what the header *said*: `:commands` is delivered by `MessagesForYouComposer`,
header **2035**, which the renderer maps to `MOTD_MESSAGES`. The client therefore
treats it as a MOTD and titles the window `notifications.motd.title` —
"Messages for you" — while the body is a command list. On top of that, #433 drew
a second, hand-styled heading bar inside the content, imitating a header without
being one.

The listing already names itself on its first line, so that line is promoted to
the card header (`Your Commands(116):` → `Your Commands (116)`) and the imitation
bar is gone, CSS included. One header, and it is the real one.

## Filter box

On a staff rank the list runs to 116 entries. A text field above the rows filters
on command name, argument hint and description. Empty input shows everything, so
nothing changes for a short list.

`generic.search` is used for the placeholder and `generic.no_results_found` for
the empty state; both keys exist in the external texts.

## Notes

- No protocol change: this is presentation only, and the alert still arrives on
  the same packet.
- Clicking a row still copies the full original command line into the chat input.

## Verification

- `yarn typecheck` — clean
- `yarn lint:hooks` — clean
- `yarn test --run` — 1072 tests in 201 files, all passing

Visual checking was done against a static page built from the real markup and the
real stylesheet; the live alert needs a client attached to a running emulator.
