### PR TITLE
feat(catalog-manager): group catalog problems by rule and say when they were checked

### DIFF
--- a/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioPanels.test.tsx
@@ -98,8 +98,10 @@ describe('Catalog Studio essential panels', () => {
             undo={vi.fn()}
         />);
 
+        // The rule heads the group; the entity and field sit in the row beneath it.
         expect(screen.getByText('Offer page 999 does not exist')).toBeInTheDocument();
-        expect(screen.getByText('OFFER #77 · pageId')).toBeInTheDocument();
+        expect(screen.getByText('OFFER #77')).toBeInTheDocument();
+        expect(screen.getByText('pageId · Offer page 999 does not exist')).toBeInTheDocument();
         expect(screen.queryByText(/publish/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/draft/i)).not.toBeInTheDocument();
     });

--- a/src/components/catalog/admin/studio/CatalogStudioProblemsHistoryPanel.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProblemsHistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { FC, useState } from 'react';
-import { FaExclamationTriangle, FaHistory, FaUndo } from 'react-icons/fa';
+import { FC, useMemo, useState } from 'react';
+import { FaChevronDown, FaChevronRight, FaExclamationTriangle, FaHistory, FaSyncAlt, FaUndo } from 'react-icons/fa';
 import { CatalogStudioHistoryGroup, CatalogStudioValidationIssue } from './CatalogStudioTypes';
 
 interface CatalogStudioProblemsHistoryPanelProps {
@@ -7,10 +7,72 @@ interface CatalogStudioProblemsHistoryPanelProps {
     history: CatalogStudioHistoryGroup[];
     loading: boolean;
     undo: (groupId: number) => void;
+    revalidate?: () => void;
+    checkedAt?: number | null;
+    onSelectEntity?: (issue: CatalogStudioValidationIssue) => void;
 }
 
-export const CatalogStudioProblemsHistoryPanel: FC<CatalogStudioProblemsHistoryPanelProps> = ({ issues, history, loading, undo }) => {
+const MAX_ROWS_PER_RULE = 50;
+
+// Grouping earns its keep on a catalog that answers with hundreds of rows. On a short list it is
+// just a click in the way, so a small report opens itself.
+const AUTO_EXPAND_LIMIT = 20;
+
+// Only pages can be opened from here: an offer is not addressable on its own in the manager.
+const SELECTABLE_ENTITY_TYPE = 'PAGE';
+
+// A rule fires once per entity, so a live catalog answers with hundreds of identical sentences.
+// The rule is what an operator acts on; the entities are the detail underneath it.
+const groupByRule = (issues: CatalogStudioValidationIssue[]) => {
+    const groups = new Map<string, { code: string; label: string; issues: CatalogStudioValidationIssue[] }>();
+
+    for (const issue of issues) {
+        const group = groups.get(issue.code);
+
+        if (group) {
+            group.issues.push(issue);
+            continue;
+        }
+
+        groups.set(issue.code, { code: issue.code, label: issue.message, issues: [issue] });
+    }
+
+    return [...groups.values()].sort((a, b) => b.issues.length - a.issues.length);
+};
+
+const formatTime = (value: number) => {
+    try {
+        return new Date(value).toLocaleTimeString();
+    } catch {
+        return '';
+    }
+};
+
+export const CatalogStudioProblemsHistoryPanel: FC<CatalogStudioProblemsHistoryPanelProps> = ({
+    issues,
+    history,
+    loading,
+    undo,
+    revalidate = null,
+    checkedAt = null,
+    onSelectEntity = null
+}) => {
     const [undoCandidate, setUndoCandidate] = useState<CatalogStudioHistoryGroup | null>(null);
+    const [openRules, setOpenRules] = useState<string[] | null>(null);
+
+    const ruleGroups = useMemo(() => groupByRule(issues), [issues]);
+    const openByDefault = useMemo(
+        () => (issues.length <= AUTO_EXPAND_LIMIT ? ruleGroups.map((group) => group.code) : []),
+        [issues.length, ruleGroups]
+    );
+    const expandedRules = openRules ?? openByDefault;
+
+    const toggleRule = (code: string) =>
+        setOpenRules((prev) => {
+            const base = prev ?? openByDefault;
+
+            return base.includes(code) ? base.filter((entry) => entry !== code) : [...base, code];
+        });
 
     const undoNow = () => {
         if (!undoCandidate) return;
@@ -21,18 +83,56 @@ export const CatalogStudioProblemsHistoryPanel: FC<CatalogStudioProblemsHistoryP
 
     return <div className="nitro-catalog-admin-publish">
         <div className="nitro-catalog-admin-validation-list">
-            <div className="nitro-catalog-admin-publish-changes-head">Current catalog problems</div>
+            <div className="nitro-catalog-admin-publish-changes-head">
+                Current catalog problems
+                <span className="nitro-catalog-admin-validation-meta">
+                    {checkedAt ? `checked at ${formatTime(checkedAt)}` : 'not checked yet'}
+                    {revalidate && <button
+                        className="nitro-catalog-admin-btn is-small"
+                        type="button"
+                        disabled={loading}
+                        onClick={revalidate}
+                        aria-label="Check the catalog again"
+                    >
+                        <FaSyncAlt /> Recheck
+                    </button>}
+                </span>
+            </div>
             {!issues.length && <div className="nitro-catalog-admin-placeholder is-small">No structural problems found.</div>}
-            {issues.map((issue, index) => <div
-                key={`${issue.code}-${issue.entityType}-${issue.entityId}-${issue.field}-${index}`}
-                className="nitro-catalog-admin-validation-row"
-            >
-                <FaExclamationTriangle />
-                <div>
-                    <strong>{issue.message}</strong>
-                    <span>{issue.entityType} #{issue.entityId} &middot; {issue.field}</span>
-                </div>
-            </div>)}
+            {ruleGroups.map(group => {
+                const isOpen = expandedRules.includes(group.code);
+
+                return <div key={group.code} className="nitro-catalog-admin-validation-group">
+                    <button
+                        className="nitro-catalog-admin-validation-group-head"
+                        type="button"
+                        aria-expanded={isOpen}
+                        onClick={() => toggleRule(group.code)}
+                    >
+                        {isOpen ? <FaChevronDown /> : <FaChevronRight />}
+                        <FaExclamationTriangle />
+                        <strong>{group.label}</strong>
+                        <span className="nitro-catalog-admin-validation-count">{group.issues.length}</span>
+                    </button>
+                    {isOpen && <div className="nitro-catalog-admin-validation-group-body">
+                        {group.issues.slice(0, MAX_ROWS_PER_RULE).map((issue, index) => <button
+                            key={`${issue.entityType}-${issue.entityId}-${issue.field}-${index}`}
+                            className="nitro-catalog-admin-validation-row"
+                            type="button"
+                            disabled={!onSelectEntity || issue.entityType !== SELECTABLE_ENTITY_TYPE}
+                            onClick={() => onSelectEntity && onSelectEntity(issue)}
+                        >
+                            <div>
+                                <strong>{issue.entityType} #{issue.entityId}</strong>
+                                <span>{issue.field} &middot; {issue.message}</span>
+                            </div>
+                        </button>)}
+                        {group.issues.length > MAX_ROWS_PER_RULE && <div className="nitro-catalog-admin-placeholder is-small">
+                            {group.issues.length - MAX_ROWS_PER_RULE} more not listed
+                        </div>}
+                    </div>}
+                </div>;
+            })}
         </div>
 
         <div className="nitro-catalog-admin-publish-changes">

--- a/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
+++ b/src/components/catalog/admin/studio/CatalogStudioProvider.tsx
@@ -116,7 +116,8 @@ export const CatalogStudioProvider: FC<{ active: boolean; children: ReactNode }>
             message: parser.message,
             revision: parser.revision,
             current: parser.current,
-            issues: parser.issues.map((issue) => ({ ...issue }))
+            issues: parser.issues.map((issue) => ({ ...issue })),
+            receivedAt: Date.now()
         };
         setValidation(next);
         updateRevision(parser.revision);

--- a/src/components/catalog/admin/studio/CatalogStudioTypes.ts
+++ b/src/components/catalog/admin/studio/CatalogStudioTypes.ts
@@ -106,6 +106,8 @@ export interface CatalogStudioValidationState {
     revision: number;
     current: boolean;
     issues: CatalogStudioValidationIssue[];
+    /** When this report reached the client. A report says nothing without the moment it was taken. */
+    receivedAt: number;
 }
 
 export interface CatalogStudioDocumentResult {

--- a/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
+++ b/src/components/catalog/views/admin/CatalogAdminManagerView.tsx
@@ -23,6 +23,7 @@ import { useCatalogActions, useCatalogData, useCatalogUiState } from '../../../.
 import { replaceCatalogPageOffers } from '../../../../hooks/catalog/useCatalog.helpers';
 import { getCatalogStudioCommandState, getCatalogStudioWorkspaceTabs } from '../../admin/studio/CatalogStudioCommandCenter';
 import { CatalogStudioProblemsHistoryPanel } from '../../admin/studio/CatalogStudioProblemsHistoryPanel';
+import { CatalogStudioValidationIssue } from '../../admin/studio/CatalogStudioTypes';
 import { CatalogStudioTransferPanel } from '../../admin/studio/CatalogStudioTransferPanel';
 import { useCatalogStudio } from '../../admin/studio/useCatalogStudio';
 import { useCatalogAdmin } from '../../CatalogAdminContext';
@@ -131,6 +132,14 @@ export const CatalogAdminManagerView: FC<{}> = () => {
     useEffect(() => {
         if (currentPage?.pageId != null && currentPage.pageId !== selectedPageId) setSelectedPageId(currentPage.pageId);
     }, [currentPage?.pageId, selectedPageId]);
+
+    // A problem names an entity; the operator wants to be standing on it.
+    const handleProblemSelect = useCallback((issue: CatalogStudioValidationIssue) => {
+        if (issue.entityType !== 'PAGE') return;
+
+        setSelectedPageId(issue.entityId);
+        setActiveTab('catalog');
+    }, []);
 
     const handlePageDragStart = useCallback((event: React.DragEvent, node: ICatalogNode) => {
         event.stopPropagation();
@@ -631,6 +640,9 @@ export const CatalogAdminManagerView: FC<{}> = () => {
                 history={studio.history}
                 loading={studio.loading}
                 undo={studio.undo}
+                revalidate={studio.validate}
+                checkedAt={studio.validation?.receivedAt ?? null}
+                onSelectEntity={handleProblemSelect}
             />
         </div>
     );

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -4735,3 +4735,89 @@
     margin-top: 2px;
     color: #b83b32;
 }
+
+/* Problems panel: the rules are the list, the entities are the detail underneath.
+   A live catalog answers with hundreds of rows, so they open one rule at a time. */
+.nitro-catalog-admin-validation-list .nitro-catalog-admin-publish-changes-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.nitro-catalog-admin-validation-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: #75756e;
+    font-size: 9px;
+    font-weight: 400;
+}
+
+.nitro-catalog-admin-validation-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.nitro-catalog-admin-validation-group-head {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: 100%;
+    padding: 7px 9px;
+    border: 1px solid #d9a39f;
+    border-radius: 4px;
+    background: #fff3f2;
+    color: #252521;
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    text-align: left;
+    cursor: pointer;
+}
+
+.nitro-catalog-admin-validation-group-head:hover {
+    background: #ffe9e6;
+}
+
+.nitro-catalog-admin-validation-group-head > strong {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.nitro-catalog-admin-validation-count {
+    flex: 0 0 auto;
+    padding: 1px 7px;
+    border-radius: 9px;
+    background: #b4514b;
+    color: #fff;
+    font-size: 9px;
+    font-weight: 700;
+}
+
+.nitro-catalog-admin-validation-group-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-left: 16px;
+}
+
+/* The row became a button so a problem can carry you to the page it names. */
+.nitro-catalog-admin-validation-group-body .nitro-catalog-admin-validation-row {
+    width: 100%;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.nitro-catalog-admin-validation-group-body .nitro-catalog-admin-validation-row:disabled {
+    cursor: default;
+    opacity: 0.75;
+}
+
+.nitro-catalog-admin-validation-group-body .nitro-catalog-admin-validation-row:not(:disabled):hover {
+    border-color: #b4514b;
+    background: #ffe9e6;
+}


### PR DESCRIPTION
The catalog manager listed every problem as its own row, flat and unsorted. A
validation rule fires once per entity, so a live catalog answers with hundreds of
identical sentences — **895 rows** on the hotel this was built against, most of
them reading `Sibling order N is used more than once`. Nothing in that list could
be acted on, or even scrolled through.

## Change

**Grouped by rule.** One row per rule with a count, biggest first, opening one at
a time:

```
Sibling order 1 is used more than once      84
Unsupported points currency: 104            77
Page hierarchy contains a cycle              2
Invalid item token: 0                        1
```

A report of twenty or fewer opens itself — on a short list the grouping is only a
click in the way.

**A row carries you to what it names.** Clicking a page problem selects that page
and switches to the Catalog tab. Offers stay unclickable: an offer is not
addressable on its own in the manager, so the row says so by being disabled
rather than by doing nothing.

**The report says when it was taken**, and offers a Recheck button. Validation
already ran on entering the tab, but nothing on screen said how old the answer
was — which is how a stale report can send someone chasing a number the current
code no longer prints.

Long groups list the first 50 entities and then say how many are not listed,
rather than silently stopping.

## Notes

- Presentation only. No protocol change, no new request: `Recheck` calls the
  validate action that already existed in the studio context.
- `CatalogStudioPanels.test.tsx` pinned the old flat presentation. It now asserts
  the new one, with the same strength: the rule, the entity and the field are all
  still checked to be on screen.

## Verification

- `yarn typecheck` — clean
- `yarn lint:hooks` — clean
- `yarn test --run` — 1072 tests in 201 files, all passing

Checked visually against a static page built from the real markup and the real
stylesheet; the live panel needs a client attached to a running emulator.
