### PR TITLE
fix(wired): give each box a window that matches what it reads

### DIFF
--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -112,4 +112,9 @@ export class WiredActionLayoutCode {
     public static CONTRACT_TRADE: number = 112;
     public static CUSTOM_CONTRACT: number = 113;
     public static CHANGE_OPACITY: number = 114;
+    /**
+     * Walking to a furni borrowed TELEPORT, whose window offers a "teleport instantly" checkbox that
+     * this effect never reads — it walks. Same three slots, one control fewer.
+     */
+    public static WALK_TO_FURNI: number = 115;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -117,4 +117,8 @@ export class WiredActionLayoutCode {
      * this effect never reads — it walks. Same three slots, one control fewer.
      */
     public static WALK_TO_FURNI: number = 115;
+    /** Sit, lie down, fast walk: they only need to know which users, not a kick message. */
+    public static USER_TARGET: number = 116;
+    /** Move a user N tiles — the fourth slot the move/rotate window never sent. */
+    public static MOVE_USER_TILES: number = 117;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -138,4 +138,6 @@ export class WiredActionLayoutCode {
      * a question the window asks.
      */
     public static ALL_USERS_LEAVE_TEAM: number = 124;
+    /** The official override-height action: a two-way choice and a 0..8000 thousandths slider. */
+    public static OVERRIDE_HEIGHT: number = 125;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -121,4 +121,15 @@ export class WiredActionLayoutCode {
     public static USER_TARGET: number = 116;
     /** Move a user N tiles — the fourth slot the move/rotate window never sent. */
     public static MOVE_USER_TILES: number = 117;
+    /**
+     * The shapes that borrowed the chat composer. They store one string and a user source like the
+     * chat effects do, but the bubble style and the visibility choice mean nothing to them, and what
+     * the textarea held was never a message.
+     */
+    public static EFFECT_AMOUNT: number = 118;
+    public static EFFECT_BADGE: number = 119;
+    public static EFFECT_TAG: number = 120;
+    public static EFFECT_ID: number = 121;
+    public static EFFECT_MESSAGE: number = 122;
+    public static EFFECT_TEXT: number = 123;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -132,4 +132,10 @@ export class WiredActionLayoutCode {
     public static EFFECT_ID: number = 121;
     public static EFFECT_MESSAGE: number = 122;
     public static EFFECT_TEXT: number = 123;
+    /**
+     * Everyone in the room leaves their game, so there is nobody to pick. The stored source still
+     * decides whether the stack needs a triggering user, so it keeps its slot - it is just no longer
+     * a question the window asks.
+     */
+    public static ALL_USERS_LEAVE_TEAM: number = 124;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -48,4 +48,10 @@ export class WiredConditionlayout {
     public static TRG_FURNI_ADJACENT_STATE: number = 46;
     public static CHEST_HAS_ITEMS: number = 47;
     public static CHEST_HAS_ITEM_TYPE: number = 48;
+    /**
+     * A condition answered by the user themselves — gender, room rights. Same dialog as the badge
+     * conditions minus the badge-code field, which those boxes showed and never read.
+     */
+    public static USER_ATTRIBUTE: number = 49;
+    public static NOT_USER_ATTRIBUTE: number = 50;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -73,4 +73,12 @@ export class WiredConditionlayout {
     public static USER_TAG: number = 54;
     public static NOT_USER_TAG: number = 55;
     public static USER_MOTTO: number = 56;
+    /**
+     * The three shapes that borrowed the altitude dialog. They inherited its counter-only furni gate,
+     * which refuses every furni that is not a game counter — and with it a radius labelled as an
+     * altitude, a furni picker where a user source is meant, and a comparison two of them never read.
+     */
+    public static USER_RANGE: number = 57;
+    public static FURNI_RANGE: number = 58;
+    public static FURNI_PROPERTY: number = 59;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -60,4 +60,10 @@ export class WiredConditionlayout {
      * those boxes consult, and with the amount ceiling the server actually enforces.
      */
     public static USER_AMOUNT: number = 51;
+    /**
+     * A boolean state the user is in — frozen. Same dialog as the wearing-effect conditions minus the
+     * effect id, which those boxes show and never read.
+     */
+    public static USER_STATE: number = 52;
+    public static NOT_USER_STATE: number = 53;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -66,4 +66,11 @@ export class WiredConditionlayout {
      */
     public static USER_STATE: number = 52;
     public static NOT_USER_STATE: number = 53;
+    /**
+     * Text read off the user that is not a badge code. The field is genuinely used by these boxes —
+     * it was only labelled "Badge code", with the badge's length limit instead of its own.
+     */
+    public static USER_TAG: number = 54;
+    public static NOT_USER_TAG: number = 55;
+    public static USER_MOTTO: number = 56;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -54,4 +54,10 @@ export class WiredConditionlayout {
      */
     public static USER_ATTRIBUTE: number = 49;
     public static NOT_USER_ATTRIBUTE: number = 50;
+    /**
+     * A threshold on something the user holds — inventory items, credits, diamonds, duckets. Same
+     * dialog as the team score minus the team colour and the comparison operator, neither of which
+     * those boxes consult, and with the amount ceiling the server actually enforces.
+     */
+    public static USER_AMOUNT: number = 51;
 }

--- a/src/api/wired/WiredTriggerLayoutCode.ts
+++ b/src/api/wired/WiredTriggerLayoutCode.ts
@@ -27,4 +27,10 @@ export class WiredTriggerLayout {
     public static PRESS_KEYBIND: number = 26;
     public static TRANSACTION_COMPLETE: number = 27;
     public static TRANSACTION_FAIL: number = 28;
+    /**
+     * Team wins and team loses take no settings. They used to answer CUSTOM, which shares code 13
+     * with the bot-reached trigger, so the window asked them which bot had arrived.
+     */
+    public static TEAM_GAME_RESULT: number = 29;
+
 }

--- a/src/components/wired/views/actions/WiredActionChatView.tsx
+++ b/src/components/wired/views/actions/WiredActionChatView.tsx
@@ -1,7 +1,8 @@
 import { FC, useEffect, useMemo, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { localizeWithFallback, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
+import { NitroInput } from '../../../../layout';
 import { WiredTextCounter, WiredTextFormattingHelp } from '../common/WiredTextFormattingHelp';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
@@ -19,6 +20,26 @@ const clampShowMessage = (value: string) => {
     return joined.slice(0, SHOW_MESSAGE_MAX_LENGTH);
 };
 
+/**
+ * Nineteen effects shared this window because they all store one string and a user source. Only the
+ * three that make somebody speak read the bubble style and the visibility choice; for the rest those
+ * two controls did nothing, and the message textarea held something that was never a message — an
+ * amount, a badge code, a tag, a room or effect id, a figure, a link, a command.
+ *
+ * Each entry says what the box really holds. `chat` is the original composer.
+ */
+const FIELDS: Record<
+    number,
+    { key: string; fallback: string; numeric?: boolean; multiline?: boolean; maxLength?: number }
+> = {
+    [WiredActionLayoutCode.EFFECT_AMOUNT]: { key: 'wiredfurni.params.amount', fallback: 'Amount', numeric: true },
+    [WiredActionLayoutCode.EFFECT_BADGE]: { key: 'wiredfurni.params.badgecode', fallback: 'Badge code', maxLength: 50 },
+    [WiredActionLayoutCode.EFFECT_TAG]: { key: 'wiredfurni.params.tag', fallback: 'Tag', maxLength: 38 },
+    [WiredActionLayoutCode.EFFECT_ID]: { key: 'wiredfurni.params.id', fallback: 'Id', numeric: true },
+    [WiredActionLayoutCode.EFFECT_MESSAGE]: { key: 'wiredfurni.params.message', fallback: 'Message', multiline: true },
+    [WiredActionLayoutCode.EFFECT_TEXT]: { key: 'wiredfurni.params.value', fallback: 'Value', maxLength: 200 }
+};
+
 export const WiredActionChatView: FC<{}> = (props) => {
     const [message, setMessage] = useState('');
     const [visibilitySelection, setVisibilitySelection] = useState<number>(0);
@@ -29,15 +50,20 @@ export const WiredActionChatView: FC<{}> = (props) => {
         return 0;
     });
     const bubbleStyleIds = useMemo(() => SHOW_MESSAGE_STYLE_IDS, []);
+    /** Undefined for the three chat effects, which keep the composer as it is. */
+    const field = FIELDS[trigger?.code];
+    const isChat = !field;
     const maxMessageLength = SHOW_MESSAGE_MAX_LENGTH;
 
     const save = () => {
-        setStringParam(clampShowMessage(message));
+        // Slots 1 and 2 keep their places so nothing about how these effects store changes; the two
+        // controls that fill them simply stop being offered where they mean nothing.
+        setStringParam(isChat || field.multiline ? clampShowMessage(message) : message);
         setIntParams([userSource, visibilitySelection, bubbleStyle]);
     };
 
     useEffect(() => {
-        setMessage(clampShowMessage(trigger.stringData));
+        setMessage(FIELDS[trigger?.code] && !FIELDS[trigger.code].multiline ? (trigger.stringData ?? '') : clampShowMessage(trigger.stringData));
         if (trigger.intData.length >= 1) setUserSource(trigger.intData[0]);
         else setUserSource(0);
         if (trigger.intData.length >= 2) setVisibilitySelection(trigger.intData[1]);
@@ -54,55 +80,70 @@ export const WiredActionChatView: FC<{}> = (props) => {
             footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
         >
             <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
-                <textarea
-                    className="form-control form-control-sm nitro-wired__resizable-textarea"
-                    maxLength={maxMessageLength}
-                    rows={4}
-                    value={message}
-                    onChange={(event) => setMessage(clampShowMessage(event.target.value))}
-                />
-                <WiredTextCounter maxLength={maxMessageLength} value={message} />
-                <WiredTextFormattingHelp />
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.show_message.visibility_selection.title')}</Text>
-                <div className="flex items-center gap-1">
-                    <input
-                        checked={visibilitySelection === 0}
-                        className="form-check-input"
-                        name="showMessageVisibilitySelection"
-                        type="radio"
-                        onChange={() => setVisibilitySelection(0)}
+                <Text bold>{field ? localizeWithFallback(field.key, field.fallback) : LocalizeText('wiredfurni.params.message')}</Text>
+                {!field || field.multiline ? (
+                    <>
+                        <textarea
+                            className="form-control form-control-sm nitro-wired__resizable-textarea"
+                            maxLength={maxMessageLength}
+                            rows={4}
+                            value={message}
+                            onChange={(event) => setMessage(clampShowMessage(event.target.value))}
+                        />
+                        <WiredTextCounter maxLength={maxMessageLength} value={message} />
+                        {isChat && <WiredTextFormattingHelp />}
+                    </>
+                ) : (
+                    <NitroInput
+                        maxLength={field.maxLength}
+                        type={field.numeric ? 'number' : 'text'}
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
                     />
-                    <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.0')}</Text>
-                </div>
-                <div className="flex items-center gap-1">
-                    <input
-                        checked={visibilitySelection === 1}
-                        className="form-check-input"
-                        name="showMessageVisibilitySelection"
-                        type="radio"
-                        onChange={() => setVisibilitySelection(1)}
-                    />
-                    <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.1')}</Text>
-                </div>
+                )}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.show_message.style_selection.title')}</Text>
-                <div className="flex items-center gap-2">
-                    <div className="bubble-container relative w-[50px] shrink-0">
-                        <div className={`relative min-h-[26px] chat-bubble bubble-${bubbleStyle}`} />
+            {isChat && (
+                <>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.show_message.visibility_selection.title')}</Text>
+                    <div className="flex items-center gap-1">
+                        <input
+                            checked={visibilitySelection === 0}
+                            className="form-check-input"
+                            name="showMessageVisibilitySelection"
+                            type="radio"
+                            onChange={() => setVisibilitySelection(0)}
+                        />
+                        <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.0')}</Text>
                     </div>
-                    <select className="form-select form-select-sm" value={bubbleStyle} onChange={(event) => setBubbleStyle(Number(event.target.value))}>
-                        {bubbleStyleIds.map((styleId) => (
-                            <option key={styleId} value={styleId}>
-                                {LocalizeText(`wiredfurni.params.show_message.style_selection.${styleId}`)}
-                            </option>
-                        ))}
-                    </select>
+                    <div className="flex items-center gap-1">
+                        <input
+                            checked={visibilitySelection === 1}
+                            className="form-check-input"
+                            name="showMessageVisibilitySelection"
+                            type="radio"
+                            onChange={() => setVisibilitySelection(1)}
+                        />
+                        <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.1')}</Text>
+                    </div>
                 </div>
-            </div>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.show_message.style_selection.title')}</Text>
+                    <div className="flex items-center gap-2">
+                        <div className="bubble-container relative w-[50px] shrink-0">
+                            <div className={`relative min-h-[26px] chat-bubble bubble-${bubbleStyle}`} />
+                        </div>
+                        <select className="form-select form-select-sm" value={bubbleStyle} onChange={(event) => setBubbleStyle(Number(event.target.value))}>
+                            {bubbleStyleIds.map((styleId) => (
+                                <option key={styleId} value={styleId}>
+                                    {LocalizeText(`wiredfurni.params.show_message.style_selection.${styleId}`)}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+                </>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionKickFromRoomView.tsx
+++ b/src/components/wired/views/actions/WiredActionKickFromRoomView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { GetConfigurationValue, LocalizeText, WiredFurniType } from '../../../../api';
+import { GetConfigurationValue, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { NitroInput } from '../../../../layout';
@@ -9,13 +9,16 @@ import { WiredActionBaseView } from './WiredActionBaseView';
 export const WiredActionKickFromRoomView: FC<{}> = (props) => {
     const [message, setMessage] = useState('');
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
+    /** Sit, lie down and fast walk share this window for its user source; nobody is being kicked, so
+     * the message the kicked person would see has nothing to say. */
+    const showMessage = trigger?.code !== WiredActionLayoutCode.USER_TARGET;
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return 0;
     });
 
     const save = () => {
-        setStringParam(message);
+        setStringParam(showMessage ? message : '');
         setIntParams([userSource]);
     };
 
@@ -32,15 +35,17 @@ export const WiredActionKickFromRoomView: FC<{}> = (props) => {
             save={save}
             footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
         >
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
-                <NitroInput
-                    maxLength={GetConfigurationValue<number>('wired.action.kick.from.room.max.length', 100)}
-                    type="text"
-                    value={message}
-                    onChange={(event) => setMessage(event.target.value)}
-                />
-            </div>
+            {showMessage && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
+                    <NitroInput
+                        maxLength={GetConfigurationValue<number>('wired.action.kick.from.room.max.length', 100)}
+                        type="text"
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
+                    />
+                </div>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -145,6 +145,13 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionTeleportView />;
         case WiredActionLayoutCode.WALK_TO_FURNI:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.EFFECT_AMOUNT:
+        case WiredActionLayoutCode.EFFECT_BADGE:
+        case WiredActionLayoutCode.EFFECT_TAG:
+        case WiredActionLayoutCode.EFFECT_ID:
+        case WiredActionLayoutCode.EFFECT_MESSAGE:
+        case WiredActionLayoutCode.EFFECT_TEXT:
+            return <WiredActionChatView />;
         case WiredActionLayoutCode.USER_TARGET:
             return <WiredActionKickFromRoomView />;
         case WiredActionLayoutCode.MOVE_USER_TILES:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -145,6 +145,10 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionTeleportView />;
         case WiredActionLayoutCode.WALK_TO_FURNI:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.USER_TARGET:
+            return <WiredActionKickFromRoomView />;
+        case WiredActionLayoutCode.MOVE_USER_TILES:
+            return <WiredActionMoveRotateUserView />;
         case WiredActionLayoutCode.FURNI_TO_FURNI:
             return <WiredActionFurniToFurniView />;
         case WiredActionLayoutCode.SET_ALTITUDE:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -103,6 +103,7 @@ import { WiredActionResetView } from './WiredActionResetView';
 import { WiredActionSendSignalView } from './WiredActionSendSignalView';
 import { WiredActionSetAltitudeView } from './WiredActionSetAltitudeView';
 import { WiredActionSetFurniStateToView } from './WiredActionSetFurniStateToView';
+import { WiredActionOverrideHeightView } from './WiredActionOverrideHeightView';
 import { WiredActionSetRollerSpeedView } from './WiredActionSetRollerSpeedView';
 import { WiredActionSetRoomAdView } from './WiredActionSetRoomAdView';
 import { WiredActionTeleportView } from './WiredActionTeleportView';
@@ -295,6 +296,8 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionSendSignalView />;
         case WiredActionLayoutCode.NEG_SEND_SIGNAL:
             return <WiredActionSendSignalView />;
+        case WiredActionLayoutCode.OVERRIDE_HEIGHT:
+            return <WiredActionOverrideHeightView />;
         case WiredActionLayoutCode.SET_ROLLER_SPEED:
             return <WiredActionSetRollerSpeedView />;
         case WiredActionLayoutCode.BOT_DANCE:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -176,6 +176,7 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionJoinTeamView />;
         case WiredActionLayoutCode.KICK_FROM_ROOM:
             return <WiredActionKickFromRoomView />;
+        case WiredActionLayoutCode.ALL_USERS_LEAVE_TEAM:
         case WiredActionLayoutCode.LEAVE_TEAM:
             return <WiredActionLeaveTeamView />;
         case WiredActionLayoutCode.MOVE_FURNI:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -143,6 +143,8 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionControlClockView />;
         case WiredActionLayoutCode.FURNI_TO_USER:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.WALK_TO_FURNI:
+            return <WiredActionTeleportView />;
         case WiredActionLayoutCode.FURNI_TO_FURNI:
             return <WiredActionFurniToFurniView />;
         case WiredActionLayoutCode.SET_ALTITUDE:

--- a/src/components/wired/views/actions/WiredActionLeaveTeamView.tsx
+++ b/src/components/wired/views/actions/WiredActionLeaveTeamView.tsx
@@ -1,11 +1,17 @@
 import { FC, useEffect, useState } from 'react';
-import { WiredFurniType } from '../../../../api';
+import { WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
 
 export const WiredActionLeaveTeamView: FC<{}> = (props) => {
     const { trigger = null, setIntParams = null } = useWired();
+    /**
+     * "All users leave team" walks every habbo in the room, so the source picker never chose its
+     * targets. The saved value is still sent back untouched, because it decides whether the stack
+     * needs a triggering user.
+     */
+    const showSource = trigger?.code !== WiredActionLayoutCode.ALL_USERS_LEAVE_TEAM;
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return 0;
@@ -24,7 +30,7 @@ export const WiredActionLeaveTeamView: FC<{}> = (props) => {
             hasSpecialInput={true}
             requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_NONE}
             save={save}
-            footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
+            footer={showSource ? <WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} /> : null}
         />
     );
 };

--- a/src/components/wired/views/actions/WiredActionMoveRotateUserView.tsx
+++ b/src/components/wired/views/actions/WiredActionMoveRotateUserView.tsx
@@ -1,9 +1,10 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { localizeWithFallback, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import iconRotateClockwise from '../../../../assets/images/wired/icon_wired_rotate_clockwise.png';
 import iconRotateCounterClockwise from '../../../../assets/images/wired/icon_wired_rotate_counter_clockwise.png';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
+import { NitroInput } from '../../../../layout';
 import { WIRED_DIRECTION_GRID, WiredDirectionIcon } from '../WiredDirectionIcon';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
@@ -76,16 +77,36 @@ const DirectionPicker: FC<DirectionPickerProps> = (props) => {
     );
 };
 
+const MIN_TILE_COUNT = 1;
+const MAX_TILE_COUNT = 10;
+
+const clampTileCount = (value: number) => {
+    if (isNaN(value)) return MIN_TILE_COUNT;
+
+    return Math.max(MIN_TILE_COUNT, Math.min(MAX_TILE_COUNT, Math.floor(value)));
+};
+
 export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
     const [movementDirection, setMovementDirection] = useState(-1);
     const [rotationDirection, setRotationDirection] = useState(-1);
     const { trigger = null, setIntParams = null } = useWired();
+    /**
+     * "Move user N tiles" reads a fourth slot the window never sent, so it always moved exactly one
+     * tile whatever the box was meant to do. The server keeps it between 1 and 10.
+     */
+    const hasTileCount = trigger?.code === WiredActionLayoutCode.MOVE_USER_TILES;
+    const [tileCount, setTileCount] = useState(MIN_TILE_COUNT);
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length > 2) return trigger.intData[2];
         return 0;
     });
 
-    const save = () => setIntParams([movementDirection, rotationDirection, userSource]);
+    const save = () =>
+        setIntParams(
+            hasTileCount
+                ? [movementDirection, rotationDirection, userSource, tileCount]
+                : [movementDirection, rotationDirection, userSource]
+        );
 
     const rotationExtraOptions: DirectionExtraOption[] = [
         { value: ROTATION_CLOCKWISE, icon: iconRotateClockwise, label: LocalizeText('wiredfurni.params.rotatefurni.1') },
@@ -96,6 +117,7 @@ export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
         setMovementDirection(trigger.intData.length > 0 ? trigger.intData[0] : -1);
         setRotationDirection(trigger.intData.length > 1 ? trigger.intData[1] : -1);
         setUserSource(trigger.intData.length > 2 ? trigger.intData[2] : 0);
+        setTileCount(clampTileCount(trigger.intData.length > 3 ? trigger.intData[3] : MIN_TILE_COUNT));
     }, [trigger]);
 
     return (
@@ -120,6 +142,18 @@ export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
                 value={rotationDirection}
                 onChange={setRotationDirection}
             />
+            {hasTileCount && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.tilecount', 'Tiles to move')}</Text>
+                    <NitroInput
+                        max={MAX_TILE_COUNT}
+                        min={MIN_TILE_COUNT}
+                        type="number"
+                        value={tileCount}
+                        onChange={(event) => setTileCount(clampTileCount(parseInt(event.target.value)))}
+                    />
+                </div>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionOverrideHeightView.tsx
+++ b/src/components/wired/views/actions/WiredActionOverrideHeightView.tsx
@@ -1,0 +1,95 @@
+import { FC, useEffect, useState } from 'react';
+import { localizeWithFallback, WiredFurniType } from '../../../../api';
+import { Slider, Text } from '../../../../common';
+import { useWired } from '../../../../hooks';
+import { WiredSourcesSelector } from '../WiredSourcesSelector';
+import { WiredActionBaseView } from './WiredActionBaseView';
+
+/**
+ * Puts the selected furni at a height you type, or hands them back their stacking height.
+ *
+ * The official dialog is a two-way choice and a slider over thousandths of a tile, 0 to 8000, so
+ * 2400 reads as 2.400. The furni source row underneath is this fork's own, the way every other furni
+ * effect offers it.
+ */
+
+const MIN_HEIGHT = 0;
+const MAX_HEIGHT = 8000;
+const HEIGHT_STEP = 1;
+
+const MODE_SET = 0;
+const MODE_RELEASE = 1;
+
+const MODE_LABELS: Record<number, { key: string; fallback: string }> = {
+    [MODE_SET]: { key: 'wiredfurni.params.override_height.type.0', fallback: 'Set this height' },
+    [MODE_RELEASE]: { key: 'wiredfurni.params.override_height.type.1', fallback: 'Back to the stacking height' }
+};
+
+const formatHeight = (value: number) => (value / 1000).toFixed(3);
+
+const clampHeight = (value: number) => {
+    if (!Number.isFinite(value)) return MIN_HEIGHT;
+    return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, Math.round(value)));
+};
+
+export const WiredActionOverrideHeightView: FC<{}> = (props) => {
+    const { trigger = null, setIntParams = null } = useWired();
+
+    const [height, setHeight] = useState<number>(0);
+    const [heightInput, setHeightInput] = useState<string>('0.000');
+    const [mode, setMode] = useState<number>(MODE_SET);
+    const [furniSource, setFurniSource] = useState<number>(0);
+
+    useEffect(() => {
+        if (!trigger) return;
+
+        const data = trigger.intData ?? [];
+        const nextHeight = clampHeight(data.length > 0 ? data[0] : 0);
+
+        setHeight(nextHeight);
+        setHeightInput(formatHeight(nextHeight));
+        setMode(data.length > 1 && data[1] === MODE_RELEASE ? MODE_RELEASE : MODE_SET);
+        setFurniSource(data.length > 2 ? data[2] : (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0);
+    }, [trigger]);
+
+    const updateHeight = (value: number) => {
+        const next = clampHeight(value);
+        setHeight(next);
+        setHeightInput(formatHeight(next));
+    };
+
+    // Typing is left alone until blur, so a half-written "2." is not rewritten under the cursor.
+    const updateHeightInput = (value: string) => {
+        setHeightInput(value);
+
+        const parsed = Number.parseFloat(value.replace(',', '.'));
+        if (Number.isFinite(parsed)) setHeight(clampHeight(parsed * 1000));
+    };
+
+    const save = () => setIntParams([height, mode, furniSource]);
+
+    return (
+        <WiredActionBaseView hasSpecialInput={true} requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_BY_ID_BY_TYPE_OR_FROM_CONTEXT} save={save} footer={<WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />}>
+            <div className="flex flex-col gap-2">
+                {[MODE_SET, MODE_RELEASE].map((value) => (
+                    <div key={value} className="flex items-center gap-1">
+                        <input checked={mode === value} className="form-check-input" id={`overrideHeightMode${value}`} name="overrideHeightMode" type="radio" onChange={() => setMode(value)} />
+                        <Text>{localizeWithFallback(MODE_LABELS[value].key, MODE_LABELS[value].fallback)}</Text>
+                    </div>
+                ))}
+            </div>
+            {mode === MODE_SET && (
+                <>
+                    <div className="flex flex-col gap-1">
+                        <Text bold>{localizeWithFallback('wiredfurni.params.override_height.height', 'Height')}</Text>
+                        <input className="form-control form-control-sm" inputMode="decimal" type="text" value={heightInput} onBlur={() => setHeightInput(formatHeight(height))} onChange={(event) => updateHeightInput(event.target.value)} />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <Slider max={MAX_HEIGHT} min={MIN_HEIGHT} step={HEIGHT_STEP} value={height} onChange={(event) => updateHeight(event as number)} />
+                        <Text small>{formatHeight(height)}</Text>
+                    </div>
+                </>
+            )}
+        </WiredActionBaseView>
+    );
+};

--- a/src/components/wired/views/actions/WiredActionTeleportView.tsx
+++ b/src/components/wired/views/actions/WiredActionTeleportView.tsx
@@ -10,6 +10,9 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     const { trigger = null, setIntParams = null } = useWired();
     const isTeleportEffect = trigger?.code === WiredActionLayoutCode.TELEPORT;
     const isUserToFurniEffect = trigger?.code === WiredActionLayoutCode.USER_TO_FURNI;
+    /** Same three slots as the teleport, but it walks — so no "teleport instantly" to offer. */
+    const isWalkToFurni = trigger?.code === WiredActionLayoutCode.WALK_TO_FURNI;
+    const usesTeleportSlots = isTeleportEffect || isWalkToFurni;
     const [fastTeleport, setFastTeleport] = useState<boolean>(() => {
         if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[0] === 1;
         return false;
@@ -20,14 +23,14 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     });
 
     const [furniSource, setFurniSource] = useState<number>(() => {
-        if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[1];
+        if (usesTeleportSlots && trigger?.intData?.length >= 3) return trigger.intData[1];
         if (isUserToFurniEffect && trigger?.intData?.length >= 3) return trigger.intData[0];
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return (trigger?.selectedItems?.length ?? 0) > 0 ? 100 : 0;
     });
 
     const [userSource, setUserSource] = useState<number>(() => {
-        if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[2];
+        if (usesTeleportSlots && trigger?.intData?.length >= 3) return trigger.intData[2];
         if (isUserToFurniEffect && trigger?.intData?.length >= 3) return trigger.intData[1];
         if (trigger?.intData?.length >= 2) return trigger.intData[1];
         return 0;
@@ -36,7 +39,7 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     useEffect(() => {
         if (!trigger) return;
 
-        if (isTeleportEffect && trigger.intData.length >= 3) {
+        if (usesTeleportSlots && trigger.intData.length >= 3) {
             setFastTeleport(trigger.intData[0] === 1);
             setFurniSource(trigger.intData[1]);
             setUserSource(trigger.intData[2]);
@@ -60,13 +63,13 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
 
         if (trigger.intData.length >= 2) setUserSource(trigger.intData[1]);
         else setUserSource(0);
-    }, [isTeleportEffect, isUserToFurniEffect, trigger]);
+    }, [isUserToFurniEffect, isWalkToFurni, usesTeleportSlots, trigger]);
 
     const onChangeFurniSource = (next: number) => setFurniSource(next);
 
     const save = () =>
         setIntParams(
-            isTeleportEffect
+            usesTeleportSlots
                 ? [fastTeleport ? 1 : 0, furniSource, userSource]
                 : isUserToFurniEffect
                   ? [furniSource, userSource, walkMode]

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
@@ -8,9 +8,15 @@ import { WiredConditionBaseView } from './WiredConditionBaseView';
 
 interface WiredConditionActorIsWearingBadgeViewProps {
     negative?: boolean;
+    /**
+     * The gender and room-rights conditions share this dialog because they need the same user source
+     * and quantifier — but their answer comes from the user, not from something you type. They pass
+     * false so the badge-code field stays out of the window.
+     */
+    showBadge?: boolean;
 }
 
-export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false }) => {
+export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, showBadge = true }) => {
     const [badge, setBadge] = useState('');
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
@@ -20,7 +26,7 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
     });
 
     const save = () => {
-        setStringParam(badge);
+        setStringParam(showBadge ? badge : '');
         setIntParams([userSource, quantifier]);
     };
 
@@ -53,10 +59,12 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
                     </label>
                 ))}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
-                <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
-            </div>
+            {showBadge && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
+                    <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
@@ -6,17 +6,26 @@ import { NitroInput } from '../../../../layout';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredConditionBaseView } from './WiredConditionBaseView';
 
+/**
+ * What the text field holds. The badge, tag and motto conditions all store a string plus the same
+ * user source and quantifier, so they share this dialog — but a tag is not a badge code and neither
+ * is a motto, and each has its own length limit. `null` is for the gender and room-rights conditions,
+ * whose answer comes from the user rather than from anything typed: they hide the field entirely.
+ */
+type WiredTextField = 'badge' | 'tag' | 'motto';
+
+const TEXT_FIELDS: Record<WiredTextField, { key: string; fallback: string; maxLength?: number }> = {
+    badge: { key: 'wiredfurni.params.badgecode', fallback: 'Badge code' },
+    tag: { key: 'wiredfurni.params.tag', fallback: 'Tag', maxLength: 38 },
+    motto: { key: 'wiredfurni.params.motto_contains', fallback: 'Motto contains', maxLength: 64 }
+};
+
 interface WiredConditionActorIsWearingBadgeViewProps {
     negative?: boolean;
-    /**
-     * The gender and room-rights conditions share this dialog because they need the same user source
-     * and quantifier — but their answer comes from the user, not from something you type. They pass
-     * false so the badge-code field stays out of the window.
-     */
-    showBadge?: boolean;
+    field?: WiredTextField | null;
 }
 
-export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, showBadge = true }) => {
+export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, field = 'badge' }) => {
     const [badge, setBadge] = useState('');
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
@@ -25,8 +34,10 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
         return 0;
     });
 
+    const text = field ? TEXT_FIELDS[field] : null;
+
     const save = () => {
-        setStringParam(showBadge ? badge : '');
+        setStringParam(text ? badge : '');
         setIntParams([userSource, quantifier]);
     };
 
@@ -59,10 +70,15 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
                     </label>
                 ))}
             </div>
-            {showBadge && (
+            {text && (
                 <div className="flex flex-col gap-1">
-                    <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
-                    <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
+                    <Text bold>{localizeWithFallback(text.key, text.fallback)}</Text>
+                    <NitroInput
+                        maxLength={text.maxLength}
+                        type="text"
+                        value={badge}
+                        onChange={(event) => setBadge(event.target.value)}
+                    />
                 </div>
             )}
         </WiredConditionBaseView>

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingEffectView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingEffectView.tsx
@@ -8,9 +8,15 @@ import { WiredConditionBaseView } from './WiredConditionBaseView';
 
 interface WiredConditionActorIsWearingEffectViewProps {
     negative?: boolean;
+    /**
+     * The freeze conditions share this dialog for its user source and quantifier, but they ask
+     * WiredFreezeUtil whether someone is frozen — there is no effect to name. They pass false, and the
+     * effect-id box stays out of the window.
+     */
+    showEffect?: boolean;
 }
 
-export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWearingEffectViewProps> = ({ negative = false }) => {
+export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWearingEffectViewProps> = ({ negative = false, showEffect = true }) => {
     const [effect, setEffect] = useState(-1);
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setIntParams = null } = useWired();
@@ -50,10 +56,12 @@ export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWea
                     </label>
                 ))}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{localizeWithFallback('wiredfurni.params.effectid', LocalizeText('wiredfurni.tooltip.effectid'))}</Text>
-                <NitroInput type="number" value={effect} onChange={(event) => setEffect(parseInt(event.target.value))} />
-            </div>
+            {showEffect && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.effectid', LocalizeText('wiredfurni.tooltip.effectid'))}</Text>
+                    <NitroInput type="number" value={effect} onChange={(event) => setEffect(parseInt(event.target.value))} />
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { LocalizeText, localizeWithFallback, WiredFurniType } from '../../../../api';
 import { Slider, Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
@@ -36,7 +36,37 @@ const parseAltitude = (value: string) => {
     return clampAltitude(parsed);
 };
 
-export const WiredConditionHasAltitudeView: FC<{}> = () => {
+/**
+ * Seven conditions borrowed this dialog and inherited things that belong to the altitude check alone.
+ * The worst was the counter-only furni gate: it refuses every furni that is not a game counter, which
+ * makes "furni in range", "owns furni" and "same height" impossible to configure. They also inherited
+ * the altitude label for what is really a radius, a furni source picker where a user source is meant,
+ * and a comparison operator two of them never read.
+ */
+type AltitudeVariant = 'altitude' | 'userRange' | 'furniRange' | 'furniProperty';
+
+const VARIANTS: Record<
+    AltitudeVariant,
+    { counterOnly: boolean; comparison: boolean; value: 'altitude' | 'radius' | null; users: boolean }
+> = {
+    altitude: { counterOnly: true, comparison: true, value: 'altitude', users: false },
+    userRange: { counterOnly: false, comparison: true, value: 'radius', users: true },
+    furniRange: { counterOnly: false, comparison: true, value: 'radius', users: false },
+    furniProperty: { counterOnly: false, comparison: false, value: null, users: false }
+};
+
+const VALUE_LABELS = {
+    altitude: { key: 'wiredfurni.params.setaltitude', fallback: 'Altitude' },
+    radius: { key: 'wiredfurni.params.setradius', fallback: 'Radius in tiles' }
+};
+
+interface WiredConditionHasAltitudeViewProps {
+    variant?: AltitudeVariant;
+}
+
+export const WiredConditionHasAltitudeView: FC<WiredConditionHasAltitudeViewProps> = ({ variant = 'altitude' }) => {
+    const spec = VARIANTS[variant];
+
     const { trigger = null, setIntParams = null, setStringParam = null, setAllowedInteractionTypes = null, setAllowedInteractionErrorKey = null } = useWired();
     const [comparison, setComparison] = useState(1);
     const [furniSource, setFurniSource] = useState<number>(() => {
@@ -49,6 +79,8 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
     const [altitudeInput, setAltitudeInput] = useState('0');
 
     useEffect(() => {
+        if (!spec.counterOnly) return;
+
         setAllowedInteractionTypes(COUNTER_INTERACTION_TYPES);
         setAllowedInteractionErrorKey('wiredfurni.error.require_counter_furni');
 
@@ -56,20 +88,28 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
             setAllowedInteractionTypes(null);
             setAllowedInteractionErrorKey(null);
         };
-    }, [setAllowedInteractionErrorKey, setAllowedInteractionTypes]);
+    }, [spec.counterOnly, setAllowedInteractionErrorKey, setAllowedInteractionTypes]);
 
     useEffect(() => {
         if (!trigger) return;
 
-        setComparison(trigger.intData.length > 0 ? trigger.intData[0] : 1);
-        setFurniSource(trigger.intData.length > 1 ? trigger.intData[1] : (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0);
-        setQuantifier(trigger.intData.length > 2 ? trigger.intData[2] : 0);
-        setShowAdvanced(trigger.intData.length > 1 ? trigger.intData[1] !== 0 || trigger.intData[2] !== 0 : false);
+        const sourceSlot = spec.comparison ? 1 : 0;
+        const quantifierSlot = sourceSlot + 1;
+        const fallbackSource = (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0;
+
+        setComparison(spec.comparison && trigger.intData.length > 0 ? trigger.intData[0] : 1);
+        setFurniSource(trigger.intData.length > sourceSlot ? trigger.intData[sourceSlot] : fallbackSource);
+        setQuantifier(trigger.intData.length > quantifierSlot ? trigger.intData[quantifierSlot] : 0);
+        setShowAdvanced(
+            trigger.intData.length > sourceSlot
+                ? trigger.intData[sourceSlot] !== 0 || trigger.intData[quantifierSlot] !== 0
+                : false
+        );
 
         const nextAltitude = parseAltitude(trigger.stringData);
         setAltitude(nextAltitude);
         setAltitudeInput(formatAltitude(nextAltitude));
-    }, [trigger]);
+    }, [spec.comparison, trigger]);
 
     const updateAltitude = (value: number) => {
         const nextValue = clampAltitude(value);
@@ -101,8 +141,9 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
     };
 
     const save = () => {
-        setIntParams([comparison, furniSource, quantifier]);
-        setStringParam(formatAltitude(altitude));
+        // furniProperty reads [source, quantifier]; the others keep the comparison in slot 0.
+        setIntParams(spec.comparison ? [comparison, furniSource, quantifier] : [furniSource, quantifier]);
+        setStringParam(spec.value ? formatAltitude(altitude) : '');
     };
 
     return (
@@ -131,49 +172,59 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
                                                 type="radio"
                                                 onChange={() => setQuantifier(value)}
                                             />
-                                            <Text>{LocalizeText(`wiredfurni.params.quantifier.furni.${value}`)}</Text>
+                                            <Text>{LocalizeText(`wiredfurni.params.quantifier.${spec.users ? 'users' : 'furni'}.${value}`)}</Text>
                                         </div>
                                     );
                                 })}
                             </div>
-                            <WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />
+                            {spec.users ? (
+                                <WiredSourcesSelector showUsers={true} userSource={furniSource} onChangeUsers={setFurniSource} />
+                            ) : (
+                                <WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />
+                            )}
                         </>
                     )}
                 </div>
             }
         >
-            <div className="flex flex-col gap-2">
-                {[0, 1, 2].map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={comparison === value}
-                                className="form-check-input"
-                                id={`altitudeComparison${value}`}
-                                name="altitudeComparison"
-                                type="radio"
-                                onChange={() => setComparison(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.setaltitude')}</Text>
-                <input
-                    className="form-control form-control-sm"
-                    inputMode="decimal"
-                    type="text"
-                    value={altitudeInput}
-                    onBlur={() => setAltitudeInput(formatAltitude(altitude))}
-                    onChange={(event) => updateAltitudeInput(event.target.value)}
-                />
-            </div>
-            <div className="flex flex-col gap-1">
-                <Slider max={MAX_ALTITUDE} min={MIN_ALTITUDE} step={ALTITUDE_STEP} value={altitude} onChange={(event) => updateAltitude(event as number)} />
-                <Text small>{formatAltitude(altitude)}</Text>
-            </div>
+            {spec.comparison && (
+                <div className="flex flex-col gap-2">
+                    {[0, 1, 2].map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={comparison === value}
+                                    className="form-check-input"
+                                    id={`altitudeComparison${value}`}
+                                    name="altitudeComparison"
+                                    type="radio"
+                                    onChange={() => setComparison(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+            {spec.value && (
+                <>
+                    <div className="flex flex-col gap-1">
+                        <Text bold>{localizeWithFallback(VALUE_LABELS[spec.value].key, VALUE_LABELS[spec.value].fallback)}</Text>
+                        <input
+                            className="form-control form-control-sm"
+                            inputMode="decimal"
+                            type="text"
+                            value={altitudeInput}
+                            onBlur={() => setAltitudeInput(formatAltitude(altitude))}
+                            onChange={(event) => updateAltitudeInput(event.target.value)}
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <Slider max={MAX_ALTITUDE} min={MIN_ALTITUDE} step={ALTITUDE_STEP} value={altitude} onChange={(event) => updateAltitude(event as number)} />
+                        <Text small>{formatAltitude(altitude)}</Text>
+                    </div>
+                </>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
@@ -41,7 +41,10 @@ const parseAltitude = (value: string) => {
  * The worst was the counter-only furni gate: it refuses every furni that is not a game counter, which
  * makes "furni in range", "owns furni" and "same height" impossible to configure. They also inherited
  * the altitude label for what is really a radius, a furni source picker where a user source is meant,
- * and a comparison operator two of them never read.
+ * and a comparison operator four of them never read.
+ *
+ * The four range boxes read it now. Their middle option is inclusive — "within the radius", the
+ * behaviour they always had — so it gets its own label instead of the altitude box's "Equals".
  */
 type AltitudeVariant = 'altitude' | 'userRange' | 'furniRange' | 'furniProperty';
 
@@ -53,6 +56,12 @@ const VARIANTS: Record<
     userRange: { counterOnly: false, comparison: true, value: 'radius', users: true },
     furniRange: { counterOnly: false, comparison: true, value: 'radius', users: false },
     furniProperty: { counterOnly: false, comparison: false, value: null, users: false }
+};
+
+const RANGE_COMPARISON_LABELS: Record<number, { key: string; fallback: string }> = {
+    0: { key: 'wiredfurni.params.range.comparison.0', fallback: 'Closer than' },
+    1: { key: 'wiredfurni.params.range.comparison.1', fallback: 'Within the radius' },
+    2: { key: 'wiredfurni.params.range.comparison.2', fallback: 'Further than' }
 };
 
 const VALUE_LABELS = {
@@ -200,7 +209,11 @@ export const WiredConditionHasAltitudeView: FC<WiredConditionHasAltitudeViewProp
                                     type="radio"
                                     onChange={() => setComparison(value)}
                                 />
-                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                                <Text>
+                                    {spec.value === 'radius'
+                                        ? localizeWithFallback(RANGE_COMPARISON_LABELS[value].key, RANGE_COMPARISON_LABELS[value].fallback)
+                                        : LocalizeText(`wiredfurni.params.comparison.${value}`)}
+                                </Text>
                             </div>
                         );
                     })}

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -82,6 +82,12 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView field={null} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:
             return <WiredConditionActorIsWearingBadgeView field={null} negative={true} />;
+        case WiredConditionlayout.USER_RANGE:
+            return <WiredConditionHasAltitudeView variant="userRange" />;
+        case WiredConditionlayout.FURNI_RANGE:
+            return <WiredConditionHasAltitudeView variant="furniRange" />;
+        case WiredConditionlayout.FURNI_PROPERTY:
+            return <WiredConditionHasAltitudeView variant="furniProperty" />;
         case WiredConditionlayout.USER_TAG:
             return <WiredConditionActorIsWearingBadgeView field="tag" />;
         case WiredConditionlayout.NOT_USER_TAG:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,8 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_AMOUNT:
+            return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:
             return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,10 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_ATTRIBUTE:
+            return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
+        case WiredConditionlayout.NOT_USER_ATTRIBUTE:
+            return <WiredConditionActorIsWearingBadgeView negative={true} showBadge={false} />;
         case WiredConditionlayout.ACTOR_IS_WEARING_EFFECT:
             return <WiredConditionActorIsWearingEffectView />;
         case WiredConditionlayout.NOT_ACTOR_WEARING_EFFECT:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,10 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_STATE:
+            return <WiredConditionActorIsWearingEffectView showEffect={false} />;
+        case WiredConditionlayout.NOT_USER_STATE:
+            return <WiredConditionActorIsWearingEffectView negative={true} showEffect={false} />;
         case WiredConditionlayout.USER_AMOUNT:
             return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -79,9 +79,15 @@ export const WiredConditionLayoutView = (code: number) => {
         case WiredConditionlayout.USER_AMOUNT:
             return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:
-            return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
+            return <WiredConditionActorIsWearingBadgeView field={null} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:
-            return <WiredConditionActorIsWearingBadgeView negative={true} showBadge={false} />;
+            return <WiredConditionActorIsWearingBadgeView field={null} negative={true} />;
+        case WiredConditionlayout.USER_TAG:
+            return <WiredConditionActorIsWearingBadgeView field="tag" />;
+        case WiredConditionlayout.NOT_USER_TAG:
+            return <WiredConditionActorIsWearingBadgeView field="tag" negative={true} />;
+        case WiredConditionlayout.USER_MOTTO:
+            return <WiredConditionActorIsWearingBadgeView field="motto" />;
         case WiredConditionlayout.ACTOR_IS_WEARING_EFFECT:
             return <WiredConditionActorIsWearingEffectView />;
         case WiredConditionlayout.NOT_ACTOR_WEARING_EFFECT:

--- a/src/components/wired/views/conditions/WiredConditionTeamHasScoreView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionTeamHasScoreView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { LocalizeText, localizeWithFallback, WiredFurniType } from '../../../../api';
 import { Slider, Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
@@ -9,16 +9,28 @@ const TEAM_OPTIONS = [1, 2, 3, 4];
 const COMPARISON_OPTIONS = [0, 1, 2];
 const MIN_SCORE = 0;
 const MAX_SCORE = 999;
+/** What the server's normalizeScore lets through. A credit threshold is useless capped at 999. */
+const MAX_AMOUNT = 1_000_000;
 const SCORE_PATTERN = /^\d*$/;
 
-const clampScore = (value: number) => {
+const clampScore = (value: number, max: number) => {
     if (isNaN(value)) return MIN_SCORE;
 
-    return Math.max(MIN_SCORE, Math.min(MAX_SCORE, Math.floor(value)));
+    return Math.max(MIN_SCORE, Math.min(max, Math.floor(value)));
 };
 
-export const WiredConditionTeamHasScoreView: FC<{}> = () => {
+interface WiredConditionTeamHasScoreViewProps {
+    /**
+     * The item-count and currency conditions share this dialog for its amount, user source and
+     * quantifier, but their predicate is fixed in the server — no team, no comparison operator. They
+     * pass false, and the two dead controls stay out of the window.
+     */
+    scoped?: boolean;
+}
+
+export const WiredConditionTeamHasScoreView: FC<WiredConditionTeamHasScoreViewProps> = ({ scoped = true }) => {
     const { trigger = null, setIntParams = null } = useWired();
+    const ceiling = scoped ? MAX_SCORE : MAX_AMOUNT;
     const [team, setTeam] = useState(1);
     const [comparison, setComparison] = useState(1);
     const [score, setScore] = useState(0);
@@ -32,7 +44,7 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
 
         const nextTeam = trigger.intData.length > 0 ? trigger.intData[0] : 1;
         const nextComparison = trigger.intData.length > 1 ? trigger.intData[1] : 1;
-        const nextScore = clampScore(trigger.intData.length > 2 ? trigger.intData[2] : 0);
+        const nextScore = clampScore(trigger.intData.length > 2 ? trigger.intData[2] : 0, ceiling);
         const nextUserSource = trigger.intData.length > 3 ? trigger.intData[3] : 0;
         const nextQuantifier = trigger.intData.length > 4 ? trigger.intData[4] : 0;
 
@@ -43,10 +55,10 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
         setUserSource(nextUserSource);
         setQuantifier(nextQuantifier === 1 ? 1 : 0);
         setShowAdvanced(nextUserSource !== 0 || nextQuantifier !== 0);
-    }, [trigger]);
+    }, [ceiling, trigger]);
 
     const updateScore = (value: number) => {
-        const nextValue = clampScore(value);
+        const nextValue = clampScore(value, ceiling);
 
         setScore(nextValue);
         setScoreInput(nextValue.toString());
@@ -66,7 +78,7 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
     };
 
     const save = () => {
-        setIntParams([team, comparison, clampScore(score), userSource, quantifier]);
+        setIntParams([team, comparison, clampScore(score, ceiling), userSource, quantifier]);
     };
 
     return (
@@ -106,57 +118,67 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
                 </div>
             }
         >
+            {scoped && (
+                <>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.team')}</Text>
+                    {TEAM_OPTIONS.map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={team === value}
+                                    className="form-check-input"
+                                    id={`teamHasScore${value}`}
+                                    name="teamHasScore"
+                                    type="radio"
+                                    onChange={() => setTeam(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.team.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.comparison_selection')}</Text>
+                    {COMPARISON_OPTIONS.map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={comparison === value}
+                                    className="form-check-input"
+                                    id={`teamScoreComparison${value}`}
+                                    name="teamScoreComparison"
+                                    type="radio"
+                                    onChange={() => setComparison(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+                </>
+            )}
             <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.team')}</Text>
-                {TEAM_OPTIONS.map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={team === value}
-                                className="form-check-input"
-                                id={`teamHasScore${value}`}
-                                name="teamHasScore"
-                                type="radio"
-                                onChange={() => setTeam(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.team.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.comparison_selection')}</Text>
-                {COMPARISON_OPTIONS.map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={comparison === value}
-                                className="form-check-input"
-                                id={`teamScoreComparison${value}`}
-                                name="teamScoreComparison"
-                                type="radio"
-                                onChange={() => setComparison(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.setscore2')}</Text>
+                <Text bold>
+                    {scoped
+                        ? LocalizeText('wiredfurni.params.setscore2')
+                        : localizeWithFallback('wiredfurni.params.user_amount', 'Amount:')}
+                </Text>
                 <input
                     className="form-control form-control-sm"
                     inputMode="numeric"
                     type="text"
                     value={scoreInput}
-                    onBlur={() => setScoreInput(clampScore(score).toString())}
+                    onBlur={() => setScoreInput(clampScore(score, ceiling).toString())}
                     onChange={(event) => updateScoreInput(event.target.value)}
                 />
             </div>
-            <div className="flex flex-col gap-1">
-                <Slider max={MAX_SCORE} min={MIN_SCORE} step={1} value={score} onChange={(event) => updateScore(event as number)} />
-                <Text small>{score}</Text>
-            </div>
+            {scoped && (
+                <div className="flex flex-col gap-1">
+                    <Slider max={MAX_SCORE} min={MIN_SCORE} step={1} value={score} onChange={(event) => updateScore(event as number)} />
+                    <Text small>{score}</Text>
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/triggers/WiredTriggerLayoutView.tsx
+++ b/src/components/wired/views/triggers/WiredTriggerLayoutView.tsx
@@ -68,6 +68,7 @@ export const WiredTriggerLayoutView = (code: number) => {
             return <WiredTriggeExecutePeriodicallyLongView />;
         case WiredTriggerLayout.GAME_ENDS:
             return <WiredTriggerGameEndsView />;
+        case WiredTriggerLayout.TEAM_GAME_RESULT:
         case WiredTriggerLayout.GAME_STARTS:
             return <WiredTriggerGameStartsView />;
         case WiredTriggerLayout.SCORE_ACHIEVED:


### PR DESCRIPTION
Client half of duckietm/Polaris-Emulator#637.

Twenty-six wired boxes reported a type code belonging to a different box, so the window that opened asked for things they never read and hid the things they did. Each code now gets a window that matches what its box actually stores.

**Controls removed** because the box never read them: the badge field from four conditions, the team colour and the operator from four amount conditions, the effect id from the freeze conditions, the kick message from sit and lay, the instant-teleport box from walk-to-furni, the source picker when everyone leaves the team, the bot name from the team-result triggers.

**Controls added** because the box reads them and the window never offered them: a tile count for move-user-tiles, which read a fourth slot the view never sent — so "move the user N tiles" always moved exactly **one**.

**Fields renamed** to what they hold: the chat composer was shared by nineteen effects whose textarea was never a message but an amount, a badge code, a tag, an id, a figure, a link or a command.

**A gate lifted**: the altitude dialog imposed `allowedInteractionTypes: ['game_upcounter']`, which refuses every furni that is not a game counter — so seven conditions that borrowed it, among them "furni in range" and "same height", could not be configured at all.

Also here, from the same pass: the three range operators now read "closer than / within the radius / further than" rather than the altitude box's "Equals", because the emulator reads them now; and a window for the new override-height action.

## Verification

`yarn typecheck`, `yarn lint:hooks`, wired suite 71/71. Not exercised in a running room — the room renders through WebGL and login needs a real session.
