### PR TITLE
Fix the renderer pairing lookup that answered "no such branch" to everything

### DIFF
--- a/.github/scripts/resolve-renderer.mjs
+++ b/.github/scripts/resolve-renderer.mjs
@@ -1,3 +1,10 @@
+import { execFile } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
 const companionRefsFor = (headRef) => {
     if (!headRef) return [];
 
@@ -58,6 +65,14 @@ export const resolveRenderer = async (input, hasRef) => {
     return { repository, ref };
 };
 
+/**
+ * `git ls-remote --exit-code` leaves the process with a non-zero status when the ref is absent, and
+ * that status is an answer: the branch is not there. Anything else -- git missing from PATH, a
+ * programming error inside this file -- is a fault, and swallowing it would answer "no such ref" to
+ * every question and quietly pair every build with the fallback branch.
+ */
+export const isAbsentRefFailure = (error) => typeof error?.code === 'number';
+
 const hasRemoteRef = async (repository, ref) => {
     try {
         await execFileAsync('git', [
@@ -69,8 +84,10 @@ const hasRemoteRef = async (repository, ref) => {
         ]);
 
         return true;
-    } catch {
-        return false;
+    } catch (error) {
+        if (isAbsentRefFailure(error)) return false;
+
+        throw error;
     }
 };
 
@@ -103,9 +120,3 @@ const run = async () => {
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await run();
-import { execFile } from 'node:child_process';
-import { appendFileSync } from 'node:fs';
-import { promisify } from 'node:util';
-import { pathToFileURL } from 'node:url';
-
-const execFileAsync = promisify(execFile);

--- a/.github/scripts/resolve-renderer.test.mjs
+++ b/.github/scripts/resolve-renderer.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { resolveRenderer } from './resolve-renderer.mjs';
+import { isAbsentRefFailure, resolveRenderer } from './resolve-renderer.mjs';
 
 const baseInput = {
     eventName: 'pull_request',
@@ -63,5 +63,30 @@ describe('renderer resolution', () => {
                 ref: 'release-candidate',
             }
         );
+    });
+});
+
+describe('remote ref lookup failures', () => {
+    // Every case above injects a healthy lookup, which is exactly why a lookup that answered `false`
+    // to everything went unnoticed: the resolver then silently paired every build with the fallback
+    // branch instead of the companion one. These pin which failures are an answer and which are a
+    // fault that has to surface.
+
+    it('treats a non-zero git exit status as "the branch is not there"', () => {
+        const missing = Object.assign(new Error('Command failed: git ls-remote'), { code: 2 });
+
+        assert.equal(isAbsentRefFailure(missing), true);
+    });
+
+    it('refuses to read a missing git binary as an absent branch', () => {
+        const noGit = Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' });
+
+        assert.equal(isAbsentRefFailure(noGit), false);
+    });
+
+    it('refuses to read a programming error as an absent branch', () => {
+        const bug = new ReferenceError("Cannot access 'execFileAsync' before initialization");
+
+        assert.equal(isAbsentRefFailure(bug), false);
     });
 });


### PR DESCRIPTION
Independent of any feature branch: the client/renderer CI pairing has been
silently broken, and every build has been pairing against `Dev` regardless of
what it was asked to pair with.

## What was wrong

`resolve-renderer.mjs` ran its entry point above its own declarations:

```
line 105   if (process.argv[1] && ...) await run();
line 106   import { execFile } from 'node:child_process';
line 111   const execFileAsync = promisify(execFile);
```

`import` statements hoist; a `const` does not. So `run()` reached `hasRemoteRef`,
which touched `execFileAsync` while it was still in the temporal dead zone and
received `ReferenceError: Cannot access 'execFileAsync' before initialization` —
caught by the bare `catch {}` and reported as "no such ref".

Every lookup answered `false`, which has three consequences:

- a companion renderer branch is never found, so the pairing falls through to
  `Dev`;
- the final block, `if (!(await hasRef(...))) { …; if (!(await hasRef(...))) ref = 'Dev' }`,
  **overwrites an explicit ref too** — so pinning `renderer_ref` through
  `workflow_dispatch` or `vars.RENDERER_REF` was equally ineffective;
- nothing ever failed loudly, because pairing with `Dev` looks like a normal
  build until a change actually needs the companion branch.

Reproduced in isolation:

```
catch swallowed: ReferenceError: Cannot access 'execFileAsync' before initialization
hasRemoteRef -> false
```

## The fix

- Declarations move above the entry point.
- The catch stops conflating two different things. `git ls-remote --exit-code`
  exits non-zero when a ref is absent, and that status is an *answer*; a missing
  git binary or a programming error is a *fault*, and now surfaces instead of
  being read as "no such branch". A broken lookup failing the step loudly is
  strictly better than one that quietly pairs every build with the fallback.

## Verification

- `node --test .github/scripts/resolve-renderer.test.mjs` — 6/6.
  Every pre-existing case injects a healthy lookup, which is precisely why this
  went unseen, so the three new cases pin the classification itself: exit status
  means absent, `ENOENT` and `ReferenceError` do not.
- Running the real script with a pull-request environment now prints
  `Resolved renderer pairing: duckietm/Octane-Renderer @ wired-chests` where it
  printed `@ Dev` before, against the same branches.
- `yarn typecheck` — clean (the file is outside `src/`, so nothing else moves).

## Related

Found while looking into why the CI check on the wired chests client PR could not
resolve its companion renderer branch. With this merged, that check pairs
correctly on its own.
