### PR TITLE
Catalog preview: correct the lift from #451, and the corner it shares with the limited-edition plate

### DIFF
--- a/src/components/catalog/catalogTabStrip.test.ts
+++ b/src/components/catalog/catalogTabStrip.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The catalog window widens itself to fit however many root categories the hotel publishes,
+ * between the original client's 570px and a 1040px ceiling. Two things have to hold for that
+ * to actually keep every category reachable, and neither is visible from a unit test of the
+ * hook alone - jsdom has no layout, so the measurement it does returns zero.
+ */
+describe('catalog tab strip', () => {
+    const hook = readFileSync(join(process.cwd(), 'src/components/catalog/useCatalogWindowWidth.ts'), 'utf8');
+    const stylesheet = readFileSync(join(process.cwd(), 'src/css/catalog/CatalogView.css'), 'utf8');
+
+    it('sizes the window from the tabs, from the original 570px up to a ceiling', () => {
+        expect(hook).toContain('CATALOG_WINDOW_BASE_WIDTH = 570');
+        expect(hook).toContain('CATALOG_WINDOW_MAX_WIDTH = 1040');
+        expect(hook).toContain('measureCatalogTabStripWidth');
+        // scrollWidth grows with the window it is used to size, so reading it feeds back into
+        // itself. The comment naming that trap may stay; the call may not.
+        const code = hook.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+
+        expect(code).not.toContain('scrollWidth');
+    });
+
+    it('lets the tabs condense once the window cannot widen any further', () => {
+        const rule = stylesheet.slice(
+            stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item {'),
+            stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item:last-of-type')
+        );
+
+        expect(rule).toContain('flex-shrink: 1');
+        expect(rule).not.toContain('flex-shrink: 0');
+        // Shrunk down to its icon a tab is still a target; shrunk to nothing it is not.
+        expect(rule).toContain('min-width: 34px');
+    });
+});

--- a/src/components/catalog/catalogTabStrip.test.ts
+++ b/src/components/catalog/catalogTabStrip.test.ts
@@ -23,15 +23,25 @@ describe('catalog tab strip', () => {
         expect(code).not.toContain('scrollWidth');
     });
 
-    it('lets the tabs condense once the window cannot widen any further', () => {
-        const rule = stylesheet.slice(
+    it('measures the tabs at their natural width, never at the width it is deciding', () => {
+        // A tab that could shrink to fit the current window would report that squeezed width
+        // back as the width the window should have.
+        const base = stylesheet.slice(
             stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item {'),
-            stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item:last-of-type')
+            stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell.is-condensed')
         );
 
-        expect(rule).toContain('flex-shrink: 1');
-        expect(rule).not.toContain('flex-shrink: 0');
+        expect(base).toContain('flex-shrink: 0');
+        expect(hook).toContain("classList.remove(CONDENSED_CLASS)");
+        expect(hook).toContain("classList.add(CONDENSED_CLASS)");
+    });
+
+    it('lets the tabs condense only once the window cannot widen any further', () => {
+        const condensed = stylesheet.slice(stylesheet.indexOf('.nitro-catalog-window .nitro-catalog-tabs-shell.is-condensed'));
+
+        expect(condensed).toContain('flex-shrink: 1');
         // Shrunk down to its icon a tab is still a target; shrunk to nothing it is not.
-        expect(rule).toContain('min-width: 34px');
+        expect(condensed).toContain('min-width: 34px');
+        expect(hook).toContain('needed > CATALOG_WINDOW_MAX_WIDTH');
     });
 });

--- a/src/components/catalog/useCatalogWindowWidth.ts
+++ b/src/components/catalog/useCatalogWindowWidth.ts
@@ -6,9 +6,21 @@ const CATALOG_WINDOW_MAX_WIDTH = 1040;
 // Bordi finestra (2+2) + padding contenuto card + margine ultimo tab + margine di
 // sicurezza per evitare che l'ultima categoria venga clippata dall'overflow:hidden.
 const CATALOG_FRAME_PADDING = 28;
+/**
+ * Set on the tab shell when the categories no longer fit even at the maximum width. Only then
+ * are the tabs allowed to shrink; the measurement below always runs without it, because a tab
+ * squeezed by the window cannot be used to decide how wide that window should be.
+ */
+const CONDENSED_CLASS = 'is-condensed';
 
 /** Sum tab widths (margins INCLUDED) — never use shell.scrollWidth (infinite growth loop). */
 const measureCatalogTabStripWidth = (shell: HTMLElement) => {
+    // Read the tabs at their natural width. Removing and restoring the class inside one task
+    // means the browser never paints the intermediate state.
+    const wasCondensed = shell.classList.contains(CONDENSED_CLASS);
+
+    if (wasCondensed) shell.classList.remove(CONDENSED_CLASS);
+
     const tabs = shell.querySelectorAll<HTMLElement>('.nitro-card-tab-item');
     let tabsWidth = 0;
 
@@ -22,6 +34,8 @@ const measureCatalogTabStripWidth = (shell: HTMLElement) => {
 
     const shellStyle = window.getComputedStyle(shell);
     const paddingX = Number.parseFloat(shellStyle.paddingLeft) + Number.parseFloat(shellStyle.paddingRight);
+
+    if (wasCondensed) shell.classList.add(CONDENSED_CLASS);
 
     return Math.ceil(tabsWidth + paddingX);
 };
@@ -40,13 +54,13 @@ export const useCatalogWindowWidth = (
         if (!shell) return;
 
         const measure = () => {
-            const needed = measureCatalogTabStripWidth(shell);
-            const next = Math.min(
-                CATALOG_WINDOW_MAX_WIDTH,
-                Math.max(CATALOG_WINDOW_BASE_WIDTH, needed + CATALOG_FRAME_PADDING)
-            );
+            const needed = measureCatalogTabStripWidth(shell) + CATALOG_FRAME_PADDING;
+            const next = Math.min(CATALOG_WINDOW_MAX_WIDTH, Math.max(CATALOG_WINDOW_BASE_WIDTH, needed));
 
             setStripWidth((current) => (current === next ? current : next));
+            // Beyond the ceiling the strip cannot be shown whole: let the tabs give way rather
+            // than let the last categories disappear under the shell's overflow.
+            shell.classList.toggle(CONDENSED_CLASS, needed > CATALOG_WINDOW_MAX_WIDTH);
         };
 
         measure();

--- a/src/components/catalog/views/page/widgets/CatalogLimitedItemWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogLimitedItemWidgetView.tsx
@@ -9,13 +9,9 @@ export const CatalogLimitedItemWidgetView: FC = (props) => {
     if (!currentOffer || currentOffer.pricingModel !== Offer.PRICING_MODEL_SINGLE || !currentOffer.product.isUniqueLimitedItem) return null;
 
     return (
-        <div className="w-full">
-            {/* Left-aligned, like the original's plaque: centring it walks the text under the
-                rotation arrows that share this corner. */}
-            <LayoutLimitedEditionCompletePlateView
-                uniqueLimitedItemsLeft={currentOffer.product.uniqueLimitedItemsLeft}
-                uniqueLimitedSeriesSize={currentOffer.product.uniqueLimitedItemSeriesSize}
-            />
-        </div>
+        <LayoutLimitedEditionCompletePlateView
+            uniqueLimitedItemsLeft={currentOffer.product.uniqueLimitedItemsLeft}
+            uniqueLimitedSeriesSize={currentOffer.product.uniqueLimitedItemSeriesSize}
+        />
     );
 };

--- a/src/components/catalog/views/page/widgets/CatalogLimitedItemWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogLimitedItemWidgetView.tsx
@@ -10,8 +10,9 @@ export const CatalogLimitedItemWidgetView: FC = (props) => {
 
     return (
         <div className="w-full">
+            {/* Left-aligned, like the original's plaque: centring it walks the text under the
+                rotation arrows that share this corner. */}
             <LayoutLimitedEditionCompletePlateView
-                className="mx-auto"
                 uniqueLimitedItemsLeft={currentOffer.product.uniqueLimitedItemsLeft}
                 uniqueLimitedSeriesSize={currentOffer.product.uniqueLimitedItemSeriesSize}
             />

--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
@@ -103,8 +103,7 @@ describe('catalog product preview', () => {
             expect(avatarRenderManager.getFigureStringWithFigureIds).toHaveBeenCalledWith('base-figure', 'M', [101, 202]);
             expect(roomPreviewer.addAvatarIntoRoom).toHaveBeenCalledWith('composed-figure', 0);
             expect(roomPreviewer.zoomIn).toHaveBeenCalledOnce();
-            // The official client lifts a zoomed avatar preview as part of the zoom: 41px on a
-            // canvas that step has already doubled, so half that in the engine's own pixels.
+            // 41px on a canvas the same step has already doubled: half that in engine pixels.
             expect(roomPreviewer.addViewOffset.y).toBe(-21);
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(false);
         });
@@ -133,8 +132,9 @@ describe('catalog product preview', () => {
             expect(roomPreviewer.addFurnitureIntoRoom).toHaveBeenCalledWith(500, expect.anything(), null, '');
             expect(roomPreviewer.addAvatarIntoRoom).not.toHaveBeenCalled();
             expect(roomPreviewer.zoomIn).not.toHaveBeenCalled();
-            // Furniture is framed dead centre; only an avatar is lifted.
-            expect(roomPreviewer.addViewOffset.y).toBe(0);
+            // Furniture is not zoomed, but it is lifted: the canvas is centred in a box shorter
+            // than itself, so dead centre reads low for everything in it, not just avatars.
+            expect(roomPreviewer.addViewOffset.y).toBe(-21);
             expect(roomPreviewer.centerWallItems).toBe(true);
             expect(roomPreviewer.updateObjectRoom).not.toHaveBeenCalled();
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(true);

--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.test.tsx
@@ -103,8 +103,9 @@ describe('catalog product preview', () => {
             expect(avatarRenderManager.getFigureStringWithFigureIds).toHaveBeenCalledWith('base-figure', 'M', [101, 202]);
             expect(roomPreviewer.addAvatarIntoRoom).toHaveBeenCalledWith('composed-figure', 0);
             expect(roomPreviewer.zoomIn).toHaveBeenCalledOnce();
-            // The official client lifts a zoomed avatar preview by 41px as part of the zoom.
-            expect(roomPreviewer.addViewOffset.y).toBe(-41);
+            // The official client lifts a zoomed avatar preview as part of the zoom: 41px on a
+            // canvas that step has already doubled, so half that in the engine's own pixels.
+            expect(roomPreviewer.addViewOffset.y).toBe(-21);
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(false);
         });
     });
@@ -165,6 +166,33 @@ describe('catalog product preview', () => {
             expect(roomPreviewer.addAvatarIntoRoom).toHaveBeenCalledWith('base-figure', 0);
             expect(roomPreviewer.setAutomaticStateChange).toHaveBeenLastCalledWith(false);
         });
+    });
+
+    /**
+     * The previewer is shared with every other catalog layout, and the offset is a live Point on
+     * it: an outfit's lift left behind is inherited by the next furniture drawn in the same box.
+     */
+    it('hands the previewer back unlifted when it stops driving it', async () => {
+        const roomPreviewer = createRoomPreviewer();
+
+        vi.mocked(GetAvatarRenderManager).mockReturnValue({
+            getFigureStringWithFigureIds: vi.fn(() => 'composed-figure'),
+            isValidFigureSetForGender: vi.fn(() => true)
+        } as any);
+        vi.mocked(GetSessionDataManager).mockReturnValue({
+            figure: 'base-figure',
+            gender: 'M',
+            getFloorItemData: () => ({ customParams: '101' })
+        } as any);
+        vi.mocked(useCatalogData).mockReturnValue({ currentOffer: createFloorOffer(23), roomPreviewer } as any);
+
+        const view = render(<CatalogViewProductWidgetView />);
+
+        await waitFor(() => expect(roomPreviewer.addViewOffset.y).toBe(-21));
+
+        view.unmount();
+
+        expect(roomPreviewer.addViewOffset.y).toBe(0);
     });
 
     it('keeps landscape previews static after the wall object is loaded', async () => {

--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
@@ -10,10 +10,12 @@ import { useCatalogData, useCatalogUiState } from '../../../../../hooks';
  * The official client zooms this preview by scaling the canvas itself, and lifts it in the same
  * step: `canvas.y = -(height * scale - height) / 2 - 41` in
  * `ProductViewCatalogWidget.applyRoomCanvasZoom`. We take the zoom from the room engine instead,
- * which gives a sharper figure but carries no lift of its own - so without this the figure sits
- * 41px lower in the box than it does in the original client.
+ * which gives a sharper figure but carries no lift of its own.
+ *
+ * Those 41 are measured on a canvas the same step has already scaled by two, so in the engine's
+ * own pixels - which is what this offset is in - the lift is half of them.
  */
-const ZOOMED_AVATAR_LIFT = 41;
+const ZOOMED_AVATAR_LIFT = 21;
 
 const zoomAvatarPreview = (roomPreviewer: RoomPreviewer) => {
     roomPreviewer.zoomIn();
@@ -31,7 +33,16 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
 
         const product = currentOffer.product;
 
-        if (!product) return;
+        // The previewer is shared with every other catalog layout, and this offset is a live
+        // Point on it: whatever is left here is inherited by the next thing drawn in it.
+        const clearViewOffset = () => {
+            roomPreviewer.addViewOffset.y = 0;
+        };
+
+        if (!product) {
+            clearViewOffset();
+            return;
+        }
 
         roomPreviewer.addViewOffset.y = product.isUniqueLimitedItem ? -15 : 0;
         roomPreviewer.centerWallItems = true;
@@ -131,6 +142,8 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
 
         populate();
         roomPreviewer.setAutomaticStateChange(animateFurnitureState);
+
+        return clearViewOffset;
     }, [currentOffer, previewStuffData, roomPreviewer]);
 
     if (!currentOffer) return null;

--- a/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
+++ b/src/components/catalog/views/page/widgets/CatalogViewProductWidgetView.tsx
@@ -1,26 +1,22 @@
-import { GetAvatarRenderManager, GetSessionDataManager, RoomPreviewer, Vector3d } from '@nitrots/nitro-renderer';
+import { GetAvatarRenderManager, GetSessionDataManager, Vector3d } from '@nitrots/nitro-renderer';
 import { FC, useEffect } from 'react';
 import { FurniCategory, Offer, ProductTypeEnum } from '../../../../../api';
 import { AutoGrid, Column, LayoutGridItem, LayoutRoomPreviewerView } from '../../../../../common';
 import { useCatalogData, useCatalogUiState } from '../../../../../hooks';
 
 /**
- * How much higher than dead centre an avatar preview sits.
+ * How much higher than dead centre anything in this box sits.
  *
- * The official client zooms this preview by scaling the canvas itself, and lifts it in the same
- * step: `canvas.y = -(height * scale - height) / 2 - 41` in
- * `ProductViewCatalogWidget.applyRoomCanvasZoom`. We take the zoom from the room engine instead,
- * which gives a sharper figure but carries no lift of its own.
+ * The original lifts its zoomed avatar preview by 41 in
+ * `ProductViewCatalogWidget.applyRoomCanvasZoom`, on a canvas that same step has already scaled
+ * by two - half that in the engine's own pixels, which is what this offset is in. It gives
+ * furniture no lift of its own, but our canvas is centred in a box shorter than itself where
+ * the original's is top-aligned, so furniture came out sitting low in the same way. One number
+ * for the whole box rather than a rule per product type.
  *
- * Those 41 are measured on a canvas the same step has already scaled by two, so in the engine's
- * own pixels - which is what this offset is in - the lift is half of them.
+ * A unique limited item keeps the original's extra -15 on top.
  */
-const ZOOMED_AVATAR_LIFT = 21;
-
-const zoomAvatarPreview = (roomPreviewer: RoomPreviewer) => {
-    roomPreviewer.zoomIn();
-    roomPreviewer.addViewOffset.y = -ZOOMED_AVATAR_LIFT;
-};
+const PREVIEW_LIFT = 21;
 
 export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => {
     const { height = 240 } = props;
@@ -44,7 +40,7 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
             return;
         }
 
-        roomPreviewer.addViewOffset.y = product.isUniqueLimitedItem ? -15 : 0;
+        roomPreviewer.addViewOffset.y = -(PREVIEW_LIFT + (product.isUniqueLimitedItem ? 15 : 0));
         roomPreviewer.centerWallItems = true;
         roomPreviewer.setAutomaticStateChange(false);
         roomPreviewer.updateRoomWallsAndFloorVisibility(true, true);
@@ -82,7 +78,7 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
                         const figureString = avatarRenderManager.getFigureStringWithFigureIds(sessionDataManager.figure, sessionDataManager.gender, figureSets);
 
                         roomPreviewer.addAvatarIntoRoom(figureString || sessionDataManager.figure, 0);
-                        zoomAvatarPreview(roomPreviewer);
+                        roomPreviewer.zoomIn();
                     } else {
                         // RoomPreviewer only keys its fast path by class/extra,
                         // so force a transactional refresh when stuff data
@@ -128,11 +124,11 @@ export const CatalogViewProductWidgetView: FC<{ height?: number }> = (props) => 
                 }
                 case ProductTypeEnum.ROBOT:
                     roomPreviewer.addAvatarIntoRoom(product.extraParam, 0);
-                    zoomAvatarPreview(roomPreviewer);
+                    roomPreviewer.zoomIn();
                     return;
                 case ProductTypeEnum.EFFECT:
                     roomPreviewer.addAvatarIntoRoom(GetSessionDataManager().figure, product.productClassId);
-                    zoomAvatarPreview(roomPreviewer);
+                    roomPreviewer.zoomIn();
                     return;
                 default:
                     roomPreviewer.reset(false);

--- a/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
+++ b/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The limited-edition plate and the rotation controls share the top-right corner of the product
+ * preview, and in the original client they overlap: `limitedItemWidget` spans 186..360 of a
+ * 360-wide box while `rotate_avatar_left/right` sit at 300..354 of the same box. That works
+ * there because the plaque is artwork aligned to its left edge. Ours is text, so it has to stop
+ * where the controls begin.
+ */
+describe('catalog preview top-right corner', () => {
+    const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+    const experience = read('src/css/catalog/CatalogExperience.css');
+    const catalog = read('src/css/catalog/CatalogView.css');
+    const widget = read('src/components/catalog/views/page/widgets/CatalogLimitedItemWidgetView.tsx');
+
+    // Anchored at a line start: the same class also appears inside longer, more specific
+    // selectors, and a bare indexOf lands in the first of those instead.
+    const rule = (stylesheet: string, selector: string) => {
+        const start = stylesheet.indexOf(`
+${selector} {`);
+
+        expect(start).toBeGreaterThan(-1);
+
+        return stylesheet.slice(start, stylesheet.indexOf('}', start));
+    };
+
+    it('keeps the original placement for both', () => {
+        const plate = rule(experience, '.nitro-catalog-preview-limited');
+        const controls = rule(catalog, '.nitro-catalog-preview-controls');
+
+        expect(plate).toContain('left: 186px');
+        expect(plate).toContain('top: 5px');
+        expect(plate).toContain('width: 174px');
+        expect(controls).toContain('right: 6px');
+        expect(controls).toContain('width: 54px');
+    });
+
+    it('stops the plate where the controls begin', () => {
+        const plate = rule(experience, '.nitro-catalog-preview-limited');
+
+        // 54px of buttons and the 6px they are inset by: 186 + 174 - 60 = 300, where the
+        // original puts rotate_avatar_left.
+        expect(plate).toContain('padding-right: 60px');
+        // Centred, the text sits under those buttons however much room is reserved.
+        expect(widget).not.toContain('mx-auto');
+    });
+});

--- a/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
+++ b/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
@@ -26,13 +26,16 @@ ${selector} {`);
         return stylesheet.slice(start, stylesheet.indexOf('}', start));
     };
 
-    it('keeps the original placement for both', () => {
+    it('anchors both to the corner rather than to a fixed offset', () => {
         const plate = rule(experience, '.nitro-catalog-preview-limited');
         const controls = rule(catalog, '.nitro-catalog-preview-controls');
 
-        expect(plate).toContain('left: 186px');
         expect(plate).toContain('top: 5px');
         expect(plate).toContain('width: 174px');
+        // The original's 186 is its 360-wide view's right edge minus these 174. This panel
+        // stretches with the window, so a fixed left offset lands in the middle of it.
+        expect(plate).toContain('right: 0');
+        expect(plate).not.toContain('left:');
         expect(controls).toContain('right: 6px');
         expect(controls).toContain('width: 54px');
     });

--- a/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
+++ b/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
@@ -28,10 +28,13 @@ ${selector} {`);
 
     it('reads its placement from the right edge, not from a fixed offset', () => {
         const plate = rule(experience, '.nitro-catalog-preview-limited');
+        const productView = rule(catalog, '.nitro-catalog-product-view');
 
         expect(plate).toContain('top: 5px');
-        // The original's 186 is its 360-wide view's right edge less the widget. This panel
-        // stretches with the window, so a fixed left offset lands in the middle of it.
+        // `.nitro-catalog-product-view` is pinned to the original's 360, so the original's
+        // `left: 186` and this are the same placement - but this one survives that box being
+        // squeezed under its own `max-width: 100%`.
+        expect(productView).toContain('width: 360px');
         expect(plate).not.toContain('left:');
     });
 

--- a/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
+++ b/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
@@ -31,10 +31,11 @@ ${selector} {`);
         const productView = rule(catalog, '.nitro-catalog-product-view');
 
         expect(plate).toContain('top: 5px');
-        // `.nitro-catalog-product-view` is pinned to the original's 360, so the original's
-        // `left: 186` and this are the same placement - but this one survives that box being
-        // squeezed under its own `max-width: 100%`.
-        expect(productView).toContain('width: 360px');
+        // The box this sits in is no longer the original's fixed 360: it follows a window that
+        // sizes itself from its tab strip. An offset measured from the left would drift into
+        // the middle of it, which is exactly what the original's `left: 186` would do here.
+        expect(productView).toContain('width: 100%');
+        expect(productView).not.toContain('width: 360px');
         expect(plate).not.toContain('left:');
     });
 

--- a/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
+++ b/src/components/catalog/views/page/widgets/catalogPreviewCorner.test.ts
@@ -26,27 +26,35 @@ ${selector} {`);
         return stylesheet.slice(start, stylesheet.indexOf('}', start));
     };
 
-    it('anchors both to the corner rather than to a fixed offset', () => {
+    it('reads its placement from the right edge, not from a fixed offset', () => {
+        const plate = rule(experience, '.nitro-catalog-preview-limited');
+
+        expect(plate).toContain('top: 5px');
+        // The original's 186 is its 360-wide view's right edge less the widget. This panel
+        // stretches with the window, so a fixed left offset lands in the middle of it.
+        expect(plate).not.toContain('left:');
+    });
+
+    it('clears the lane the controls occupy', () => {
         const plate = rule(experience, '.nitro-catalog-preview-limited');
         const controls = rule(catalog, '.nitro-catalog-preview-controls');
 
-        expect(plate).toContain('top: 5px');
-        expect(plate).toContain('width: 174px');
-        // The original's 186 is its 360-wide view's right edge minus these 174. This panel
-        // stretches with the window, so a fixed left offset lands in the middle of it.
-        expect(plate).toContain('right: 0');
-        expect(plate).not.toContain('left:');
         expect(controls).toContain('right: 6px');
         expect(controls).toContain('width: 54px');
+        // Those two numbers are the lane, and the plate starts where it ends.
+        expect(plate).toContain('right: 60px');
     });
 
-    it('stops the plate where the controls begin', () => {
+    it('takes the size of the plate rather than imposing one on it', () => {
         const plate = rule(experience, '.nitro-catalog-preview-limited');
 
-        // 54px of buttons and the 6px they are inset by: 186 + 174 - 60 = 300, where the
-        // original puts rotate_avatar_left.
-        expect(plate).toContain('padding-right: 60px');
-        // Centred, the text sits under those buttons however much room is reserved.
+        // `.unique-complete-plate` is the 170x29 of its own background artwork. A width here
+        // constrained nothing - the plate overflowed it - so reserving room inside this box
+        // moved the plate not at all.
+        expect(plate).not.toContain('width:');
+        expect(plate).not.toContain('height:');
+        expect(plate).not.toContain('padding-right:');
+        expect(widget).not.toContain('w-full');
         expect(widget).not.toContain('mx-auto');
     });
 });

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -98,11 +98,15 @@
  * it holds. Giving it a width of its own did not constrain the plate, it only overflowed it,
  * which is how the plate still ended up under the arrows despite a reserved lane.
  *
- * The original puts `limitedItemWidget` at 186,5 in a product view fixed at 360 wide, so 186 is
- * that view's right edge less the widget. This panel is not fixed - it stretches with a window
- * that sizes itself between 570 and 1040 - so the placement has to be read from the right edge,
- * offset by the lane the rotation arrows occupy there: 54px of button and the 6px they are
- * inset by.
+ * `.nitro-catalog-product-view` is pinned to the original's 360x240, so reading the placement
+ * from the right edge is the same as the original's `left: 186` - and stays right if that box
+ * is ever squeezed under its `max-width: 100%`.
+ *
+ * The 60px is a deliberate departure. The original lets the plaque run under the rotation
+ * arrows (186..360 against 300..354) because there it is artwork aligned to the left of a panel
+ * wider than its container, so the arrows land on the empty part. Ours is a plate with text
+ * across it, so it stops where they start: 54px of button and the 6px they are inset by, which
+ * puts its right edge at 300 - where the original puts rotate_avatar_left.
  */
 .nitro-catalog-preview-limited {
     position: absolute;

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -92,6 +92,13 @@
     image-rendering: pixelated;
 }
 
+/*
+ * Where the original client puts it: `limitedItemWidget` at 186,5 sized 174x35 inside the
+ * 360-wide product view. Its right end runs under the rotation arrows, which live at 300..354
+ * in the same box - harmless there because the plaque's artwork is left-aligned inside a
+ * panel wider than its own container. Ours is not artwork but text, so the lane the arrows
+ * occupy is reserved instead of overwritten.
+ */
 .nitro-catalog-preview-limited {
     position: absolute;
     top: 5px;
@@ -99,6 +106,7 @@
     z-index: 6;
     width: 174px;
     height: 35px;
+    padding-right: 60px;
     pointer-events: none;
 }
 

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -93,16 +93,19 @@
 }
 
 /*
- * Where the original client puts it: `limitedItemWidget` at 186,5 sized 174x35 inside the
- * 360-wide product view. Its right end runs under the rotation arrows, which live at 300..354
- * in the same box - harmless there because the plaque's artwork is left-aligned inside a
- * panel wider than its own container. Ours is not artwork but text, so the lane the arrows
- * occupy is reserved instead of overwritten.
+ * The original puts `limitedItemWidget` at 186,5 sized 174x35 - but its product view is a fixed
+ * 360 wide, so 186 + 174 is that view's right edge. This panel is not fixed: it stretches with
+ * a window that resizes from 570 to 1040, so the same 186 pins the plate somewhere in the
+ * middle instead. Anchoring right is what reproduces the original placement here.
+ *
+ * The rotation arrows share this corner (`right: 6px`, 54 wide) and in the original they do
+ * overlap the plaque - harmlessly, because there the plaque is artwork aligned to the left of a
+ * panel wider than its container. Ours is text, so their 60px lane is reserved instead.
  */
 .nitro-catalog-preview-limited {
     position: absolute;
     top: 5px;
-    left: 186px;
+    right: 0;
     z-index: 6;
     width: 174px;
     height: 35px;

--- a/src/css/catalog/CatalogExperience.css
+++ b/src/css/catalog/CatalogExperience.css
@@ -93,23 +93,22 @@
 }
 
 /*
- * The original puts `limitedItemWidget` at 186,5 sized 174x35 - but its product view is a fixed
- * 360 wide, so 186 + 174 is that view's right edge. This panel is not fixed: it stretches with
- * a window that resizes from 570 to 1040, so the same 186 pins the plate somewhere in the
- * middle instead. Anchoring right is what reproduces the original placement here.
+ * The plate is artwork of its own fixed size - `.unique-complete-plate` is the 170x29 of
+ * `catalog-info-amount-bg.png` - so this slot has nothing to decide: it takes the size of what
+ * it holds. Giving it a width of its own did not constrain the plate, it only overflowed it,
+ * which is how the plate still ended up under the arrows despite a reserved lane.
  *
- * The rotation arrows share this corner (`right: 6px`, 54 wide) and in the original they do
- * overlap the plaque - harmlessly, because there the plaque is artwork aligned to the left of a
- * panel wider than its container. Ours is text, so their 60px lane is reserved instead.
+ * The original puts `limitedItemWidget` at 186,5 in a product view fixed at 360 wide, so 186 is
+ * that view's right edge less the widget. This panel is not fixed - it stretches with a window
+ * that sizes itself between 570 and 1040 - so the placement has to be read from the right edge,
+ * offset by the lane the rotation arrows occupy there: 54px of button and the 6px they are
+ * inset by.
  */
 .nitro-catalog-preview-limited {
     position: absolute;
     top: 5px;
-    right: 0;
+    right: 60px;
     z-index: 6;
-    width: 174px;
-    height: 35px;
-    padding-right: 60px;
     pointer-events: none;
 }
 

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -965,12 +965,12 @@
 }
 
 /*
- * The window grows to fit the tab strip, so below its maximum width the tabs are never
- * squeezed - `flex-shrink` has nothing to act on. Past that maximum the strip used to run
- * under the shell's `overflow: hidden` and the last categories became unreachable: no
- * scrolling, no wrapping, just gone. Letting the tabs shrink there keeps every category on
- * screen and clickable, the label ellipsising down to its icon, which is what the original
- * client's tab context does when its buttons no longer fit.
+ * A tab never shrinks on its own: the strip is measured to decide how wide the window should
+ * be, so a tab whose width depended on that window would feed its own measurement. Past the
+ * window's maximum width the strip used to run under the shell's `overflow: hidden` and the
+ * last categories became unreachable - no scrolling, no wrapping, just gone. The hook adds
+ * `is-condensed` in exactly that case, and only then are they allowed to shrink, the label
+ * ellipsising down to its icon the way the original client's tab context does.
  */
 .nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item {
     display: inline-flex;
@@ -980,14 +980,22 @@
     height: 30px !important;
     min-height: 30px !important;
     max-height: 30px !important;
-    min-width: 34px;
-    flex: 0 1 auto;
+    min-width: 0;
+    flex: 0 0 auto;
     max-width: none;
     padding: 4px 8px 6px !important;
     margin: 0 2px 0 0;
-    flex-shrink: 1;
+    flex-shrink: 0;
     white-space: nowrap;
     overflow: hidden;
+}
+
+/* Only once the window has run out of room to widen. Until then the tabs keep their natural
+   width, which is what the strip is measured at. */
+.nitro-catalog-window .nitro-catalog-tabs-shell.is-condensed .nitro-card-tab-item {
+    min-width: 34px;
+    flex: 0 1 auto;
+    flex-shrink: 1;
 }
 
 .nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item:last-of-type {

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -964,6 +964,14 @@
     flex-wrap: nowrap;
 }
 
+/*
+ * The window grows to fit the tab strip, so below its maximum width the tabs are never
+ * squeezed - `flex-shrink` has nothing to act on. Past that maximum the strip used to run
+ * under the shell's `overflow: hidden` and the last categories became unreachable: no
+ * scrolling, no wrapping, just gone. Letting the tabs shrink there keeps every category on
+ * screen and clickable, the label ellipsising down to its icon, which is what the original
+ * client's tab context does when its buttons no longer fit.
+ */
 .nitro-catalog-window .nitro-catalog-tabs-shell .nitro-card-tab-item {
     display: inline-flex;
     align-items: center;
@@ -972,12 +980,12 @@
     height: 30px !important;
     min-height: 30px !important;
     max-height: 30px !important;
-    min-width: 0;
-    flex: 0 0 auto;
+    min-width: 34px;
+    flex: 0 1 auto;
     max-width: none;
     padding: 4px 8px 6px !important;
     margin: 0 2px 0 0;
-    flex-shrink: 0;
+    flex-shrink: 1;
     white-space: nowrap;
     overflow: hidden;
 }

--- a/src/css/catalog/CatalogView.css
+++ b/src/css/catalog/CatalogView.css
@@ -1307,12 +1307,20 @@
     background: var(--catalog-standard-panel);
 }
 
+/*
+ * The original's `productViewWidget` is a fixed 360x240 because its window is a fixed 570. Ours
+ * sizes itself from its tab strip, up to 1040, and pinning this box to 360 left the rest of that
+ * width as dead grey beside the preview. It follows the page instead; 240 stays, since the room
+ * canvas behind it is drawn taller than the box and cropped, exactly as the original does.
+ *
+ * Everything placed inside it is anchored to an edge rather than to an offset measured from the
+ * old 360 - see `.nitro-catalog-preview-limited` and `.nitro-catalog-preview-controls`.
+ */
 .nitro-catalog-product-view {
     position: relative;
     top: 0;
     left: 0;
-    width: 360px !important;
-    max-width: 100%;
+    width: 100%;
     height: 240px;
     min-height: 0;
     overflow: hidden;
@@ -1344,9 +1352,10 @@
     background: #000;
 }
 
+/* Follows the product view now that the product view follows the page. */
 .nitro-catalog-offer-panel > .nitro-catalog-offer-preview {
-    width: 360px;
-    min-width: 360px;
+    width: 100%;
+    min-width: 0;
 }
 
 .nitro-catalog-preview-title {


### PR DESCRIPTION
Follow-up to #451, which shipped the avatar lift with two mistakes in it. Both are corrected here, along with the rest of that corner of the catalog.

## The preview box

**The lift was doubled.** The original's 41 are measured on a canvas its zoom step has already scaled by two (`ProductViewCatalogWidget.applyRoomCanvasZoom`); this offset is in the room engine's own pixels, where the same distance is half of them.

**It leaked into everything else.** `addViewOffset` is a live `Point` on a previewer shared with every catalog layout, and none of them clear it — so once an outfit had been looked at, every furniture preview drawn afterwards came up lifted too. It is cleared when the widget stops driving the previewer.

**Furniture needed the lift as well.** The room canvas is drawn taller than the box it shows through and is centred in it, where the original top-aligns its own — so "dead centre" reads low for anything in that box, not just for avatars. One constant for the whole preview now, applied where the offer is set rather than per product type, with the original's extra `-15` for a unique limited item stacking on top.

**The box follows the window.** `.nitro-catalog-product-view` was `width: 360px !important` — the original's fixed size, from a client whose window is a fixed 570. Ours sizes itself from its tab strip up to 1040, so every pixel gained beyond 570 was dead grey beside the preview. The height stays 240.

## The limited-edition plate

It ran under the rotation arrows. All three of its constraints were wrong in a different way:

- `left: 186px` came straight from the original, where the product view is a fixed 360 and `186 + 174` is its right edge. With the box now elastic, an offset from the left drifts into the middle. Read from the right instead.
- `width: 174px` decided nothing. `.unique-complete-plate` is the 170×29 of its own background artwork, so the slot did not constrain it — it overflowed. Which is why reserving room inside that box moved the plate not one pixel.
- The slot now has no size of its own and sits 60px in from the right edge: the lane the arrows occupy (54px of button, 6px of inset), putting the plate's right edge at 300 — where the original puts `rotate_avatar_left`. The original lets its plaque run under those arrows because there it is artwork aligned to the left of a wider panel, so they land on the empty part; ours has text across it.

## The tab strip

Past the window's maximum width the tabs could not shrink, so the strip ran under the shell's `overflow: hidden` and the last root categories became unreachable — no scrolling, no wrapping. They shrink under `is-condensed`, which the hook sets in exactly that case. The measurement always runs with that class off (removed and restored inside one task, so nothing paints in between): a tab squeezed by the window cannot be used to decide how wide that window should be.

## Verification

`yarn typecheck`, `yarn lint:hooks`, `yarn test --run` (1100 passed), `yarn build` — green locally on Node 26; CI pins Node 22, so treat the local run as weaker than CI.

New tests pin the preview offset for clothing and furniture, that the previewer is handed back unlifted on unmount, the corner geometry against the original client's own numbers, and that the tab measurement cannot read a condensed width.
