### PR TITLE
Mod tool: search the chatlog, and confirm a sanction before it lands

### DIFF
--- a/src/components/mod-tools/views/chatlog/ChatlogView.filter.test.ts
+++ b/src/components/mod-tools/views/chatlog/ChatlogView.filter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { ChatlogRecord } from './ChatlogRecord';
+import { filterChatlogRecords } from './ChatlogView';
+
+const room = (roomId: number, roomName: string): ChatlogRecord => ({ isRoomInfo: true, roomId, roomName });
+
+const line = (username: string, message: string): ChatlogRecord => ({
+    isRoomInfo: false,
+    timestamp: '12:00',
+    habboId: 1,
+    username,
+    hasHighlighting: false,
+    message
+});
+
+describe('filterChatlogRecords', () => {
+    const records = [
+        room(1, 'Lobby'),
+        line('alice', 'hello there'),
+        line('bob', 'selling furni'),
+        room(2, 'Cafe'),
+        line('carol', 'good morning')
+    ];
+
+    it('returns everything when nothing is typed', () => {
+        expect(filterChatlogRecords(records, '   ')).toBe(records);
+    });
+
+    it('keeps the room heading above a surviving line', () => {
+        expect(filterChatlogRecords(records, 'furni')).toEqual([room(1, 'Lobby'), line('bob', 'selling furni')]);
+    });
+
+    it('drops the heading of a room where nothing matched', () => {
+        const result = filterChatlogRecords(records, 'morning');
+
+        expect(result).toEqual([room(2, 'Cafe'), line('carol', 'good morning')]);
+        expect(result.some((r) => r.isRoomInfo && r.roomName === 'Lobby')).toBe(false);
+    });
+
+    it('matches the speaker as well as what was said', () => {
+        expect(filterChatlogRecords(records, 'alice')).toEqual([room(1, 'Lobby'), line('alice', 'hello there')]);
+    });
+
+    it('ignores case', () => {
+        expect(filterChatlogRecords(records, 'HELLO')).toHaveLength(2);
+    });
+
+    it('emits a heading once, however many lines match under it', () => {
+        const result = filterChatlogRecords(records, 'e');
+
+        expect(result.filter((r) => r.isRoomInfo && r.roomId === 1)).toHaveLength(1);
+    });
+
+    it('returns nothing when a room heading is the only thing that would match', () => {
+        expect(filterChatlogRecords(records, 'Lobby')).toEqual([]);
+    });
+});

--- a/src/components/mod-tools/views/chatlog/ChatlogView.tsx
+++ b/src/components/mod-tools/views/chatlog/ChatlogView.tsx
@@ -8,6 +8,8 @@ import { ChatlogRecord } from './ChatlogRecord';
 
 interface ChatlogViewProps {
     records: ChatRecordData[];
+    /** Opens already filtered - a user's own chatlog is only ever read for that user. */
+    initialQuery?: string;
 }
 
 /**
@@ -47,9 +49,9 @@ export const filterChatlogRecords = (records: ChatlogRecord[], query: string): C
 };
 
 export const ChatlogView: FC<ChatlogViewProps> = (props) => {
-    const { records = null } = props;
+    const { records = null, initialQuery = '' } = props;
     const { openRoomInfo = null } = useModTools();
-    const [query, setQuery] = useState('');
+    const [query, setQuery] = useState(initialQuery);
 
     const allRecords = useMemo(() => {
         const results: ChatlogRecord[] = [];
@@ -149,7 +151,7 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
             <div className="min-w-0 overflow-x-auto">
                 <div className="min-w-[360px]">
                     {/* Column headers */}
-                    <div className="grid grid-cols-[60px_120px_1fr] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
+                    <div className="grid grid-cols-[84px_120px_1fr] gap-2 text-[.7rem] uppercase tracking-wide opacity-60 font-semibold border-b border-zinc-200 pb-1 px-1">
                         <div>{LocalizeText('modtools.chatlog.column.time')}</div>
                         <div>{LocalizeText('modtools.chatlog.column.user')}</div>
                         <div>{LocalizeText('modtools.chatlog.column.message')}</div>
@@ -171,7 +173,7 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
 
                                 return (
                                     <div
-                                        className={`grid grid-cols-[60px_120px_1fr] gap-2 items-start px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors ${row.hasHighlighting ? 'bg-amber-50/60' : ''}`}
+                                        className={`grid grid-cols-[84px_120px_1fr] gap-2 items-start px-1 py-1.5 text-sm border-b border-zinc-100 even:bg-black/[0.02] hover:bg-sky-50/50 transition-colors ${row.hasHighlighting ? 'bg-amber-50/60' : ''}`}
                                     >
                                         <span className="font-mono text-[.7rem] opacity-70 tabular-nums whitespace-nowrap">{row.timestamp}</span>
                                         <button

--- a/src/components/mod-tools/views/chatlog/ChatlogView.tsx
+++ b/src/components/mod-tools/views/chatlog/ChatlogView.tsx
@@ -1,6 +1,6 @@
 import { ChatRecordData, CreateLinkEvent } from '@nitrots/nitro-renderer';
-import { FC, useMemo } from 'react';
-import { FaCommentDots, FaDoorOpen, FaSignInAlt, FaTools } from 'react-icons/fa';
+import { FC, Fragment, useMemo, useState } from 'react';
+import { FaCommentDots, FaDoorOpen, FaSearch, FaSignInAlt, FaTimes, FaTools } from 'react-icons/fa';
 import { LocalizeText, TryVisitRoom } from '../../../../api';
 import { Column, InfiniteScroll } from '../../../../common';
 import { useModTools } from '../../../../hooks';
@@ -10,9 +10,46 @@ interface ChatlogViewProps {
     records: ChatRecordData[];
 }
 
+/**
+ * Keeps the rows a moderator is looking for, and the room heading above each surviving
+ * group. Filtering the flat list on its own would leave headings for rooms that matched
+ * nothing, so a heading is only emitted once something under it survives.
+ */
+export const filterChatlogRecords = (records: ChatlogRecord[], query: string): ChatlogRecord[] => {
+    const needle = query.trim().toLowerCase();
+
+    if (!needle.length) return records;
+
+    const results: ChatlogRecord[] = [];
+    let pendingRoom: ChatlogRecord = null;
+
+    for (const record of records) {
+        if (record.isRoomInfo) {
+            pendingRoom = record;
+            continue;
+        }
+
+        const matches =
+            (record.message ?? '').toLowerCase().includes(needle) ||
+            (record.username ?? '').toLowerCase().includes(needle);
+
+        if (!matches) continue;
+
+        if (pendingRoom) {
+            results.push(pendingRoom);
+            pendingRoom = null;
+        }
+
+        results.push(record);
+    }
+
+    return results;
+};
+
 export const ChatlogView: FC<ChatlogViewProps> = (props) => {
     const { records = null } = props;
     const { openRoomInfo = null } = useModTools();
+    const [query, setQuery] = useState('');
 
     const allRecords = useMemo(() => {
         const results: ChatlogRecord[] = [];
@@ -41,6 +78,26 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
 
     const totalMessages = useMemo(() => allRecords.filter((r) => !r.isRoomInfo).length, [allRecords]);
 
+    const visibleRecords = useMemo(() => filterChatlogRecords(allRecords, query), [allRecords, query]);
+
+    const matchCount = useMemo(() => visibleRecords.filter((r) => !r.isRoomInfo).length, [visibleRecords]);
+    const isFiltering = query.trim().length > 0;
+
+    // The match is what the moderator is looking for; the rest is context.
+    const highlight = (text: string) => {
+        const needle = query.trim();
+
+        if (!needle.length || !text) return text;
+
+        const parts = text.split(new RegExp(`(${needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+
+        return parts.map((part, index) =>
+            part.toLowerCase() === needle.toLowerCase()
+                ? <mark key={index} className="bg-amber-200 text-inherit rounded-[2px] px-[1px]">{part}</mark>
+                : <Fragment key={index}>{part}</Fragment>
+        );
+    };
+
     const RoomInfo = (props: { roomId: number; roomName: string }) => (
         <div className="flex items-center gap-2 bg-gradient-to-r from-sky-50 to-transparent rounded p-2 border border-sky-100 my-1">
             <FaDoorOpen className="text-sky-600 shrink-0" size={14} />
@@ -66,6 +123,29 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
 
     return (
         <Column fit gap={0} overflow="hidden">
+            <div className="flex items-center gap-1 pb-1.5">
+                <div className="relative grow min-w-0">
+                    <input
+                        className="w-full"
+                        type="text"
+                        value={query}
+                        placeholder={LocalizeText('generic.search')}
+                        onChange={(event) => setQuery(event.target.value)}
+                    />
+                    {isFiltering && <button
+                        className="absolute right-1 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-4 h-4 rounded text-zinc-500 hover:text-rose-600"
+                        type="button"
+                        title={LocalizeText('generic.cancel')}
+                        onClick={() => setQuery('')}
+                    >
+                        <FaTimes size={9} />
+                    </button>}
+                </div>
+                <span className="text-[.65rem] opacity-60 shrink-0 tabular-nums">
+                    {isFiltering ? `${matchCount}/${totalMessages}` : totalMessages}
+                    <FaSearch className="inline ml-1 opacity-50" size={9} />
+                </span>
+            </div>
             <div className="min-w-0 overflow-x-auto">
                 <div className="min-w-[360px]">
                     {/* Column headers */}
@@ -74,7 +154,12 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
                         <div>{LocalizeText('modtools.chatlog.column.user')}</div>
                         <div>{LocalizeText('modtools.chatlog.column.message')}</div>
                     </div>
-                    {isEmpty ? (
+                    {!isEmpty && isFiltering && !matchCount ? (
+                        <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
+                            <FaSearch size={20} />
+                            <span>{LocalizeText('generic.no_results_found')}</span>
+                        </div>
+                    ) : isEmpty ? (
                         <div className="flex flex-col items-center justify-center gap-1 py-6 opacity-50 text-sm">
                             <FaCommentDots size={22} />
                             <span>{LocalizeText('modtools.chatlog.empty')}</span>
@@ -93,13 +178,13 @@ export const ChatlogView: FC<ChatlogViewProps> = (props) => {
                                             className="text-left font-semibold text-sky-700 hover:text-sky-900 hover:underline truncate"
                                             onClick={() => CreateLinkEvent(`mod-tools/open-user-info/${row.habboId}`)}
                                         >
-                                            {row.username}
+                                            {highlight(row.username)}
                                         </button>
-                                        <span className="break-words">{row.message}</span>
+                                        <span className="break-words">{highlight(row.message)}</span>
                                     </div>
                                 );
                             }}
-                            rows={allRecords}
+                            rows={visibleRecords}
                         />
                     )}
                 </div>

--- a/src/components/mod-tools/views/user/ModToolsUserChatlogView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserChatlogView.tsx
@@ -41,7 +41,7 @@ export const ModToolsUserChatlogView: FC<ModToolsUserChatlogViewProps> = (props)
             />
             <NitroCardContentView className="text-black h-full" gap={1}>
                 {userChatlog ? (
-                    <ChatlogView records={userChatlog} />
+                    <ChatlogView key={username ?? ''} initialQuery={username ?? ''} records={userChatlog} />
                 ) : (
                     <div className="flex flex-col items-center justify-center gap-2 py-8 opacity-50 text-sm">
                         <FaSpinner className="animate-spin" size={22} />

--- a/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
+++ b/src/components/mod-tools/views/user/ModToolsUserModActionView.tsx
@@ -9,7 +9,7 @@ import {
     ModTradingLockMessageComposer
 } from '@nitrots/nitro-renderer';
 import { FC, useMemo, useRef, useState } from 'react';
-import { FaBan, FaBolt, FaEnvelope, FaExclamationTriangle, FaGavel, FaUserSlash, FaVolumeMute } from 'react-icons/fa';
+import { FaBan, FaBolt, FaEnvelope, FaExclamationTriangle, FaGavel, FaHistory, FaUserSlash, FaVolumeMute } from 'react-icons/fa';
 import { ISelectedUser, LocalizeText, ModActionDefinition, NotificationAlertType, SendMessageComposer } from '../../../../api';
 import { Button, DraggableWindowPosition, NitroCardContentView, NitroCardHeaderView, NitroCardView } from '../../../../common';
 import { useModTools, useNotification } from '../../../../hooks';
@@ -52,14 +52,24 @@ const ACTION_TONE: Record<number, string> = {
     [ModActionDefinition.MESSAGE]: 'bg-zinc-100 text-zinc-800 border-zinc-200'
 };
 
+const formatSanctionTime = (at: number) => {
+    try {
+        return new Date(at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+        return '';
+    }
+};
+
 export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = (props) => {
     const { user = null, onCloseClick = null } = props;
     const [selectedTopic, setSelectedTopic] = useState(-1);
     const [selectedAction, setSelectedAction] = useState(-1);
     const [message, setMessage] = useState<string>('');
-    const { cfhCategories = null, settings = null } = useModTools();
+    const [pendingSanction, setPendingSanction] = useState<ModActionDefinition>(null);
+    const { cfhCategories = null, settings = null, sanctionLog = null, recordSanction = null } = useModTools();
     const { simpleAlert = null } = useNotification();
     const isSendingRef = useRef<boolean>(false);
+    const appliedThisSession = sanctionLog?.[user?.userId] ?? [];
 
     const topics = useMemo(() => {
         const values: CallForHelpTopicData[] = [];
@@ -91,6 +101,27 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = (pr
         onCloseClick();
     };
 
+    // Ban, kick, mute and trade lock cannot be undone from this window, and the panel
+    // shows one user while another may be selected behind it. The confirmation names
+    // who and what before anything leaves the client.
+    const NEEDS_CONFIRMATION = [
+        ModActionDefinition.BAN,
+        ModActionDefinition.KICK,
+        ModActionDefinition.MUTE,
+        ModActionDefinition.TRADE_LOCK
+    ];
+
+    const requestSanction = () => {
+        const sanction = MOD_ACTION_DEFINITIONS[selectedAction];
+
+        if (sanction && NEEDS_CONFIRMATION.includes(sanction.actionType)) {
+            setPendingSanction(sanction);
+            return;
+        }
+
+        sendSanction();
+    };
+
     const sendSanction = () => {
         if (isSendingRef.current) return;
 
@@ -106,6 +137,8 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = (pr
         if (errorMessage) return sendAlert(errorMessage);
 
         const messageOrDefault = message.trim().length === 0 ? LocalizeText(`help.cfh.topic.${category.id}`) : message;
+
+        recordSanction?.(user.userId, sanction.name);
 
         switch (sanction.actionType) {
             case ModActionDefinition.ALERT: {
@@ -160,7 +193,7 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = (pr
                 headerText={LocalizeText('modtools.user.modaction.title', ['username'], [user.username])}
                 onCloseClick={() => onCloseClick()}
             />
-            <NitroCardContentView className="text-black" gap={2}>
+            <NitroCardContentView className="text-black relative" gap={2}>
                 {/* Target header */}
                 <div className="flex items-center gap-2 bg-gradient-to-r from-rose-50 to-transparent rounded p-2 border border-rose-100">
                     <FaGavel className="text-rose-600 shrink-0" size={16} />
@@ -239,15 +272,59 @@ export const ModToolsUserModActionView: FC<ModToolsUserModActionViewProps> = (pr
                     </div>
                 )}
 
+                {/* What this moderator has already applied to this person, this session */}
+                {!!appliedThisSession.length && (
+                    <div className="flex flex-col gap-0.5 rounded border border-amber-200 bg-amber-50/60 p-1.5">
+                        <span className="text-[.6rem] uppercase tracking-wide font-semibold opacity-70">
+                            {LocalizeText('modtools.user.modaction.button.apply')}
+                        </span>
+                        {appliedThisSession.slice(-3).map((entry, index) => (
+                            <span key={index} className="text-[.65rem] flex items-center gap-1">
+                                <FaHistory className="opacity-50 shrink-0" size={8} />
+                                <strong className="truncate">{entry.label}</strong>
+                                <span className="opacity-60 tabular-nums shrink-0">{formatSanctionTime(entry.at)}</span>
+                            </span>
+                        ))}
+                    </div>
+                )}
+
                 {/* Action buttons */}
                 <div className="flex gap-1.5 pt-1 border-t border-zinc-200">
                     <Button className="grow" disabled={!canSubmit} gap={1} variant="primary" onClick={sendDefaultSanction}>
                         <FaBolt size={12} /> {LocalizeText('modtools.user.modaction.button.default')}
                     </Button>
-                    <Button className="grow" disabled={!canSubmit || selectedAction === -1} gap={1} variant="success" onClick={sendSanction}>
+                    <Button className="grow" disabled={!canSubmit || selectedAction === -1} gap={1} variant="success" onClick={requestSanction}>
                         <FaGavel size={12} /> {LocalizeText('modtools.user.modaction.button.apply')}
                     </Button>
                 </div>
+                {pendingSanction && (
+                    <div
+                        aria-label="Confirm moderation action"
+                        aria-modal="true"
+                        className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-white/95 p-3 text-center"
+                        role="dialog"
+                    >
+                        <FaExclamationTriangle className="text-amber-500" size={20} />
+                        <div className="text-sm">
+                            <strong>{pendingSanction.name}</strong>
+                            <div className="opacity-70">{user?.username}</div>
+                        </div>
+                        <div className="flex gap-1.5">
+                            <Button variant="secondary" onClick={() => setPendingSanction(null)}>
+                                {LocalizeText('generic.cancel')}
+                            </Button>
+                            <Button
+                                variant="danger"
+                                onClick={() => {
+                                    setPendingSanction(null);
+                                    sendSanction();
+                                }}
+                            >
+                                {LocalizeText('modtools.user.modaction.button.apply')}
+                            </Button>
+                        </div>
+                    </div>
+                )}
             </NitroCardContentView>
         </NitroCardView>
     );

--- a/src/hooks/mod-tools/useModTools.ts
+++ b/src/hooks/mod-tools/useModTools.ts
@@ -11,11 +11,16 @@ import {
     ModeratorInitMessageEvent,
     ModeratorToolPreferencesEvent
 } from '@nitrots/nitro-renderer';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { registerSharedHook, useSharedHook } from '@/state/useSharedHook';
 import { NotificationAlertType, PlaySound, SoundNames } from '../../api';
 import { useMessageEvent } from '../events';
 import { useNotification } from '../notification';
+
+export interface ModToolsSanctionEntry {
+    label: string;
+    at: number;
+}
 
 const useModToolsState = () => {
     const [settings, setSettings] = useState<ModeratorInitData>(null);
@@ -25,6 +30,9 @@ const useModToolsState = () => {
     const [openUserChatlogs, setOpenUserChatlogs] = useState<number[]>([]);
     const [tickets, setTickets] = useState<IssueMessageData[]>([]);
     const [cfhCategories, setCfhCategories] = useState<CallForHelpCategoryData[]>([]);
+    // What this moderator has already applied to whom, for as long as the client is open.
+    // Two panels on the same person is the easy way to sanction twice for one thing.
+    const [sanctionLog, setSanctionLog] = useState<Record<number, ModToolsSanctionEntry[]>>({});
     const { simpleAlert = null } = useNotification();
 
     const openRoomInfo = (roomId: number) => {
@@ -185,8 +193,14 @@ const useModToolsState = () => {
         // todo: update sanction data
     });
 
+    const recordSanction = useCallback((userId: number, label: string) => {
+        setSanctionLog((prev) => ({ ...prev, [userId]: [...(prev[userId] ?? []), { label, at: Date.now() }] }));
+    }, []);
+
     return {
         settings,
+        sanctionLog,
+        recordSanction,
         openRooms,
         openRoomChatlogs,
         openUserChatlogs,


### PR DESCRIPTION
## What this changes

Two additions to the moderation chatlog.

**The chatlog can be searched.** A busy room's log is hundreds of lines and the moderator is usually looking for one of them. A search field filters by message text or by speaker, highlights the match, and shows a `matches/total` count. Filtering a flat list on its own would leave room headings above rooms that matched nothing, so a heading is emitted only once a line under it survives — that rule is `filterChatlogRecords`, a pure function with its own tests (7 cases).

A user's own chatlog opens already filtered to that user, since that is the only reason it is ever read.

**Sanctions ask before they land, and say what already landed.** Ban, kick, mute and trade lock applied on the first click with no confirmation, in a panel where the buttons sit next to each other. Those four now raise a confirmation naming the user and the sanction; the rest still apply directly. Everything applied during the session is listed underneath with its time, so a moderator working a queue can see what they have already done to this user rather than reconstructing it from memory.

## Risk

Client-only; no packet or server change. The confirmation is a local overlay, and the session log is local state on `useModTools` — it is not persisted and does not claim to be a server-side record.

## Verification

`yarn typecheck`, `yarn lint:hooks`, `yarn test --run`, `yarn build` — all green locally on Node 26; CI pins Node 22, so treat the local run as weaker than CI.
