### PR TITLE
feat(wired): show the NO_TARGETS warning in the monitor

### DIFF
--- a/src/components/wired-tools/WiredCreatorTools.constants.ts
+++ b/src/components/wired-tools/WiredCreatorTools.constants.ts
@@ -12,7 +12,7 @@ export const TABS: Array<{ key: WiredToolsTab; label: string }> = [
     { key: 'settings', label: 'Settings' }
 ];
 
-export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT'];
+export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT', 'NO_TARGETS'];
 
 export const WIRED_MONITOR_ACTION_FETCH = 0;
 export const WIRED_MONITOR_ACTION_CLEAR_LOGS = 1;
@@ -22,6 +22,15 @@ export const WIRED_INSPECTION_REFRESH_MS = 50;
 export const WIRED_CLOCK_REFRESH_MS = 50;
 
 export const MONITOR_ERROR_INFO: Record<string, { description: string[]; severity: string; title: string }> = {
+    NO_TARGETS: {
+        title: 'NO_TARGETS',
+        severity: 'WARNING',
+        description: [
+            'A chain fired and one of its effects had nothing to act on, so it did nothing.',
+            'The reason names which source came back empty. "The triggering item" is empty when the trigger is not about a furni at all; "the selector" is empty when no selector picked anything; "the picked furni" is empty when the chosen furni have since been taken up.',
+            'This is not an engine error. It means the setup asked for something that was not there, which until now was the one way a chain could fail in complete silence.'
+        ]
+    },
     EXECUTION_CAP: {
         title: 'EXECUTION_CAP',
         severity: 'ERROR',


### PR DESCRIPTION
Client half of duckietm/Polaris-Emulator#641.

Gives the new `NO_TARGETS` warning its entry in the monitor: a chain fired and one of its effects had nothing to act on. The description says what each empty source means — "the triggering item" is empty when the trigger is not about a furni, "the selector" when nothing was picked, "the picked furni" when the chosen furni have since been taken up — so the reason line reads as an explanation rather than a code.

### Verification

`yarn typecheck`, `yarn lint:hooks`, wired suite 71/71. Not exercised in a running room.