### PR TITLE
Lift the catalog avatar preview the way the original client does

### DIFF
--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
@@ -103,6 +103,8 @@ describe('catalog product preview', () => {
             expect(avatarRenderManager.getFigureStringWithFigureIds).toHaveBeenCalledWith('base-figure', 'M', [101, 202]);
             expect(roomPreviewer.addAvatarIntoRoom).toHaveBeenCalledWith('composed-figure', 0);
             expect(roomPreviewer.zoomIn).toHaveBeenCalledOnce();
+            // The official client lifts a zoomed avatar preview by 41px as part of the zoom.
+            expect(roomPreviewer.addViewOffset.y).toBe(-41);
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(false);
         });
     });
@@ -130,6 +132,8 @@ describe('catalog product preview', () => {
             expect(roomPreviewer.addFurnitureIntoRoom).toHaveBeenCalledWith(500, expect.anything(), null, '');
             expect(roomPreviewer.addAvatarIntoRoom).not.toHaveBeenCalled();
             expect(roomPreviewer.zoomIn).not.toHaveBeenCalled();
+            // Furniture is framed dead centre; only an avatar is lifted.
+            expect(roomPreviewer.addViewOffset.y).toBe(0);
             expect(roomPreviewer.centerWallItems).toBe(true);
             expect(roomPreviewer.updateObjectRoom).not.toHaveBeenCalled();
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(true);

--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
@@ -1,8 +1,24 @@
-import { GetAvatarRenderManager, GetSessionDataManager, Vector3d } from '@nitrots/nitro-renderer';
+import { GetAvatarRenderManager, GetSessionDataManager, RoomPreviewer, Vector3d } from '@nitrots/nitro-renderer';
 import { FC, useEffect } from 'react';
 import { FurniCategory, Offer, ProductTypeEnum } from '../../../../../api';
 import { AutoGrid, Column, LayoutGridItem, LayoutRoomPreviewerView } from '../../../../../common';
 import { useCatalogData, useCatalogUiState } from '../../../../../hooks';
+
+/**
+ * How much higher than dead centre an avatar preview sits.
+ *
+ * The official client zooms this preview by scaling the canvas itself, and lifts it in the same
+ * step: `canvas.y = -(height * scale - height) / 2 - 41` in
+ * `ProductViewCatalogWidget.applyRoomCanvasZoom`. We take the zoom from the room engine instead,
+ * which gives a sharper figure but carries no lift of its own - so without this the figure sits
+ * 41px lower in the box than it does in the original client.
+ */
+const ZOOMED_AVATAR_LIFT = 41;
+
+const zoomAvatarPreview = (roomPreviewer: RoomPreviewer) => {
+    roomPreviewer.zoomIn();
+    roomPreviewer.addViewOffset.y = -ZOOMED_AVATAR_LIFT;
+};
 
 export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => {
     const { height = 240 } = props;
@@ -55,7 +71,7 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
                         const figureString = avatarRenderManager.getFigureStringWithFigureIds(sessionDataManager.figure, sessionDataManager.gender, figureSets);
 
                         roomPreviewer.addAvatarIntoRoom(figureString || sessionDataManager.figure, 0);
-                        roomPreviewer.zoomIn();
+                        zoomAvatarPreview(roomPreviewer);
                     } else {
                         // RoomPreviewer only keys its fast path by class/extra,
                         // so force a transactional refresh when stuff data
@@ -101,11 +117,11 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
                 }
                 case ProductTypeEnum.ROBOT:
                     roomPreviewer.addAvatarIntoRoom(product.extraParam, 0);
-                    roomPreviewer.zoomIn();
+                    zoomAvatarPreview(roomPreviewer);
                     return;
                 case ProductTypeEnum.EFFECT:
                     roomPreviewer.addAvatarIntoRoom(GetSessionDataManager().figure, product.productClassId);
-                    roomPreviewer.zoomIn();
+                    zoomAvatarPreview(roomPreviewer);
                     return;
                 default:
                     roomPreviewer.reset(false);


### PR DESCRIPTION
## What this changes

An outfit, an effect or a bot sat 41px lower in the catalog preview box than it does in the original client: empty room above the figure, and the figure crowding the bottom edge.

The original zooms this preview by scaling the canvas itself, and the lift is part of that same step — `ProductViewCatalogWidget.applyRoomCanvasZoom`:

```as3
var _loc1_:Number = 1 + (2 - 1) * _previewZoomAnimationProgress;   // scale 1 → 2
var _loc2_:Number = 41 * _previewZoomAnimationProgress;            // lift 0 → 41
_roomCanvasDisplayObject.scaleY = _loc1_;
_roomCanvasDisplayObject.y = -(height * _loc1_ - height) / 2 - _loc2_;
```

We take the zoom from the room engine instead (`roomPreviewer.zoomIn()`), which draws a sharper figure at the same size but carries no lift of its own — so the figure came out exactly those 41px low.

The offset is the previewer's own `addViewOffset`, the same knob this widget already uses for the `-15` nudge on a unique limited item. It applies to all three avatar previews — purchasable clothing, effects, bots — because the original drives all three from one preview mode (`_previewMode == 1`).

## Not the cause

`RoomPreviewer.getCanvasOffset` was checked against the original line by line first: same `Math.min(15, height - 10)`, same UNIT branch, same 10px-per-update damping. The centring maths is not where the drift came from.

## Risk

Furniture and wall previews are untouched and stay centred.

## Verification

`yarn typecheck`, `yarn lint:hooks`, `yarn test --run` (1093 passed), `yarn build` — green locally on Node 26; CI pins Node 22, so treat the local run as weaker than CI. The preview tests now pin `addViewOffset.y` at `-41` for clothing and `0` for furniture.
