### PR TITLE
🆙 Furniture Inventory

### DIFF
--- a/src/api/inventory/FurnitureUtilities.ts
+++ b/src/api/inventory/FurnitureUtilities.ts
@@ -6,6 +6,9 @@ import { GroupItem } from './GroupItem';
 export const createGroupItem = (type: number, category: number, stuffData: IObjectData, extra: number = NaN) =>
     new GroupItem(type, category, GetRoomEngine(), stuffData, extra);
 
+export const getGroupItemKey = (group: GroupItem): string =>
+    `${group.type}:${group.isWallItem ? 1 : 0}:${group.stuffData?.getLegacyString?.() ?? ''}`;
+
 const addSingleFurnitureItem = (set: GroupItem[], item: FurnitureItem, unseen: boolean) => {
     const groupItems: GroupItem[] = [];
 
@@ -58,19 +61,25 @@ const addGroupableFurnitureItem = (set: GroupItem[], item: FurnitureItem, unseen
     }
 
     if (existingGroup) {
-        existingGroup.push(item);
+        const index = set.indexOf(existingGroup);
+
+        const clonedGroup = existingGroup.clone();
+
+        clonedGroup.push(item);
 
         if (unseen) {
-            existingGroup.hasUnseenItems = true;
-
-            const index = set.indexOf(existingGroup);
+            clonedGroup.hasUnseenItems = true;
 
             if (index >= 0) set.splice(index, 1);
 
-            set.unshift(existingGroup);
+            set.unshift(clonedGroup);
+        } else if (index >= 0) {
+            set[index] = clonedGroup;
+        } else {
+            set.push(clonedGroup);
         }
 
-        return existingGroup;
+        return clonedGroup;
     }
 
     existingGroup = createGroupItem(item.type, item.category, item.stuffData, item.extra);

--- a/src/components/inventory/InventoryView.tsx
+++ b/src/components/inventory/InventoryView.tsx
@@ -11,8 +11,8 @@ import {
     RoomPreviewer,
     RoomSessionEvent
 } from '@nitrots/nitro-renderer';
-import { FC, useEffect, useState } from 'react';
-import { GroupItem, isObjectMoverRequested, LocalizeText, setObjectMoverRequested, UnseenItemCategory } from '../../api';
+import { FC, useEffect, useMemo, useState } from 'react';
+import { isObjectMoverRequested, LocalizeBadgeName, LocalizeText, setObjectMoverRequested, UnseenItemCategory } from '../../api';
 import { NitroCardHeaderView, NitroCardTabsItemView, NitroCardTabsView, NitroCardView } from '../../common';
 import {
     useInventoryBadges,
@@ -28,7 +28,7 @@ import { InventoryBotView } from './views/bot/InventoryBotView';
 import { InventoryFurnitureDeleteView } from './views/furniture/InventoryFurnitureDeleteView';
 import { InventoryFurnitureView } from './views/furniture/InventoryFurnitureView';
 import { InventoryTradeView } from './views/furniture/InventoryTradeView';
-import { InventoryCategoryFilterView } from './views/InventoryCategoryFilterView';
+import { FILTER_EVERYTHING, FILTER_FLOOR, FILTER_WALL, InventoryCategoryFilterView } from './views/InventoryCategoryFilterView';
 import { InventoryPetView } from './views/pet/InventoryPetView';
 import { InventoryPrefixView } from './views/prefix/InventoryPrefixView';
 
@@ -38,8 +38,7 @@ const TAB_PETS: string = 'inventory.furni.tab.pets';
 const TAB_BADGES: string = 'inventory.badges';
 const TAB_PREFIXES: string = 'inventory.prefixes';
 const TABS = [TAB_FURNITURE, TAB_PETS, TAB_BADGES, TAB_PREFIXES, TAB_BOTS];
-// Maps an optional link code (inventory/show/<code>) to a tab so other views
-// (e.g. the profile "Change Badges" button) can deep-link to a specific tab.
+
 const TAB_BY_CODE: Record<string, string> = {
     furni: TAB_FURNITURE,
     furniture: TAB_FURNITURE,
@@ -55,12 +54,53 @@ export const InventoryView: FC<{}> = (props) => {
     const [currentTab, setCurrentTab] = useState<string>(TABS[0]);
     const [roomSession, setRoomSession] = useState<IRoomSession>(null);
     const [roomPreviewer, setRoomPreviewer] = useState<RoomPreviewer>(null);
-    const [filteredGroupItems, setFilteredGroupItems] = useState<GroupItem[]>([]);
-    const [filteredBadgeCodes, setFilteredBadgeCodes] = useState<string[]>([]);
+    const [searchValue, setSearchValue] = useState('');
+    const [filterType, setFilterType] = useState<string>(FILTER_EVERYTHING);
     const { isTrading = false, stopTrading = null } = useInventoryTrade();
     const { getCount = null } = useInventoryUnseenTracker();
     const { groupItems = [] } = useInventoryFurni();
     const { badgeCodes = [] } = useInventoryBadges();
+
+    useEffect(() => {
+        setSearchValue('');
+        setFilterType(FILTER_EVERYTHING);
+    }, [currentTab]);
+
+    const filteredGroupItems = useMemo(() => {
+        const comparison = searchValue.toLocaleLowerCase();
+
+        if (filterType === FILTER_EVERYTHING) {
+            return groupItems.filter((item) => item.name.toLocaleLowerCase().includes(comparison));
+        }
+
+        return groupItems.filter((item) => {
+            const isWall = filterType === FILTER_WALL ? item.isWallItem : false;
+            const isFloor = filterType === FILTER_FLOOR ? !item.isWallItem : false;
+            const matchesSearch = item.name.toLocaleLowerCase().includes(comparison);
+
+            return comparison.length ? matchesSearch && (isWall || isFloor) : isWall || isFloor;
+        });
+    }, [groupItems, searchValue, filterType]);
+
+    const filteredBadgeCodes = useMemo(() => {
+        const comparison = searchValue.toLocaleLowerCase().replace(' ', '');
+
+        const achievementBadges = badgeCodes.filter((badge) => badge.startsWith('ACH_'));
+        const numberMap: { [key: string]: number } = {};
+
+        achievementBadges.forEach((badge) => {
+            const name = badge.split(/[\d]+/)[0];
+            const number = Number(badge.replace(name, ''));
+
+            if (numberMap[name] === undefined || number > numberMap[name]) numberMap[name] = number;
+        });
+
+        const deduped = Object.keys(numberMap)
+            .map((name) => `${name}${numberMap[name]}`)
+            .concat(badgeCodes.filter((badge) => !badge.startsWith('ACH_')));
+
+        return deduped.filter((badgeCode) => LocalizeBadgeName(badgeCode).toLocaleLowerCase().includes(comparison));
+    }, [badgeCodes, searchValue]);
 
     const onClose = () => {
         if (isTrading) stopTrading();
@@ -169,11 +209,11 @@ export const InventoryView: FC<{}> = (props) => {
                         <div className="nitro-inventory-body flex flex-col overflow-hidden p-2 h-full gap-2">
                             {showFilter && (
                                 <InventoryCategoryFilterView
-                                    badgeCodes={badgeCodes}
                                     currentTab={currentTab}
-                                    groupItems={groupItems}
-                                    setBadgeCodes={setFilteredBadgeCodes}
-                                    setGroupItems={setFilteredGroupItems}
+                                    filterType={filterType}
+                                    searchValue={searchValue}
+                                    onFilterTypeChange={setFilterType}
+                                    onSearchChange={setSearchValue}
                                 />
                             )}
                             <div className="flex-1 overflow-hidden">

--- a/src/components/inventory/views/InventoryCategoryFilterView.tsx
+++ b/src/components/inventory/views/InventoryCategoryFilterView.tsx
@@ -1,78 +1,24 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
-import { GroupItem, LocalizeBadgeName, LocalizeText } from '../../../api';
+import { FC } from 'react';
+import { LocalizeText } from '../../../api';
 import { NitroInput } from '../../../layout';
 
-const FILTER_EVERYTHING = 'inventory.filter.option.everything';
-const FILTER_FLOOR = 'inventory.furni.tab.floor';
-const FILTER_WALL = 'inventory.furni.tab.wall';
+// Filter option keys (also consumed by InventoryView's useMemo derivation).
+export const FILTER_EVERYTHING = 'inventory.filter.option.everything';
+export const FILTER_FLOOR = 'inventory.furni.tab.floor';
+export const FILTER_WALL = 'inventory.furni.tab.wall';
 
 const TAB_BADGES = 'inventory.badges';
-const TAB_FURNITURE = 'inventory.furni';
 
 interface InventoryCategoryFilterViewProps {
     currentTab: string;
-    groupItems: GroupItem[];
-    badgeCodes: string[];
-    setGroupItems: Dispatch<SetStateAction<GroupItem[]>>;
-    setBadgeCodes: Dispatch<SetStateAction<string[]>>;
+    searchValue: string;
+    filterType: string;
+    onSearchChange: (value: string) => void;
+    onFilterTypeChange: (value: string) => void;
 }
 
 export const InventoryCategoryFilterView: FC<InventoryCategoryFilterViewProps> = (props) => {
-    const { currentTab = null, groupItems = [], badgeCodes = [], setGroupItems = null, setBadgeCodes = null } = props;
-    const [filterType, setFilterType] = useState<string>(FILTER_EVERYTHING);
-    const [searchValue, setSearchValue] = useState('');
-
-    useEffect(() => {
-        if (currentTab !== TAB_BADGES) return;
-
-        const comparison = searchValue.toLocaleLowerCase().replace(' ', '');
-
-        const filteredBadges = badgeCodes.filter((badge) => badge.startsWith('ACH_'));
-        const numberMap: { [key: string]: number } = {};
-
-        filteredBadges.forEach((badge) => {
-            const name = badge.split(/[\d]+/)[0];
-            const number = Number(badge.replace(name, ''));
-
-            if (numberMap[name] === undefined || number > numberMap[name]) {
-                numberMap[name] = number;
-            }
-        });
-
-        const deduped = Object.keys(numberMap)
-            .map((name) => `${name}${numberMap[name]}`)
-            .concat(badgeCodes.filter((badge) => !badge.startsWith('ACH_')));
-
-        const filtered = deduped.filter((badgeCode) => LocalizeBadgeName(badgeCode).toLocaleLowerCase().includes(comparison));
-
-        setBadgeCodes(filtered);
-    }, [badgeCodes, currentTab, searchValue, setBadgeCodes]);
-
-    useEffect(() => {
-        if (currentTab !== TAB_FURNITURE) return;
-
-        const comparison = searchValue.toLocaleLowerCase();
-
-        if (filterType === FILTER_EVERYTHING) {
-            setGroupItems(groupItems.filter((item) => item.name.toLocaleLowerCase().includes(comparison)));
-            return;
-        }
-
-        const filtered = groupItems.filter((item) => {
-            const isWall = filterType === FILTER_WALL ? item.isWallItem : false;
-            const isFloor = filterType === FILTER_FLOOR ? !item.isWallItem : false;
-            const matchesSearch = item.name.toLocaleLowerCase().includes(comparison);
-
-            return comparison.length ? matchesSearch && (isWall || isFloor) : isWall || isFloor;
-        });
-
-        setGroupItems(filtered);
-    }, [groupItems, setGroupItems, searchValue, filterType, currentTab]);
-
-    useEffect(() => {
-        setFilterType(FILTER_EVERYTHING);
-        setSearchValue('');
-    }, [currentTab]);
+    const { currentTab = null, searchValue = '', filterType = FILTER_EVERYTHING, onSearchChange = null, onFilterTypeChange = null } = props;
 
     return (
         <div className={`nitro-inventory-filter-bar flex gap-1 rounded p-1 shrink-0 ${currentTab === TAB_BADGES ? 'is-badges' : ''}`}>
@@ -81,17 +27,17 @@ export const InventoryCategoryFilterView: FC<InventoryCategoryFilterViewProps> =
                     className="w-full"
                     placeholder={LocalizeText('catalog.search')}
                     value={searchValue}
-                    onChange={(event) => setSearchValue(event.target.value)}
+                    onChange={(event) => onSearchChange?.(event.target.value)}
                 />
                 {searchValue && searchValue.length > 0 && (
-                    <i className="icon icon-clear absolute cursor-pointer right-1 top-1" onClick={() => setSearchValue('')} />
+                    <i className="icon icon-clear absolute cursor-pointer right-1 top-1" onClick={() => onSearchChange?.('')} />
                 )}
             </div>
             {currentTab !== TAB_BADGES && (
                 <select
                     className="form-select text-xs rounded px-1 py-0 border border-gray-400 bg-white cursor-pointer"
                     value={filterType}
-                    onChange={(event) => setFilterType(event.target.value)}
+                    onChange={(event) => onFilterTypeChange?.(event.target.value)}
                 >
                     {[FILTER_EVERYTHING, FILTER_FLOOR, FILTER_WALL].map((type, index) => (
                         <option key={index} value={type}>

--- a/src/components/inventory/views/furniture/InventoryFurnitureItemView.tsx
+++ b/src/components/inventory/views/furniture/InventoryFurnitureItemView.tsx
@@ -1,27 +1,27 @@
 import { MouseEventType } from '@nitrots/nitro-renderer';
 import { FC, MouseEvent, useState } from 'react';
 import { attemptItemPlacement, GroupItem } from '../../../../api';
-import { useInventoryFurni } from '../../../../hooks';
 import { classNames, InfiniteGrid } from '../../../../layout';
 
 export const InventoryFurnitureItemView: FC<{
     groupItem: GroupItem;
+    isActive: boolean;
+    onSelect: (groupItem: GroupItem) => void;
 }> = (props) => {
-    const { groupItem = null, ...rest } = props;
+    const { groupItem = null, isActive = false, onSelect = null } = props;
     const [isMouseDown, setMouseDown] = useState(false);
-    const { selectedItem = null, setSelectedItem = null } = useInventoryFurni();
 
     const onMouseEvent = (event: MouseEvent) => {
         switch (event.type) {
             case MouseEventType.MOUSE_DOWN:
-                setSelectedItem(groupItem);
+                onSelect?.(groupItem);
                 setMouseDown(true);
                 return;
             case MouseEventType.MOUSE_UP:
                 setMouseDown(false);
                 return;
             case MouseEventType.ROLL_OUT:
-                if (!isMouseDown || !(groupItem === selectedItem)) return;
+                if (!isMouseDown || !isActive) return;
 
                 attemptItemPlacement(groupItem);
                 return;
@@ -36,8 +36,8 @@ export const InventoryFurnitureItemView: FC<{
     return (
         <InfiniteGrid.Item
             className={classNames(!count && 'opacity-50')}
-            itemActive={groupItem === selectedItem}
-            itemCount={groupItem.getUnlockedCount()}
+            itemActive={isActive}
+            itemCount={count}
             itemImage={groupItem.iconUrl}
             itemUniqueNumber={groupItem.stuffData.uniqueNumber}
             itemUnseen={groupItem.hasUnseenItems}

--- a/src/components/inventory/views/furniture/InventoryFurnitureView.tsx
+++ b/src/components/inventory/views/furniture/InventoryFurnitureView.tsx
@@ -2,7 +2,7 @@ import { InfiniteGrid } from '@layout/InfiniteGrid';
 import { GetSessionDataManager, IRoomSession, RoomPreviewer, Vector3d } from '@nitrots/nitro-renderer';
 import { FC, useEffect, useState } from 'react';
 import { FaPowerOff, FaSyncAlt, FaTrashAlt } from 'react-icons/fa';
-import { attemptItemPlacement, DispatchUiEvent, FurniCategory, GroupItem, LocalizeText, UnseenItemCategory } from '../../../../api';
+import { attemptItemPlacement, DispatchUiEvent, FurniCategory, getGroupItemKey, GroupItem, LocalizeText, UnseenItemCategory } from '../../../../api';
 import { LayoutLimitedEditionCompactPlateView, LayoutRarityLevelView, LayoutRoomPreviewerView } from '../../../../common';
 import { CatalogPostMarketplaceOfferEvent, DeleteItemConfirmEvent } from '../../../../events';
 import { useInventoryFurni, useInventoryUnseenTracker } from '../../../../hooks';
@@ -35,7 +35,7 @@ export const InventoryFurnitureView: FC<{
 }> = (props) => {
     const { roomSession = null, roomPreviewer = null, filteredGroupItems = [] } = props;
     const [isVisible, setIsVisible] = useState(false);
-    const { groupItems = [], selectedItem = null, activate = null, deactivate = null } = useInventoryFurni();
+    const { groupItems = [], selectedItem = null, setSelectedItem = null, activate = null, deactivate = null } = useInventoryFurni();
     const { resetItems = null } = useInventoryUnseenTracker();
 
     useEffect(() => {
@@ -114,7 +114,12 @@ export const InventoryFurnitureView: FC<{
     return (
         <div className="grid h-full grid-cols-12 gap-2">
             <div className="flex flex-col col-span-7 gap-1 overflow-hidden">
-                <InfiniteGrid<GroupItem> columnCount={6} itemRender={(item) => <InventoryFurnitureItemView groupItem={item} />} items={filteredGroupItems} />
+                <InfiniteGrid<GroupItem>
+                    columnCount={6}
+                    itemKey={getGroupItemKey}
+                    itemRender={(item) => <InventoryFurnitureItemView groupItem={item} isActive={item === selectedItem} onSelect={setSelectedItem} />}
+                    items={filteredGroupItems}
+                />
             </div>
             <div className="flex flex-col col-span-5">
                 <div className="relative flex flex-col">

--- a/src/hooks/inventory/useInventoryFurni.reducers.ts
+++ b/src/hooks/inventory/useInventoryFurni.reducers.ts
@@ -1,7 +1,6 @@
 import {
     CreateLinkEvent,
     FurnitureListAddOrUpdateEvent,
-    FurnitureListEvent,
     FurnitureListItemParser,
     FurnitureListRemovedEvent
 } from '@nitrots/nitro-renderer';
@@ -14,14 +13,12 @@ import {
     GroupItem,
     getAllItemIds,
     getPlacingItemId,
-    mergeFurniFragments,
     UnseenItemCategory
 } from '../../api';
 
 export interface FurniReducerContext {
     isUnseen: (category: number, id: number) => boolean;
     dispatchAdded: (id: number, type: number, category: number) => void;
-    fragments: { current: Map<number, FurnitureListItemParser>[] | null };
 }
 
 export const applyFurnitureListAddOrUpdate = (state: GroupItem[], event: FurnitureListAddOrUpdateEvent, ctx: FurniReducerContext): GroupItem[] => {
@@ -30,7 +27,7 @@ export const applyFurnitureListAddOrUpdate = (state: GroupItem[], event: Furnitu
 
     for (const item of parser.items) {
         let i = 0;
-        let groupItem: GroupItem = null;
+        let matched = false;
 
         while (i < newValue.length) {
             const group = newValue[i];
@@ -41,15 +38,21 @@ export const applyFurnitureListAddOrUpdate = (state: GroupItem[], event: Furnitu
                 const furniture = group.items[j];
 
                 if (furniture.id === item.itemId) {
-                    furniture.update(item);
+                    const clonedGroup = group.clone();
+                    const clonedFurniture = furniture.clone();
 
-                    const newFurniture = [...group.items];
+                    clonedFurniture.update(item);
 
-                    newFurniture[j] = furniture;
+                    const newFurniture = [...clonedGroup.items];
 
-                    group.items = newFurniture;
+                    newFurniture[j] = clonedFurniture;
 
-                    groupItem = group;
+                    clonedGroup.items = newFurniture;
+                    clonedGroup.hasUnseenItems = true;
+
+                    newValue[i] = clonedGroup;
+
+                    matched = true;
 
                     break;
                 }
@@ -57,16 +60,12 @@ export const applyFurnitureListAddOrUpdate = (state: GroupItem[], event: Furnitu
                 j++;
             }
 
-            if (groupItem) break;
+            if (matched) break;
 
             i++;
         }
 
-        if (groupItem) {
-            groupItem.hasUnseenItems = true;
-
-            newValue[i] = CloneObject(groupItem);
-        } else {
+        if (!matched) {
             const furniture = new FurnitureItem(item);
 
             addFurnitureItem(newValue, furniture, ctx.isUnseen(UnseenItemCategory.FURNI, item.itemId));
@@ -78,17 +77,10 @@ export const applyFurnitureListAddOrUpdate = (state: GroupItem[], event: Furnitu
     return newValue;
 };
 
-export const applyFurnitureList = (state: GroupItem[], event: FurnitureListEvent, ctx: FurniReducerContext): GroupItem[] => {
-    const parser = event.getParser();
-
-    if (!ctx.fragments.current) ctx.fragments.current = new Array(parser.totalFragments);
-
-    const fragment = mergeFurniFragments(parser.fragment, parser.totalFragments, parser.fragmentNumber, ctx.fragments.current);
-
-    if (!fragment) return state;
-
+export const applyMergedFurnitureList = (state: GroupItem[], fragment: Map<number, FurnitureListItemParser>, ctx: FurniReducerContext): GroupItem[] => {
     const newValue = [...state];
     const existingIds = getAllItemIds(newValue);
+    const existingIdSet = new Set(existingIds);
 
     for (const existingId of existingIds) {
         if (fragment.get(existingId)) continue;
@@ -96,16 +88,18 @@ export const applyFurnitureList = (state: GroupItem[], event: FurnitureListEvent
         let index = 0;
 
         while (index < newValue.length) {
-            const group = newValue[index];
-            const item = group.remove(existingId);
+            const originalGroup = newValue[index];
 
-            if (!item) {
+            if (!originalGroup.getItemById(existingId)) {
                 index++;
 
                 continue;
             }
 
-            if (getPlacingItemId() === item.ref) {
+            const group = originalGroup.clone();
+            const item = group.remove(existingId);
+
+            if (item && getPlacingItemId() === item.ref) {
                 queueMicrotask(() => {
                     cancelRoomObjectPlacement();
 
@@ -117,8 +111,8 @@ export const applyFurnitureList = (state: GroupItem[], event: FurnitureListEvent
 
             if (group.getTotalCount() <= 0) {
                 newValue.splice(index, 1);
-
-                group.dispose();
+            } else {
+                newValue[index] = group;
             }
 
             break;
@@ -126,7 +120,7 @@ export const applyFurnitureList = (state: GroupItem[], event: FurnitureListEvent
     }
 
     for (const itemId of fragment.keys()) {
-        if (existingIds.indexOf(itemId) >= 0) continue;
+        if (existingIdSet.has(itemId)) continue;
 
         const parserItem = fragment.get(itemId);
 
@@ -138,8 +132,6 @@ export const applyFurnitureList = (state: GroupItem[], event: FurnitureListEvent
 
         ctx.dispatchAdded(item.id, item.type, item.category);
     }
-
-    ctx.fragments.current = null;
 
     return newValue;
 };
@@ -183,11 +175,15 @@ export const applyFurnitureListRemoved = (state: GroupItem[], event: FurnitureLi
 };
 
 export const clearUnseenFlags = (state: GroupItem[]): GroupItem[] => {
-    const newValue = [...state];
+    if (!state?.length) return state;
 
-    for (const newGroup of newValue) newGroup.hasUnseenItems = false;
+    return state.map((groupItem) => {
+        const nextGroupItem = groupItem.clone();
 
-    return newValue;
+        nextGroupItem.hasUnseenItems = false;
+
+        return nextGroupItem;
+    });
 };
 
 export const refreshGroupItemsLocalization = (state: GroupItem[]): GroupItem[] => {

--- a/src/hooks/inventory/useInventoryFurni.ts
+++ b/src/hooks/inventory/useInventoryFurni.ts
@@ -8,14 +8,14 @@ import {
 } from '@nitrots/nitro-renderer';
 import { useEffect, useRef, useState } from 'react';
 import { registerSharedHook, useSharedHook } from '@/state/useSharedHook';
-import { DispatchUiEvent, GroupItem, SendMessageComposer, UnseenItemCategory } from '../../api';
+import { DispatchUiEvent, getGroupItemKey, GroupItem, mergeFurniFragments, SendMessageComposer, UnseenItemCategory } from '../../api';
 import { InventoryFurniAddedEvent } from '../../events';
 import { useMessageEvent } from '../events';
 import { useSharedVisibility } from '../useSharedVisibility';
 import {
-    applyFurnitureList,
     applyFurnitureListAddOrUpdate,
     applyFurnitureListRemoved,
+    applyMergedFurnitureList,
     clearUnseenFlags,
     FurniReducerContext,
     refreshGroupItemsLocalization
@@ -62,8 +62,7 @@ const useInventoryFurniState = () => {
 
     const buildContext = (): FurniReducerContext => ({
         isUnseen,
-        dispatchAdded: (id, type, category) => queueMicrotask(() => DispatchUiEvent(new InventoryFurniAddedEvent(id, type, category))),
-        fragments: fragmentsRef
+        dispatchAdded: (id, type, category) => queueMicrotask(() => DispatchUiEvent(new InventoryFurniAddedEvent(id, type, category)))
     });
 
     useMessageEvent<FurnitureListAddOrUpdateEvent>(FurnitureListAddOrUpdateEvent, (event) => {
@@ -71,7 +70,19 @@ const useInventoryFurniState = () => {
     });
 
     useMessageEvent<FurnitureListEvent>(FurnitureListEvent, (event) => {
-        setGroupItems((prev) => applyFurnitureList(prev, event, buildContext()));
+        const parser = event.getParser();
+
+        if (!fragmentsRef.current) fragmentsRef.current = new Array(parser.totalFragments);
+
+        const merged = mergeFurniFragments(parser.fragment, parser.totalFragments, parser.fragmentNumber, fragmentsRef.current);
+
+        if (!merged) return;
+
+        fragmentsRef.current = null;
+
+        const context = buildContext();
+
+        setGroupItems((prev) => applyMergedFurnitureList(prev, merged, context));
     });
 
     useMessageEvent<FurnitureListInvalidateEvent>(FurnitureListInvalidateEvent, () => {
@@ -86,13 +97,14 @@ const useInventoryFurniState = () => {
         if (!groupItems || !groupItems.length) return;
 
         setSelectedItem((prevValue) => {
-            let newValue = prevValue;
+            if (!prevValue) return groupItems[0];
 
-            if (newValue && groupItems.indexOf(newValue) === -1) newValue = null;
+            if (groupItems.indexOf(prevValue) !== -1) return prevValue;
 
-            if (!newValue) newValue = groupItems[0];
+            const key = getGroupItemKey(prevValue);
+            const match = groupItems.find((group) => getGroupItemKey(group) === key);
 
-            return newValue;
+            return match ?? groupItems[0];
         });
     }, [groupItems]);
 

--- a/src/layout/InfiniteGrid.tsx
+++ b/src/layout/InfiniteGrid.tsx
@@ -18,6 +18,10 @@ type Props<T> = {
     airColumnAdmission?: boolean;
     onColumnCountChange?: (columnCount: number) => void;
     itemRender?: (item: T, index?: number) => ReactElement;
+    // Optional stable React key per item. Defaults to the grid position (index), which is fine
+    // for static lists but lets a cell's local state bleed to a different item when the list
+    // reorders - pass this for lists whose items are added/removed/reordered.
+    itemKey?: (item: T, index: number) => string | number;
 };
 
 const GRID_GAP_PX = 4;
@@ -73,6 +77,7 @@ const InfiniteGridSquare = <T,>(props: Props<T>) => {
         airColumnAdmission = false,
         onColumnCountChange,
         itemRender = null,
+        itemKey = null,
         classicScrollbar = false
     } = props;
     const { parentRef } = useColumnMeasure(itemMinWidth, columnCountProp, columnGap, airColumnAdmission, onColumnCountChange);
@@ -86,7 +91,7 @@ const InfiniteGridSquare = <T,>(props: Props<T>) => {
             {items.map((item, index) => {
                 if (!item) return <Fragment key={`${index}-empty`} />;
 
-                return <Fragment key={`${index}-item`}>{itemRender(item, index)}</Fragment>;
+                return <Fragment key={itemKey ? itemKey(item, index) : `${index}-item`}>{itemRender(item, index)}</Fragment>;
             })}
         </div>
     );
@@ -118,6 +123,7 @@ const InfiniteGridVirtualized = <T,>(props: Props<T>) => {
         airColumnAdmission = false,
         onColumnCountChange,
         itemRender = null,
+        itemKey = null,
         classicScrollbar = false
     } = props;
     const { parentRef, columnCount } = useColumnMeasure(itemMinWidth, columnCountProp, columnGap, airColumnAdmission, onColumnCountChange);
@@ -188,7 +194,7 @@ const InfiniteGridVirtualized = <T,>(props: Props<T>) => {
 
                 if (!item) return <Fragment key={virtualRow.index + i + 'b'} />;
 
-                return <Fragment key={i}>{itemRender(item, index)}</Fragment>;
+                return <Fragment key={itemKey ? itemKey(item, index) : i}>{itemRender(item, index)}</Fragment>;
             })}
         </div>
     ));


### PR DESCRIPTION
no more derived-state-in-an-effect. The filter bar is now controlled/presentational; InventoryView owns searchValue/filterType and derives filteredGroupItems + filteredBadgeCodes with useMemo. That removes the effect → parent-setState → re-render round-trip, the extra commit, and the one-frame stale render on every change. Same filtering logic, including the achievement-badge de-dup.

tiles don't subscribe to the whole store. InventoryFurnitureItemView now takes isActive/onSelect as props, so selecting a tile re-renders only the two tiles whose active state changed instead of every tile.

stable selection. The selected item reconciles by a stable identity key (getGroupItemKey = type + wall + stuff) instead of object reference, so it stops jumping to the first tile whenever a reducer clones a group.

stable grid keys. InfiniteGrid got an optional itemKey prop; the furni grid keys tiles by identity so hover/mousedown state can't bleed to a different item on reorder. Every other InfiniteGrid consumer keeps the index-key default (fully backward-compatible).