### PR TITLE
fix(wired): give each box a window that matches what it reads

### DIFF
--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -112,4 +112,9 @@ export class WiredActionLayoutCode {
     public static CONTRACT_TRADE: number = 112;
     public static CUSTOM_CONTRACT: number = 113;
     public static CHANGE_OPACITY: number = 114;
+    /**
+     * Walking to a furni borrowed TELEPORT, whose window offers a "teleport instantly" checkbox that
+     * this effect never reads — it walks. Same three slots, one control fewer.
+     */
+    public static WALK_TO_FURNI: number = 115;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -117,4 +117,8 @@ export class WiredActionLayoutCode {
      * this effect never reads — it walks. Same three slots, one control fewer.
      */
     public static WALK_TO_FURNI: number = 115;
+    /** Sit, lie down, fast walk: they only need to know which users, not a kick message. */
+    public static USER_TARGET: number = 116;
+    /** Move a user N tiles — the fourth slot the move/rotate window never sent. */
+    public static MOVE_USER_TILES: number = 117;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -138,4 +138,6 @@ export class WiredActionLayoutCode {
      * a question the window asks.
      */
     public static ALL_USERS_LEAVE_TEAM: number = 124;
+    /** The official override-height action: a two-way choice and a 0..8000 thousandths slider. */
+    public static OVERRIDE_HEIGHT: number = 125;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -121,4 +121,15 @@ export class WiredActionLayoutCode {
     public static USER_TARGET: number = 116;
     /** Move a user N tiles — the fourth slot the move/rotate window never sent. */
     public static MOVE_USER_TILES: number = 117;
+    /**
+     * The shapes that borrowed the chat composer. They store one string and a user source like the
+     * chat effects do, but the bubble style and the visibility choice mean nothing to them, and what
+     * the textarea held was never a message.
+     */
+    public static EFFECT_AMOUNT: number = 118;
+    public static EFFECT_BADGE: number = 119;
+    public static EFFECT_TAG: number = 120;
+    public static EFFECT_ID: number = 121;
+    public static EFFECT_MESSAGE: number = 122;
+    public static EFFECT_TEXT: number = 123;
 }

--- a/src/api/wired/WiredActionLayoutCode.ts
+++ b/src/api/wired/WiredActionLayoutCode.ts
@@ -132,4 +132,10 @@ export class WiredActionLayoutCode {
     public static EFFECT_ID: number = 121;
     public static EFFECT_MESSAGE: number = 122;
     public static EFFECT_TEXT: number = 123;
+    /**
+     * Everyone in the room leaves their game, so there is nobody to pick. The stored source still
+     * decides whether the stack needs a triggering user, so it keeps its slot - it is just no longer
+     * a question the window asks.
+     */
+    public static ALL_USERS_LEAVE_TEAM: number = 124;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -48,4 +48,10 @@ export class WiredConditionlayout {
     public static TRG_FURNI_ADJACENT_STATE: number = 46;
     public static CHEST_HAS_ITEMS: number = 47;
     public static CHEST_HAS_ITEM_TYPE: number = 48;
+    /**
+     * A condition answered by the user themselves — gender, room rights. Same dialog as the badge
+     * conditions minus the badge-code field, which those boxes showed and never read.
+     */
+    public static USER_ATTRIBUTE: number = 49;
+    public static NOT_USER_ATTRIBUTE: number = 50;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -73,4 +73,12 @@ export class WiredConditionlayout {
     public static USER_TAG: number = 54;
     public static NOT_USER_TAG: number = 55;
     public static USER_MOTTO: number = 56;
+    /**
+     * The three shapes that borrowed the altitude dialog. They inherited its counter-only furni gate,
+     * which refuses every furni that is not a game counter — and with it a radius labelled as an
+     * altitude, a furni picker where a user source is meant, and a comparison two of them never read.
+     */
+    public static USER_RANGE: number = 57;
+    public static FURNI_RANGE: number = 58;
+    public static FURNI_PROPERTY: number = 59;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -60,4 +60,10 @@ export class WiredConditionlayout {
      * those boxes consult, and with the amount ceiling the server actually enforces.
      */
     public static USER_AMOUNT: number = 51;
+    /**
+     * A boolean state the user is in — frozen. Same dialog as the wearing-effect conditions minus the
+     * effect id, which those boxes show and never read.
+     */
+    public static USER_STATE: number = 52;
+    public static NOT_USER_STATE: number = 53;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -66,4 +66,11 @@ export class WiredConditionlayout {
      */
     public static USER_STATE: number = 52;
     public static NOT_USER_STATE: number = 53;
+    /**
+     * Text read off the user that is not a badge code. The field is genuinely used by these boxes —
+     * it was only labelled "Badge code", with the badge's length limit instead of its own.
+     */
+    public static USER_TAG: number = 54;
+    public static NOT_USER_TAG: number = 55;
+    public static USER_MOTTO: number = 56;
 }

--- a/src/api/wired/WiredConditionLayoutCode.ts
+++ b/src/api/wired/WiredConditionLayoutCode.ts
@@ -54,4 +54,10 @@ export class WiredConditionlayout {
      */
     public static USER_ATTRIBUTE: number = 49;
     public static NOT_USER_ATTRIBUTE: number = 50;
+    /**
+     * A threshold on something the user holds — inventory items, credits, diamonds, duckets. Same
+     * dialog as the team score minus the team colour and the comparison operator, neither of which
+     * those boxes consult, and with the amount ceiling the server actually enforces.
+     */
+    public static USER_AMOUNT: number = 51;
 }

--- a/src/api/wired/WiredTriggerLayoutCode.ts
+++ b/src/api/wired/WiredTriggerLayoutCode.ts
@@ -27,4 +27,10 @@ export class WiredTriggerLayout {
     public static PRESS_KEYBIND: number = 26;
     public static TRANSACTION_COMPLETE: number = 27;
     public static TRANSACTION_FAIL: number = 28;
+    /**
+     * Team wins and team loses take no settings. They used to answer CUSTOM, which shares code 13
+     * with the bot-reached trigger, so the window asked them which bot had arrived.
+     */
+    public static TEAM_GAME_RESULT: number = 29;
+
 }

--- a/src/components/room/widgets/furniture/FurnitureHighScoreView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureHighScoreView.tsx
@@ -7,25 +7,30 @@ import { ContextMenuHeaderView } from '../context-menu/ContextMenuHeaderView';
 import { ContextMenuListView } from '../context-menu/ContextMenuListView';
 
 export const FurnitureHighScoreView: FC<{}> = (props) => {
-    const { stuffDatas = null, getScoreType = null, getClearType = null } = useFurnitureHighScoreWidget();
+    const { stuffDatas = null, getScoreType = null, getClearType = null, isConfigured = null, isTimeScore = null, formatScore = null } = useFurnitureHighScoreWidget();
 
     if (!stuffDatas || !stuffDatas.size) return null;
 
     return (
         <>
             {Array.from(stuffDatas.entries()).map(([objectId, stuffData], index) => {
+                const configured = isConfigured(stuffData.scoreType, stuffData.clearType);
+                const timeScore = configured && isTimeScore(stuffData.scoreType);
+
                 return (
                     <DraggableWindow key={index} uniqueKey={`high-score-${objectId}`}>
                         <Column className="nitro-widget-high-score nitro-context-menu bg-[#1e1f23] p-2 w-[280px] max-w-[280px] h-[320px]" gap={0}>
                             <ContextMenuHeaderView classNames={['drag-handler cursor-move']}>
-                                {LocalizeText(
-                                    'high.score.display.caption',
-                                    ['scoretype', 'cleartype'],
-                                    [
-                                        LocalizeText(`high.score.display.scoretype.${getScoreType(stuffData.scoreType)}`),
-                                        LocalizeText(`high.score.display.cleartype.${getClearType(stuffData.clearType)}`)
-                                    ]
-                                )}
+                                {configured
+                                    ? LocalizeText(
+                                        'high.score.display.caption',
+                                        ['scoretype', 'cleartype'],
+                                        [
+                                            LocalizeText(`high.score.display.scoretype.${getScoreType(stuffData.scoreType)}`),
+                                            LocalizeText(`high.score.display.cleartype.${getClearType(stuffData.clearType)}`)
+                                        ]
+                                    )
+                                    : LocalizeText('high.score.display.users.header')}
                             </ContextMenuHeaderView>
                             <ContextMenuListView className="!h-auto" gap={1} overflow="hidden">
                                 <div className="flex flex-col gap-1">
@@ -34,7 +39,7 @@ export const FurnitureHighScoreView: FC<{}> = (props) => {
                                             {LocalizeText('high.score.display.users.header')}
                                         </Text>
                                         <Text bold center className="col-span-4" variant="white">
-                                            {LocalizeText('high.score.display.score.header')}
+                                            {LocalizeText(timeScore ? 'high.score.display.time.header' : 'high.score.display.score.header')}
                                         </Text>
                                     </div>
                                     <hr className="m-0" />
@@ -47,7 +52,7 @@ export const FurnitureHighScoreView: FC<{}> = (props) => {
                                                     {entry.users.join(', ')}
                                                 </Text>
                                                 <Text center className="col-span-4" variant="white">
-                                                    {entry.score}
+                                                    {formatScore(entry.score, stuffData.scoreType)}
                                                 </Text>
                                             </div>
                                         );

--- a/src/components/wired-tools/WiredCreatorTools.constants.ts
+++ b/src/components/wired-tools/WiredCreatorTools.constants.ts
@@ -12,7 +12,7 @@ export const TABS: Array<{ key: WiredToolsTab; label: string }> = [
     { key: 'settings', label: 'Settings' }
 ];
 
-export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT', 'NO_TARGETS'];
+export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT', 'NO_TARGETS', 'UNREACHABLE'];
 
 export const WIRED_MONITOR_ACTION_FETCH = 0;
 export const WIRED_MONITOR_ACTION_CLEAR_LOGS = 1;
@@ -22,6 +22,15 @@ export const WIRED_INSPECTION_REFRESH_MS = 50;
 export const WIRED_CLOCK_REFRESH_MS = 50;
 
 export const MONITOR_ERROR_INFO: Record<string, { description: string[]; severity: string; title: string }> = {
+    UNREACHABLE: {
+        title: 'UNREACHABLE',
+        severity: 'WARNING',
+        description: [
+            'A furni in this room is waiting on something the room has no way of producing, so it will sit there doing nothing.',
+            'A highscore board is the usual case: it only fills when a game ends, and a game can only end through a game timer. Without one in the room the board stays empty forever.',
+            'Nothing has failed. The furni is fine and so is the engine - the room is simply missing the piece that would feed it.'
+        ]
+    },
     NO_TARGETS: {
         title: 'NO_TARGETS',
         severity: 'WARNING',

--- a/src/components/wired-tools/WiredCreatorTools.constants.ts
+++ b/src/components/wired-tools/WiredCreatorTools.constants.ts
@@ -12,7 +12,7 @@ export const TABS: Array<{ key: WiredToolsTab; label: string }> = [
     { key: 'settings', label: 'Settings' }
 ];
 
-export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT'];
+export const MONITOR_LOG_ORDER: string[] = ['EXECUTION_CAP', 'DELAYED_EVENTS_CAP', 'EXECUTOR_OVERLOAD', 'MARKED_AS_HEAVY', 'KILLED', 'RECURSION_TIMEOUT', 'NO_TARGETS'];
 
 export const WIRED_MONITOR_ACTION_FETCH = 0;
 export const WIRED_MONITOR_ACTION_CLEAR_LOGS = 1;
@@ -22,6 +22,15 @@ export const WIRED_INSPECTION_REFRESH_MS = 50;
 export const WIRED_CLOCK_REFRESH_MS = 50;
 
 export const MONITOR_ERROR_INFO: Record<string, { description: string[]; severity: string; title: string }> = {
+    NO_TARGETS: {
+        title: 'NO_TARGETS',
+        severity: 'WARNING',
+        description: [
+            'A chain fired and one of its effects had nothing to act on, so it did nothing.',
+            'The reason names which source came back empty. "The triggering item" is empty when the trigger is not about a furni at all; "the selector" is empty when no selector picked anything; "the picked furni" is empty when the chosen furni have since been taken up.',
+            'This is not an engine error. It means the setup asked for something that was not there, which until now was the one way a chain could fail in complete silence.'
+        ]
+    },
     EXECUTION_CAP: {
         title: 'EXECUTION_CAP',
         severity: 'ERROR',

--- a/src/components/wired/views/actions/WiredActionChatView.tsx
+++ b/src/components/wired/views/actions/WiredActionChatView.tsx
@@ -1,7 +1,8 @@
 import { FC, useEffect, useMemo, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { localizeWithFallback, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
+import { NitroInput } from '../../../../layout';
 import { WiredTextCounter, WiredTextFormattingHelp } from '../common/WiredTextFormattingHelp';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
@@ -19,6 +20,26 @@ const clampShowMessage = (value: string) => {
     return joined.slice(0, SHOW_MESSAGE_MAX_LENGTH);
 };
 
+/**
+ * Nineteen effects shared this window because they all store one string and a user source. Only the
+ * three that make somebody speak read the bubble style and the visibility choice; for the rest those
+ * two controls did nothing, and the message textarea held something that was never a message — an
+ * amount, a badge code, a tag, a room or effect id, a figure, a link, a command.
+ *
+ * Each entry says what the box really holds. `chat` is the original composer.
+ */
+const FIELDS: Record<
+    number,
+    { key: string; fallback: string; numeric?: boolean; multiline?: boolean; maxLength?: number }
+> = {
+    [WiredActionLayoutCode.EFFECT_AMOUNT]: { key: 'wiredfurni.params.amount', fallback: 'Amount', numeric: true },
+    [WiredActionLayoutCode.EFFECT_BADGE]: { key: 'wiredfurni.params.badgecode', fallback: 'Badge code', maxLength: 50 },
+    [WiredActionLayoutCode.EFFECT_TAG]: { key: 'wiredfurni.params.tag', fallback: 'Tag', maxLength: 38 },
+    [WiredActionLayoutCode.EFFECT_ID]: { key: 'wiredfurni.params.id', fallback: 'Id', numeric: true },
+    [WiredActionLayoutCode.EFFECT_MESSAGE]: { key: 'wiredfurni.params.message', fallback: 'Message', multiline: true },
+    [WiredActionLayoutCode.EFFECT_TEXT]: { key: 'wiredfurni.params.value', fallback: 'Value', maxLength: 200 }
+};
+
 export const WiredActionChatView: FC<{}> = (props) => {
     const [message, setMessage] = useState('');
     const [visibilitySelection, setVisibilitySelection] = useState<number>(0);
@@ -29,15 +50,20 @@ export const WiredActionChatView: FC<{}> = (props) => {
         return 0;
     });
     const bubbleStyleIds = useMemo(() => SHOW_MESSAGE_STYLE_IDS, []);
+    /** Undefined for the three chat effects, which keep the composer as it is. */
+    const field = FIELDS[trigger?.code];
+    const isChat = !field;
     const maxMessageLength = SHOW_MESSAGE_MAX_LENGTH;
 
     const save = () => {
-        setStringParam(clampShowMessage(message));
+        // Slots 1 and 2 keep their places so nothing about how these effects store changes; the two
+        // controls that fill them simply stop being offered where they mean nothing.
+        setStringParam(isChat || field.multiline ? clampShowMessage(message) : message);
         setIntParams([userSource, visibilitySelection, bubbleStyle]);
     };
 
     useEffect(() => {
-        setMessage(clampShowMessage(trigger.stringData));
+        setMessage(FIELDS[trigger?.code] && !FIELDS[trigger.code].multiline ? (trigger.stringData ?? '') : clampShowMessage(trigger.stringData));
         if (trigger.intData.length >= 1) setUserSource(trigger.intData[0]);
         else setUserSource(0);
         if (trigger.intData.length >= 2) setVisibilitySelection(trigger.intData[1]);
@@ -54,55 +80,70 @@ export const WiredActionChatView: FC<{}> = (props) => {
             footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
         >
             <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
-                <textarea
-                    className="form-control form-control-sm nitro-wired__resizable-textarea"
-                    maxLength={maxMessageLength}
-                    rows={4}
-                    value={message}
-                    onChange={(event) => setMessage(clampShowMessage(event.target.value))}
-                />
-                <WiredTextCounter maxLength={maxMessageLength} value={message} />
-                <WiredTextFormattingHelp />
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.show_message.visibility_selection.title')}</Text>
-                <div className="flex items-center gap-1">
-                    <input
-                        checked={visibilitySelection === 0}
-                        className="form-check-input"
-                        name="showMessageVisibilitySelection"
-                        type="radio"
-                        onChange={() => setVisibilitySelection(0)}
+                <Text bold>{field ? localizeWithFallback(field.key, field.fallback) : LocalizeText('wiredfurni.params.message')}</Text>
+                {!field || field.multiline ? (
+                    <>
+                        <textarea
+                            className="form-control form-control-sm nitro-wired__resizable-textarea"
+                            maxLength={maxMessageLength}
+                            rows={4}
+                            value={message}
+                            onChange={(event) => setMessage(clampShowMessage(event.target.value))}
+                        />
+                        <WiredTextCounter maxLength={maxMessageLength} value={message} />
+                        {isChat && <WiredTextFormattingHelp />}
+                    </>
+                ) : (
+                    <NitroInput
+                        maxLength={field.maxLength}
+                        type={field.numeric ? 'number' : 'text'}
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
                     />
-                    <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.0')}</Text>
-                </div>
-                <div className="flex items-center gap-1">
-                    <input
-                        checked={visibilitySelection === 1}
-                        className="form-check-input"
-                        name="showMessageVisibilitySelection"
-                        type="radio"
-                        onChange={() => setVisibilitySelection(1)}
-                    />
-                    <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.1')}</Text>
-                </div>
+                )}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.show_message.style_selection.title')}</Text>
-                <div className="flex items-center gap-2">
-                    <div className="bubble-container relative w-[50px] shrink-0">
-                        <div className={`relative min-h-[26px] chat-bubble bubble-${bubbleStyle}`} />
+            {isChat && (
+                <>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.show_message.visibility_selection.title')}</Text>
+                    <div className="flex items-center gap-1">
+                        <input
+                            checked={visibilitySelection === 0}
+                            className="form-check-input"
+                            name="showMessageVisibilitySelection"
+                            type="radio"
+                            onChange={() => setVisibilitySelection(0)}
+                        />
+                        <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.0')}</Text>
                     </div>
-                    <select className="form-select form-select-sm" value={bubbleStyle} onChange={(event) => setBubbleStyle(Number(event.target.value))}>
-                        {bubbleStyleIds.map((styleId) => (
-                            <option key={styleId} value={styleId}>
-                                {LocalizeText(`wiredfurni.params.show_message.style_selection.${styleId}`)}
-                            </option>
-                        ))}
-                    </select>
+                    <div className="flex items-center gap-1">
+                        <input
+                            checked={visibilitySelection === 1}
+                            className="form-check-input"
+                            name="showMessageVisibilitySelection"
+                            type="radio"
+                            onChange={() => setVisibilitySelection(1)}
+                        />
+                        <Text>{LocalizeText('wiredfurni.params.show_message.visibility_selection.1')}</Text>
+                    </div>
                 </div>
-            </div>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.show_message.style_selection.title')}</Text>
+                    <div className="flex items-center gap-2">
+                        <div className="bubble-container relative w-[50px] shrink-0">
+                            <div className={`relative min-h-[26px] chat-bubble bubble-${bubbleStyle}`} />
+                        </div>
+                        <select className="form-select form-select-sm" value={bubbleStyle} onChange={(event) => setBubbleStyle(Number(event.target.value))}>
+                            {bubbleStyleIds.map((styleId) => (
+                                <option key={styleId} value={styleId}>
+                                    {LocalizeText(`wiredfurni.params.show_message.style_selection.${styleId}`)}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+                </>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionKickFromRoomView.tsx
+++ b/src/components/wired/views/actions/WiredActionKickFromRoomView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { GetConfigurationValue, LocalizeText, WiredFurniType } from '../../../../api';
+import { GetConfigurationValue, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { NitroInput } from '../../../../layout';
@@ -9,13 +9,16 @@ import { WiredActionBaseView } from './WiredActionBaseView';
 export const WiredActionKickFromRoomView: FC<{}> = (props) => {
     const [message, setMessage] = useState('');
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
+    /** Sit, lie down and fast walk share this window for its user source; nobody is being kicked, so
+     * the message the kicked person would see has nothing to say. */
+    const showMessage = trigger?.code !== WiredActionLayoutCode.USER_TARGET;
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return 0;
     });
 
     const save = () => {
-        setStringParam(message);
+        setStringParam(showMessage ? message : '');
         setIntParams([userSource]);
     };
 
@@ -32,15 +35,17 @@ export const WiredActionKickFromRoomView: FC<{}> = (props) => {
             save={save}
             footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
         >
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
-                <NitroInput
-                    maxLength={GetConfigurationValue<number>('wired.action.kick.from.room.max.length', 100)}
-                    type="text"
-                    value={message}
-                    onChange={(event) => setMessage(event.target.value)}
-                />
-            </div>
+            {showMessage && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.message')}</Text>
+                    <NitroInput
+                        maxLength={GetConfigurationValue<number>('wired.action.kick.from.room.max.length', 100)}
+                        type="text"
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
+                    />
+                </div>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -145,6 +145,13 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionTeleportView />;
         case WiredActionLayoutCode.WALK_TO_FURNI:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.EFFECT_AMOUNT:
+        case WiredActionLayoutCode.EFFECT_BADGE:
+        case WiredActionLayoutCode.EFFECT_TAG:
+        case WiredActionLayoutCode.EFFECT_ID:
+        case WiredActionLayoutCode.EFFECT_MESSAGE:
+        case WiredActionLayoutCode.EFFECT_TEXT:
+            return <WiredActionChatView />;
         case WiredActionLayoutCode.USER_TARGET:
             return <WiredActionKickFromRoomView />;
         case WiredActionLayoutCode.MOVE_USER_TILES:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -145,6 +145,10 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionTeleportView />;
         case WiredActionLayoutCode.WALK_TO_FURNI:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.USER_TARGET:
+            return <WiredActionKickFromRoomView />;
+        case WiredActionLayoutCode.MOVE_USER_TILES:
+            return <WiredActionMoveRotateUserView />;
         case WiredActionLayoutCode.FURNI_TO_FURNI:
             return <WiredActionFurniToFurniView />;
         case WiredActionLayoutCode.SET_ALTITUDE:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -103,6 +103,7 @@ import { WiredActionResetView } from './WiredActionResetView';
 import { WiredActionSendSignalView } from './WiredActionSendSignalView';
 import { WiredActionSetAltitudeView } from './WiredActionSetAltitudeView';
 import { WiredActionSetFurniStateToView } from './WiredActionSetFurniStateToView';
+import { WiredActionOverrideHeightView } from './WiredActionOverrideHeightView';
 import { WiredActionSetRollerSpeedView } from './WiredActionSetRollerSpeedView';
 import { WiredActionSetRoomAdView } from './WiredActionSetRoomAdView';
 import { WiredActionTeleportView } from './WiredActionTeleportView';
@@ -295,6 +296,8 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionSendSignalView />;
         case WiredActionLayoutCode.NEG_SEND_SIGNAL:
             return <WiredActionSendSignalView />;
+        case WiredActionLayoutCode.OVERRIDE_HEIGHT:
+            return <WiredActionOverrideHeightView />;
         case WiredActionLayoutCode.SET_ROLLER_SPEED:
             return <WiredActionSetRollerSpeedView />;
         case WiredActionLayoutCode.BOT_DANCE:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -176,6 +176,7 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionJoinTeamView />;
         case WiredActionLayoutCode.KICK_FROM_ROOM:
             return <WiredActionKickFromRoomView />;
+        case WiredActionLayoutCode.ALL_USERS_LEAVE_TEAM:
         case WiredActionLayoutCode.LEAVE_TEAM:
             return <WiredActionLeaveTeamView />;
         case WiredActionLayoutCode.MOVE_FURNI:

--- a/src/components/wired/views/actions/WiredActionLayoutView.tsx
+++ b/src/components/wired/views/actions/WiredActionLayoutView.tsx
@@ -143,6 +143,8 @@ export const WiredActionLayoutView = (code: number) => {
             return <WiredActionControlClockView />;
         case WiredActionLayoutCode.FURNI_TO_USER:
             return <WiredActionTeleportView />;
+        case WiredActionLayoutCode.WALK_TO_FURNI:
+            return <WiredActionTeleportView />;
         case WiredActionLayoutCode.FURNI_TO_FURNI:
             return <WiredActionFurniToFurniView />;
         case WiredActionLayoutCode.SET_ALTITUDE:

--- a/src/components/wired/views/actions/WiredActionLeaveTeamView.tsx
+++ b/src/components/wired/views/actions/WiredActionLeaveTeamView.tsx
@@ -1,11 +1,17 @@
 import { FC, useEffect, useState } from 'react';
-import { WiredFurniType } from '../../../../api';
+import { WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
 
 export const WiredActionLeaveTeamView: FC<{}> = (props) => {
     const { trigger = null, setIntParams = null } = useWired();
+    /**
+     * "All users leave team" walks every habbo in the room, so the source picker never chose its
+     * targets. The saved value is still sent back untouched, because it decides whether the stack
+     * needs a triggering user.
+     */
+    const showSource = trigger?.code !== WiredActionLayoutCode.ALL_USERS_LEAVE_TEAM;
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return 0;
@@ -24,7 +30,7 @@ export const WiredActionLeaveTeamView: FC<{}> = (props) => {
             hasSpecialInput={true}
             requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_NONE}
             save={save}
-            footer={<WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} />}
+            footer={showSource ? <WiredSourcesSelector showUsers={true} userSource={userSource} onChangeUsers={setUserSource} /> : null}
         />
     );
 };

--- a/src/components/wired/views/actions/WiredActionMoveRotateUserView.tsx
+++ b/src/components/wired/views/actions/WiredActionMoveRotateUserView.tsx
@@ -1,9 +1,10 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { localizeWithFallback, LocalizeText, WiredActionLayoutCode, WiredFurniType } from '../../../../api';
 import iconRotateClockwise from '../../../../assets/images/wired/icon_wired_rotate_clockwise.png';
 import iconRotateCounterClockwise from '../../../../assets/images/wired/icon_wired_rotate_counter_clockwise.png';
 import { Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
+import { NitroInput } from '../../../../layout';
 import { WIRED_DIRECTION_GRID, WiredDirectionIcon } from '../WiredDirectionIcon';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredActionBaseView } from './WiredActionBaseView';
@@ -76,16 +77,36 @@ const DirectionPicker: FC<DirectionPickerProps> = (props) => {
     );
 };
 
+const MIN_TILE_COUNT = 1;
+const MAX_TILE_COUNT = 10;
+
+const clampTileCount = (value: number) => {
+    if (isNaN(value)) return MIN_TILE_COUNT;
+
+    return Math.max(MIN_TILE_COUNT, Math.min(MAX_TILE_COUNT, Math.floor(value)));
+};
+
 export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
     const [movementDirection, setMovementDirection] = useState(-1);
     const [rotationDirection, setRotationDirection] = useState(-1);
     const { trigger = null, setIntParams = null } = useWired();
+    /**
+     * "Move user N tiles" reads a fourth slot the window never sent, so it always moved exactly one
+     * tile whatever the box was meant to do. The server keeps it between 1 and 10.
+     */
+    const hasTileCount = trigger?.code === WiredActionLayoutCode.MOVE_USER_TILES;
+    const [tileCount, setTileCount] = useState(MIN_TILE_COUNT);
     const [userSource, setUserSource] = useState<number>(() => {
         if (trigger?.intData?.length > 2) return trigger.intData[2];
         return 0;
     });
 
-    const save = () => setIntParams([movementDirection, rotationDirection, userSource]);
+    const save = () =>
+        setIntParams(
+            hasTileCount
+                ? [movementDirection, rotationDirection, userSource, tileCount]
+                : [movementDirection, rotationDirection, userSource]
+        );
 
     const rotationExtraOptions: DirectionExtraOption[] = [
         { value: ROTATION_CLOCKWISE, icon: iconRotateClockwise, label: LocalizeText('wiredfurni.params.rotatefurni.1') },
@@ -96,6 +117,7 @@ export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
         setMovementDirection(trigger.intData.length > 0 ? trigger.intData[0] : -1);
         setRotationDirection(trigger.intData.length > 1 ? trigger.intData[1] : -1);
         setUserSource(trigger.intData.length > 2 ? trigger.intData[2] : 0);
+        setTileCount(clampTileCount(trigger.intData.length > 3 ? trigger.intData[3] : MIN_TILE_COUNT));
     }, [trigger]);
 
     return (
@@ -120,6 +142,18 @@ export const WiredActionMoveRotateUserView: FC<{}> = (props) => {
                 value={rotationDirection}
                 onChange={setRotationDirection}
             />
+            {hasTileCount && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.tilecount', 'Tiles to move')}</Text>
+                    <NitroInput
+                        max={MAX_TILE_COUNT}
+                        min={MIN_TILE_COUNT}
+                        type="number"
+                        value={tileCount}
+                        onChange={(event) => setTileCount(clampTileCount(parseInt(event.target.value)))}
+                    />
+                </div>
+            )}
         </WiredActionBaseView>
     );
 };

--- a/src/components/wired/views/actions/WiredActionOverrideHeightView.tsx
+++ b/src/components/wired/views/actions/WiredActionOverrideHeightView.tsx
@@ -1,0 +1,95 @@
+import { FC, useEffect, useState } from 'react';
+import { localizeWithFallback, WiredFurniType } from '../../../../api';
+import { Slider, Text } from '../../../../common';
+import { useWired } from '../../../../hooks';
+import { WiredSourcesSelector } from '../WiredSourcesSelector';
+import { WiredActionBaseView } from './WiredActionBaseView';
+
+/**
+ * Puts the selected furni at a height you type, or hands them back their stacking height.
+ *
+ * The official dialog is a two-way choice and a slider over thousandths of a tile, 0 to 8000, so
+ * 2400 reads as 2.400. The furni source row underneath is this fork's own, the way every other furni
+ * effect offers it.
+ */
+
+const MIN_HEIGHT = 0;
+const MAX_HEIGHT = 8000;
+const HEIGHT_STEP = 1;
+
+const MODE_SET = 0;
+const MODE_RELEASE = 1;
+
+const MODE_LABELS: Record<number, { key: string; fallback: string }> = {
+    [MODE_SET]: { key: 'wiredfurni.params.override_height.type.0', fallback: 'Set this height' },
+    [MODE_RELEASE]: { key: 'wiredfurni.params.override_height.type.1', fallback: 'Back to the stacking height' }
+};
+
+const formatHeight = (value: number) => (value / 1000).toFixed(3);
+
+const clampHeight = (value: number) => {
+    if (!Number.isFinite(value)) return MIN_HEIGHT;
+    return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, Math.round(value)));
+};
+
+export const WiredActionOverrideHeightView: FC<{}> = (props) => {
+    const { trigger = null, setIntParams = null } = useWired();
+
+    const [height, setHeight] = useState<number>(0);
+    const [heightInput, setHeightInput] = useState<string>('0.000');
+    const [mode, setMode] = useState<number>(MODE_SET);
+    const [furniSource, setFurniSource] = useState<number>(0);
+
+    useEffect(() => {
+        if (!trigger) return;
+
+        const data = trigger.intData ?? [];
+        const nextHeight = clampHeight(data.length > 0 ? data[0] : 0);
+
+        setHeight(nextHeight);
+        setHeightInput(formatHeight(nextHeight));
+        setMode(data.length > 1 && data[1] === MODE_RELEASE ? MODE_RELEASE : MODE_SET);
+        setFurniSource(data.length > 2 ? data[2] : (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0);
+    }, [trigger]);
+
+    const updateHeight = (value: number) => {
+        const next = clampHeight(value);
+        setHeight(next);
+        setHeightInput(formatHeight(next));
+    };
+
+    // Typing is left alone until blur, so a half-written "2." is not rewritten under the cursor.
+    const updateHeightInput = (value: string) => {
+        setHeightInput(value);
+
+        const parsed = Number.parseFloat(value.replace(',', '.'));
+        if (Number.isFinite(parsed)) setHeight(clampHeight(parsed * 1000));
+    };
+
+    const save = () => setIntParams([height, mode, furniSource]);
+
+    return (
+        <WiredActionBaseView hasSpecialInput={true} requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_BY_ID_BY_TYPE_OR_FROM_CONTEXT} save={save} footer={<WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />}>
+            <div className="flex flex-col gap-2">
+                {[MODE_SET, MODE_RELEASE].map((value) => (
+                    <div key={value} className="flex items-center gap-1">
+                        <input checked={mode === value} className="form-check-input" id={`overrideHeightMode${value}`} name="overrideHeightMode" type="radio" onChange={() => setMode(value)} />
+                        <Text>{localizeWithFallback(MODE_LABELS[value].key, MODE_LABELS[value].fallback)}</Text>
+                    </div>
+                ))}
+            </div>
+            {mode === MODE_SET && (
+                <>
+                    <div className="flex flex-col gap-1">
+                        <Text bold>{localizeWithFallback('wiredfurni.params.override_height.height', 'Height')}</Text>
+                        <input className="form-control form-control-sm" inputMode="decimal" type="text" value={heightInput} onBlur={() => setHeightInput(formatHeight(height))} onChange={(event) => updateHeightInput(event.target.value)} />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <Slider max={MAX_HEIGHT} min={MIN_HEIGHT} step={HEIGHT_STEP} value={height} onChange={(event) => updateHeight(event as number)} />
+                        <Text small>{formatHeight(height)}</Text>
+                    </div>
+                </>
+            )}
+        </WiredActionBaseView>
+    );
+};

--- a/src/components/wired/views/actions/WiredActionTeleportView.tsx
+++ b/src/components/wired/views/actions/WiredActionTeleportView.tsx
@@ -10,6 +10,9 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     const { trigger = null, setIntParams = null } = useWired();
     const isTeleportEffect = trigger?.code === WiredActionLayoutCode.TELEPORT;
     const isUserToFurniEffect = trigger?.code === WiredActionLayoutCode.USER_TO_FURNI;
+    /** Same three slots as the teleport, but it walks — so no "teleport instantly" to offer. */
+    const isWalkToFurni = trigger?.code === WiredActionLayoutCode.WALK_TO_FURNI;
+    const usesTeleportSlots = isTeleportEffect || isWalkToFurni;
     const [fastTeleport, setFastTeleport] = useState<boolean>(() => {
         if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[0] === 1;
         return false;
@@ -20,14 +23,14 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     });
 
     const [furniSource, setFurniSource] = useState<number>(() => {
-        if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[1];
+        if (usesTeleportSlots && trigger?.intData?.length >= 3) return trigger.intData[1];
         if (isUserToFurniEffect && trigger?.intData?.length >= 3) return trigger.intData[0];
         if (trigger?.intData?.length >= 1) return trigger.intData[0];
         return (trigger?.selectedItems?.length ?? 0) > 0 ? 100 : 0;
     });
 
     const [userSource, setUserSource] = useState<number>(() => {
-        if (isTeleportEffect && trigger?.intData?.length >= 3) return trigger.intData[2];
+        if (usesTeleportSlots && trigger?.intData?.length >= 3) return trigger.intData[2];
         if (isUserToFurniEffect && trigger?.intData?.length >= 3) return trigger.intData[1];
         if (trigger?.intData?.length >= 2) return trigger.intData[1];
         return 0;
@@ -36,7 +39,7 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
     useEffect(() => {
         if (!trigger) return;
 
-        if (isTeleportEffect && trigger.intData.length >= 3) {
+        if (usesTeleportSlots && trigger.intData.length >= 3) {
             setFastTeleport(trigger.intData[0] === 1);
             setFurniSource(trigger.intData[1]);
             setUserSource(trigger.intData[2]);
@@ -60,13 +63,13 @@ export const WiredActionTeleportView: FC<{}> = (props) => {
 
         if (trigger.intData.length >= 2) setUserSource(trigger.intData[1]);
         else setUserSource(0);
-    }, [isTeleportEffect, isUserToFurniEffect, trigger]);
+    }, [isUserToFurniEffect, isWalkToFurni, usesTeleportSlots, trigger]);
 
     const onChangeFurniSource = (next: number) => setFurniSource(next);
 
     const save = () =>
         setIntParams(
-            isTeleportEffect
+            usesTeleportSlots
                 ? [fastTeleport ? 1 : 0, furniSource, userSource]
                 : isUserToFurniEffect
                   ? [furniSource, userSource, walkMode]

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
@@ -8,9 +8,15 @@ import { WiredConditionBaseView } from './WiredConditionBaseView';
 
 interface WiredConditionActorIsWearingBadgeViewProps {
     negative?: boolean;
+    /**
+     * The gender and room-rights conditions share this dialog because they need the same user source
+     * and quantifier — but their answer comes from the user, not from something you type. They pass
+     * false so the badge-code field stays out of the window.
+     */
+    showBadge?: boolean;
 }
 
-export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false }) => {
+export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, showBadge = true }) => {
     const [badge, setBadge] = useState('');
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
@@ -20,7 +26,7 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
     });
 
     const save = () => {
-        setStringParam(badge);
+        setStringParam(showBadge ? badge : '');
         setIntParams([userSource, quantifier]);
     };
 
@@ -53,10 +59,12 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
                     </label>
                 ))}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
-                <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
-            </div>
+            {showBadge && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
+                    <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingBadgeView.tsx
@@ -6,17 +6,26 @@ import { NitroInput } from '../../../../layout';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
 import { WiredConditionBaseView } from './WiredConditionBaseView';
 
+/**
+ * What the text field holds. The badge, tag and motto conditions all store a string plus the same
+ * user source and quantifier, so they share this dialog — but a tag is not a badge code and neither
+ * is a motto, and each has its own length limit. `null` is for the gender and room-rights conditions,
+ * whose answer comes from the user rather than from anything typed: they hide the field entirely.
+ */
+type WiredTextField = 'badge' | 'tag' | 'motto';
+
+const TEXT_FIELDS: Record<WiredTextField, { key: string; fallback: string; maxLength?: number }> = {
+    badge: { key: 'wiredfurni.params.badgecode', fallback: 'Badge code' },
+    tag: { key: 'wiredfurni.params.tag', fallback: 'Tag', maxLength: 38 },
+    motto: { key: 'wiredfurni.params.motto_contains', fallback: 'Motto contains', maxLength: 64 }
+};
+
 interface WiredConditionActorIsWearingBadgeViewProps {
     negative?: boolean;
-    /**
-     * The gender and room-rights conditions share this dialog because they need the same user source
-     * and quantifier — but their answer comes from the user, not from something you type. They pass
-     * false so the badge-code field stays out of the window.
-     */
-    showBadge?: boolean;
+    field?: WiredTextField | null;
 }
 
-export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, showBadge = true }) => {
+export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWearingBadgeViewProps> = ({ negative = false, field = 'badge' }) => {
     const [badge, setBadge] = useState('');
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setStringParam = null, setIntParams = null } = useWired();
@@ -25,8 +34,10 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
         return 0;
     });
 
+    const text = field ? TEXT_FIELDS[field] : null;
+
     const save = () => {
-        setStringParam(showBadge ? badge : '');
+        setStringParam(text ? badge : '');
         setIntParams([userSource, quantifier]);
     };
 
@@ -59,10 +70,15 @@ export const WiredConditionActorIsWearingBadgeView: FC<WiredConditionActorIsWear
                     </label>
                 ))}
             </div>
-            {showBadge && (
+            {text && (
                 <div className="flex flex-col gap-1">
-                    <Text bold>{localizeWithFallback('wiredfurni.params.badgecode', 'Badge code')}</Text>
-                    <NitroInput type="text" value={badge} onChange={(event) => setBadge(event.target.value)} />
+                    <Text bold>{localizeWithFallback(text.key, text.fallback)}</Text>
+                    <NitroInput
+                        maxLength={text.maxLength}
+                        type="text"
+                        value={badge}
+                        onChange={(event) => setBadge(event.target.value)}
+                    />
                 </div>
             )}
         </WiredConditionBaseView>

--- a/src/components/wired/views/conditions/WiredConditionActorIsWearingEffectView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionActorIsWearingEffectView.tsx
@@ -8,9 +8,15 @@ import { WiredConditionBaseView } from './WiredConditionBaseView';
 
 interface WiredConditionActorIsWearingEffectViewProps {
     negative?: boolean;
+    /**
+     * The freeze conditions share this dialog for its user source and quantifier, but they ask
+     * WiredFreezeUtil whether someone is frozen — there is no effect to name. They pass false, and the
+     * effect-id box stays out of the window.
+     */
+    showEffect?: boolean;
 }
 
-export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWearingEffectViewProps> = ({ negative = false }) => {
+export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWearingEffectViewProps> = ({ negative = false, showEffect = true }) => {
     const [effect, setEffect] = useState(-1);
     const [quantifier, setQuantifier] = useState(1);
     const { trigger = null, setIntParams = null } = useWired();
@@ -50,10 +56,12 @@ export const WiredConditionActorIsWearingEffectView: FC<WiredConditionActorIsWea
                     </label>
                 ))}
             </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{localizeWithFallback('wiredfurni.params.effectid', LocalizeText('wiredfurni.tooltip.effectid'))}</Text>
-                <NitroInput type="number" value={effect} onChange={(event) => setEffect(parseInt(event.target.value))} />
-            </div>
+            {showEffect && (
+                <div className="flex flex-col gap-1">
+                    <Text bold>{localizeWithFallback('wiredfurni.params.effectid', LocalizeText('wiredfurni.tooltip.effectid'))}</Text>
+                    <NitroInput type="number" value={effect} onChange={(event) => setEffect(parseInt(event.target.value))} />
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionChestHasItemsView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionChestHasItemsView.tsx
@@ -1,17 +1,31 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { localizeWithFallback, WiredFurniType } from '../../../../api';
 import { Text } from '../../../../common';
-import { useWired } from '../../../../hooks';
+import { useWired, useWiredTools } from '../../../../hooks';
 import { normalizeWiredComparison, WIRED_CMP_DEFAULT, WiredComparisonOperator } from '../WiredComparisonOperator';
+import { WiredVariablePicker } from '../WiredVariablePicker';
+import { buildWiredVariablePickerEntries, createFallbackVariableEntry, flattenWiredVariablePickerEntries, normalizeVariableTokenFromWire } from '../WiredVariablePickerData';
 import { WiredConditionBaseView } from './WiredConditionBaseView';
 
-// Server contract (WiredConditionChestHasItems): intData[0] = amount, intData[1] = comparison op.
-// The comparison operator value encoding is owned by WiredComparisonOperator and mirrored by the
-// Java `compare()` switch. Old saves (1 int) read comparison as the default (>=), preserving behaviour.
+// Server contract (WiredConditionChestHasItems):
+//   intData[0] = amount, [1] = comparison, [2] = amount mode, [3] = variable target
+//   stringData = the variable token
+// Old saves carry two ints and no token, so they read as a constant and behave as they did.
+
+const AMOUNT_CONSTANT = 0;
+const AMOUNT_VARIABLE = 1;
+const TARGET_USER = 0;
+const TARGET_ROOM = 3;
+
 export const WiredConditionChestHasItemsView: FC<{}> = () => {
-    const { trigger = null, setIntParams = null } = useWired();
+    const { trigger = null, setIntParams = null, setStringParam = null } = useWired();
+    const { userVariableDefinitions = [], roomVariableDefinitions = [] } = useWiredTools();
+
     const [amount, setAmount] = useState(1);
     const [comparison, setComparison] = useState(WIRED_CMP_DEFAULT);
+    const [amountMode, setAmountMode] = useState(AMOUNT_CONSTANT);
+    const [amountTarget, setAmountTarget] = useState(TARGET_ROOM);
+    const [variableToken, setVariableToken] = useState('');
 
     useEffect(() => {
         if (!trigger) return;
@@ -19,31 +33,70 @@ export const WiredConditionChestHasItemsView: FC<{}> = () => {
         const data = trigger.intData ?? [];
         setAmount(data.length > 0 ? Math.max(0, data[0]) : 1);
         setComparison(data.length > 1 ? normalizeWiredComparison(data[1]) : WIRED_CMP_DEFAULT);
+        setAmountMode(data.length > 2 && data[2] === AMOUNT_VARIABLE ? AMOUNT_VARIABLE : AMOUNT_CONSTANT);
+        setAmountTarget(data.length > 3 && data[3] === TARGET_USER ? TARGET_USER : TARGET_ROOM);
+        setVariableToken(normalizeVariableTokenFromWire(trigger.stringData ?? ''));
     }, [trigger]);
 
-    const save = () => setIntParams([Math.max(0, amount), comparison]);
+    const pickerTarget = amountTarget === TARGET_USER ? 'user' : 'global';
+    const definitions = amountTarget === TARGET_USER ? userVariableDefinitions : roomVariableDefinitions;
+
+    const entries = useMemo(() => buildWiredVariablePickerEntries(pickerTarget, 'change-reference', definitions), [definitions, pickerTarget]);
+
+    // A token saved against a variable that has since gone keeps its place in the list, so reopening
+    // the box shows what it was set to instead of looking unconfigured.
+    const resolvedEntries = useMemo(() => {
+        if (!variableToken) return entries;
+        if (flattenWiredVariablePickerEntries(entries).some((entry) => entry.token === variableToken)) return entries;
+
+        const fallback = createFallbackVariableEntry(pickerTarget, variableToken);
+        return fallback ? [fallback, ...entries] : entries;
+    }, [entries, pickerTarget, variableToken]);
+
+    const save = () => {
+        setStringParam(amountMode === AMOUNT_VARIABLE ? variableToken : '');
+        setIntParams([Math.max(0, amount), comparison, amountMode, amountTarget]);
+    };
 
     return (
         <WiredConditionBaseView hasSpecialInput={true} requiresFurni={WiredFurniType.STUFF_SELECTION_OPTION_BY_ID} save={save}>
             <div className="flex flex-col gap-3">
                 <Text small className="text-black/60">
-                    {localizeWithFallback(
-                        'wiredfurni.params.sources.furni.title.chests',
-                        'Pick the chest above. Passes when its total contents compare to the amount below.'
-                    )}
+                    {localizeWithFallback('wiredfurni.params.sources.furni.title.chests', 'Pick the chest above. Passes when its total contents compare to the amount below.')}
                 </Text>
                 <WiredComparisonOperator name="chestHasItemsComparison" value={comparison} onChange={setComparison} />
-                <div className="flex flex-col gap-1">
-                    <Text bold>{localizeWithFallback('wiredfurni.params.count', 'Amount')}</Text>
-                    <input
-                        type="number"
-                        min={0}
-                        className="form-control form-control-sm"
-                        style={{ maxWidth: 140 }}
-                        value={amount}
-                        onChange={(event) => setAmount(Math.max(0, parseInt(event.target.value, 10) || 0))}
-                    />
+                <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-1">
+                        <input checked={amountMode === AMOUNT_CONSTANT} className="form-check-input" id="chestAmountConstant" name="chestAmountMode" type="radio" onChange={() => setAmountMode(AMOUNT_CONSTANT)} />
+                        <Text>{localizeWithFallback('wiredfurni.params.amount.from_value', 'A number')}</Text>
+                    </div>
+                    <div className="flex items-center gap-1">
+                        <input checked={amountMode === AMOUNT_VARIABLE} className="form-check-input" id="chestAmountVariable" name="chestAmountMode" type="radio" onChange={() => setAmountMode(AMOUNT_VARIABLE)} />
+                        <Text>{localizeWithFallback('wiredfurni.params.amount.from_variable', 'The value of a variable')}</Text>
+                    </div>
                 </div>
+                {amountMode === AMOUNT_CONSTANT ? (
+                    <div className="flex flex-col gap-1">
+                        <Text bold>{localizeWithFallback('wiredfurni.params.count', 'Amount')}</Text>
+                        <input className="form-control form-control-sm" min={0} style={{ maxWidth: 140 }} type="number" value={amount} onChange={(event) => setAmount(Math.max(0, parseInt(event.target.value, 10) || 0))} />
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        <div className="flex flex-col gap-1">
+                            <Text bold>{localizeWithFallback('wiredfurni.params.variables.target', 'Where the variable lives')}</Text>
+                            {[
+                                { target: TARGET_ROOM, key: 'wiredfurni.params.variables.target.room', fallback: 'The room' },
+                                { target: TARGET_USER, key: 'wiredfurni.params.variables.target.user', fallback: 'The user who triggered' }
+                            ].map((option) => (
+                                <div key={option.target} className="flex items-center gap-1">
+                                    <input checked={amountTarget === option.target} className="form-check-input" id={`chestAmountTarget${option.target}`} name="chestAmountTarget" type="radio" onChange={() => setAmountTarget(option.target)} />
+                                    <Text>{localizeWithFallback(option.key, option.fallback)}</Text>
+                                </div>
+                            ))}
+                        </div>
+                        <WiredVariablePicker entries={resolvedEntries} recentScope={`chest-amount-${pickerTarget}`} selectedToken={variableToken} onSelect={(entry) => setVariableToken(entry.token)} />
+                    </div>
+                )}
             </div>
         </WiredConditionBaseView>
     );

--- a/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { LocalizeText, localizeWithFallback, WiredFurniType } from '../../../../api';
 import { Slider, Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
@@ -36,7 +36,37 @@ const parseAltitude = (value: string) => {
     return clampAltitude(parsed);
 };
 
-export const WiredConditionHasAltitudeView: FC<{}> = () => {
+/**
+ * Seven conditions borrowed this dialog and inherited things that belong to the altitude check alone.
+ * The worst was the counter-only furni gate: it refuses every furni that is not a game counter, which
+ * makes "furni in range", "owns furni" and "same height" impossible to configure. They also inherited
+ * the altitude label for what is really a radius, a furni source picker where a user source is meant,
+ * and a comparison operator two of them never read.
+ */
+type AltitudeVariant = 'altitude' | 'userRange' | 'furniRange' | 'furniProperty';
+
+const VARIANTS: Record<
+    AltitudeVariant,
+    { counterOnly: boolean; comparison: boolean; value: 'altitude' | 'radius' | null; users: boolean }
+> = {
+    altitude: { counterOnly: true, comparison: true, value: 'altitude', users: false },
+    userRange: { counterOnly: false, comparison: true, value: 'radius', users: true },
+    furniRange: { counterOnly: false, comparison: true, value: 'radius', users: false },
+    furniProperty: { counterOnly: false, comparison: false, value: null, users: false }
+};
+
+const VALUE_LABELS = {
+    altitude: { key: 'wiredfurni.params.setaltitude', fallback: 'Altitude' },
+    radius: { key: 'wiredfurni.params.setradius', fallback: 'Radius in tiles' }
+};
+
+interface WiredConditionHasAltitudeViewProps {
+    variant?: AltitudeVariant;
+}
+
+export const WiredConditionHasAltitudeView: FC<WiredConditionHasAltitudeViewProps> = ({ variant = 'altitude' }) => {
+    const spec = VARIANTS[variant];
+
     const { trigger = null, setIntParams = null, setStringParam = null, setAllowedInteractionTypes = null, setAllowedInteractionErrorKey = null } = useWired();
     const [comparison, setComparison] = useState(1);
     const [furniSource, setFurniSource] = useState<number>(() => {
@@ -49,6 +79,8 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
     const [altitudeInput, setAltitudeInput] = useState('0');
 
     useEffect(() => {
+        if (!spec.counterOnly) return;
+
         setAllowedInteractionTypes(COUNTER_INTERACTION_TYPES);
         setAllowedInteractionErrorKey('wiredfurni.error.require_counter_furni');
 
@@ -56,20 +88,28 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
             setAllowedInteractionTypes(null);
             setAllowedInteractionErrorKey(null);
         };
-    }, [setAllowedInteractionErrorKey, setAllowedInteractionTypes]);
+    }, [spec.counterOnly, setAllowedInteractionErrorKey, setAllowedInteractionTypes]);
 
     useEffect(() => {
         if (!trigger) return;
 
-        setComparison(trigger.intData.length > 0 ? trigger.intData[0] : 1);
-        setFurniSource(trigger.intData.length > 1 ? trigger.intData[1] : (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0);
-        setQuantifier(trigger.intData.length > 2 ? trigger.intData[2] : 0);
-        setShowAdvanced(trigger.intData.length > 1 ? trigger.intData[1] !== 0 || trigger.intData[2] !== 0 : false);
+        const sourceSlot = spec.comparison ? 1 : 0;
+        const quantifierSlot = sourceSlot + 1;
+        const fallbackSource = (trigger.selectedItems?.length ?? 0) > 0 ? 100 : 0;
+
+        setComparison(spec.comparison && trigger.intData.length > 0 ? trigger.intData[0] : 1);
+        setFurniSource(trigger.intData.length > sourceSlot ? trigger.intData[sourceSlot] : fallbackSource);
+        setQuantifier(trigger.intData.length > quantifierSlot ? trigger.intData[quantifierSlot] : 0);
+        setShowAdvanced(
+            trigger.intData.length > sourceSlot
+                ? trigger.intData[sourceSlot] !== 0 || trigger.intData[quantifierSlot] !== 0
+                : false
+        );
 
         const nextAltitude = parseAltitude(trigger.stringData);
         setAltitude(nextAltitude);
         setAltitudeInput(formatAltitude(nextAltitude));
-    }, [trigger]);
+    }, [spec.comparison, trigger]);
 
     const updateAltitude = (value: number) => {
         const nextValue = clampAltitude(value);
@@ -101,8 +141,9 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
     };
 
     const save = () => {
-        setIntParams([comparison, furniSource, quantifier]);
-        setStringParam(formatAltitude(altitude));
+        // furniProperty reads [source, quantifier]; the others keep the comparison in slot 0.
+        setIntParams(spec.comparison ? [comparison, furniSource, quantifier] : [furniSource, quantifier]);
+        setStringParam(spec.value ? formatAltitude(altitude) : '');
     };
 
     return (
@@ -131,49 +172,59 @@ export const WiredConditionHasAltitudeView: FC<{}> = () => {
                                                 type="radio"
                                                 onChange={() => setQuantifier(value)}
                                             />
-                                            <Text>{LocalizeText(`wiredfurni.params.quantifier.furni.${value}`)}</Text>
+                                            <Text>{LocalizeText(`wiredfurni.params.quantifier.${spec.users ? 'users' : 'furni'}.${value}`)}</Text>
                                         </div>
                                     );
                                 })}
                             </div>
-                            <WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />
+                            {spec.users ? (
+                                <WiredSourcesSelector showUsers={true} userSource={furniSource} onChangeUsers={setFurniSource} />
+                            ) : (
+                                <WiredSourcesSelector showFurni={true} furniSource={furniSource} onChangeFurni={setFurniSource} />
+                            )}
                         </>
                     )}
                 </div>
             }
         >
-            <div className="flex flex-col gap-2">
-                {[0, 1, 2].map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={comparison === value}
-                                className="form-check-input"
-                                id={`altitudeComparison${value}`}
-                                name="altitudeComparison"
-                                type="radio"
-                                onChange={() => setComparison(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.setaltitude')}</Text>
-                <input
-                    className="form-control form-control-sm"
-                    inputMode="decimal"
-                    type="text"
-                    value={altitudeInput}
-                    onBlur={() => setAltitudeInput(formatAltitude(altitude))}
-                    onChange={(event) => updateAltitudeInput(event.target.value)}
-                />
-            </div>
-            <div className="flex flex-col gap-1">
-                <Slider max={MAX_ALTITUDE} min={MIN_ALTITUDE} step={ALTITUDE_STEP} value={altitude} onChange={(event) => updateAltitude(event as number)} />
-                <Text small>{formatAltitude(altitude)}</Text>
-            </div>
+            {spec.comparison && (
+                <div className="flex flex-col gap-2">
+                    {[0, 1, 2].map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={comparison === value}
+                                    className="form-check-input"
+                                    id={`altitudeComparison${value}`}
+                                    name="altitudeComparison"
+                                    type="radio"
+                                    onChange={() => setComparison(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+            {spec.value && (
+                <>
+                    <div className="flex flex-col gap-1">
+                        <Text bold>{localizeWithFallback(VALUE_LABELS[spec.value].key, VALUE_LABELS[spec.value].fallback)}</Text>
+                        <input
+                            className="form-control form-control-sm"
+                            inputMode="decimal"
+                            type="text"
+                            value={altitudeInput}
+                            onBlur={() => setAltitudeInput(formatAltitude(altitude))}
+                            onChange={(event) => updateAltitudeInput(event.target.value)}
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <Slider max={MAX_ALTITUDE} min={MIN_ALTITUDE} step={ALTITUDE_STEP} value={altitude} onChange={(event) => updateAltitude(event as number)} />
+                        <Text small>{formatAltitude(altitude)}</Text>
+                    </div>
+                </>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionHasAltitudeView.tsx
@@ -41,7 +41,10 @@ const parseAltitude = (value: string) => {
  * The worst was the counter-only furni gate: it refuses every furni that is not a game counter, which
  * makes "furni in range", "owns furni" and "same height" impossible to configure. They also inherited
  * the altitude label for what is really a radius, a furni source picker where a user source is meant,
- * and a comparison operator two of them never read.
+ * and a comparison operator four of them never read.
+ *
+ * The four range boxes read it now. Their middle option is inclusive — "within the radius", the
+ * behaviour they always had — so it gets its own label instead of the altitude box's "Equals".
  */
 type AltitudeVariant = 'altitude' | 'userRange' | 'furniRange' | 'furniProperty';
 
@@ -53,6 +56,12 @@ const VARIANTS: Record<
     userRange: { counterOnly: false, comparison: true, value: 'radius', users: true },
     furniRange: { counterOnly: false, comparison: true, value: 'radius', users: false },
     furniProperty: { counterOnly: false, comparison: false, value: null, users: false }
+};
+
+const RANGE_COMPARISON_LABELS: Record<number, { key: string; fallback: string }> = {
+    0: { key: 'wiredfurni.params.range.comparison.0', fallback: 'Closer than' },
+    1: { key: 'wiredfurni.params.range.comparison.1', fallback: 'Within the radius' },
+    2: { key: 'wiredfurni.params.range.comparison.2', fallback: 'Further than' }
 };
 
 const VALUE_LABELS = {
@@ -200,7 +209,11 @@ export const WiredConditionHasAltitudeView: FC<WiredConditionHasAltitudeViewProp
                                     type="radio"
                                     onChange={() => setComparison(value)}
                                 />
-                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                                <Text>
+                                    {spec.value === 'radius'
+                                        ? localizeWithFallback(RANGE_COMPARISON_LABELS[value].key, RANGE_COMPARISON_LABELS[value].fallback)
+                                        : LocalizeText(`wiredfurni.params.comparison.${value}`)}
+                                </Text>
                             </div>
                         );
                     })}

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -82,6 +82,12 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView field={null} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:
             return <WiredConditionActorIsWearingBadgeView field={null} negative={true} />;
+        case WiredConditionlayout.USER_RANGE:
+            return <WiredConditionHasAltitudeView variant="userRange" />;
+        case WiredConditionlayout.FURNI_RANGE:
+            return <WiredConditionHasAltitudeView variant="furniRange" />;
+        case WiredConditionlayout.FURNI_PROPERTY:
+            return <WiredConditionHasAltitudeView variant="furniProperty" />;
         case WiredConditionlayout.USER_TAG:
             return <WiredConditionActorIsWearingBadgeView field="tag" />;
         case WiredConditionlayout.NOT_USER_TAG:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,8 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_AMOUNT:
+            return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:
             return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,10 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_ATTRIBUTE:
+            return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
+        case WiredConditionlayout.NOT_USER_ATTRIBUTE:
+            return <WiredConditionActorIsWearingBadgeView negative={true} showBadge={false} />;
         case WiredConditionlayout.ACTOR_IS_WEARING_EFFECT:
             return <WiredConditionActorIsWearingEffectView />;
         case WiredConditionlayout.NOT_ACTOR_WEARING_EFFECT:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -72,6 +72,10 @@ export const WiredConditionLayoutView = (code: number) => {
             return <WiredConditionActorIsWearingBadgeView />;
         case WiredConditionlayout.NOT_ACTOR_WEARS_BADGE:
             return <WiredConditionActorIsWearingBadgeView negative={true} />;
+        case WiredConditionlayout.USER_STATE:
+            return <WiredConditionActorIsWearingEffectView showEffect={false} />;
+        case WiredConditionlayout.NOT_USER_STATE:
+            return <WiredConditionActorIsWearingEffectView negative={true} showEffect={false} />;
         case WiredConditionlayout.USER_AMOUNT:
             return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:

--- a/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionLayoutView.tsx
@@ -79,9 +79,15 @@ export const WiredConditionLayoutView = (code: number) => {
         case WiredConditionlayout.USER_AMOUNT:
             return <WiredConditionTeamHasScoreView scoped={false} />;
         case WiredConditionlayout.USER_ATTRIBUTE:
-            return <WiredConditionActorIsWearingBadgeView showBadge={false} />;
+            return <WiredConditionActorIsWearingBadgeView field={null} />;
         case WiredConditionlayout.NOT_USER_ATTRIBUTE:
-            return <WiredConditionActorIsWearingBadgeView negative={true} showBadge={false} />;
+            return <WiredConditionActorIsWearingBadgeView field={null} negative={true} />;
+        case WiredConditionlayout.USER_TAG:
+            return <WiredConditionActorIsWearingBadgeView field="tag" />;
+        case WiredConditionlayout.NOT_USER_TAG:
+            return <WiredConditionActorIsWearingBadgeView field="tag" negative={true} />;
+        case WiredConditionlayout.USER_MOTTO:
+            return <WiredConditionActorIsWearingBadgeView field="motto" />;
         case WiredConditionlayout.ACTOR_IS_WEARING_EFFECT:
             return <WiredConditionActorIsWearingEffectView />;
         case WiredConditionlayout.NOT_ACTOR_WEARING_EFFECT:

--- a/src/components/wired/views/conditions/WiredConditionTeamHasScoreView.tsx
+++ b/src/components/wired/views/conditions/WiredConditionTeamHasScoreView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import { LocalizeText, WiredFurniType } from '../../../../api';
+import { LocalizeText, localizeWithFallback, WiredFurniType } from '../../../../api';
 import { Slider, Text } from '../../../../common';
 import { useWired } from '../../../../hooks';
 import { WiredSourcesSelector } from '../WiredSourcesSelector';
@@ -9,16 +9,28 @@ const TEAM_OPTIONS = [1, 2, 3, 4];
 const COMPARISON_OPTIONS = [0, 1, 2];
 const MIN_SCORE = 0;
 const MAX_SCORE = 999;
+/** What the server's normalizeScore lets through. A credit threshold is useless capped at 999. */
+const MAX_AMOUNT = 1_000_000;
 const SCORE_PATTERN = /^\d*$/;
 
-const clampScore = (value: number) => {
+const clampScore = (value: number, max: number) => {
     if (isNaN(value)) return MIN_SCORE;
 
-    return Math.max(MIN_SCORE, Math.min(MAX_SCORE, Math.floor(value)));
+    return Math.max(MIN_SCORE, Math.min(max, Math.floor(value)));
 };
 
-export const WiredConditionTeamHasScoreView: FC<{}> = () => {
+interface WiredConditionTeamHasScoreViewProps {
+    /**
+     * The item-count and currency conditions share this dialog for its amount, user source and
+     * quantifier, but their predicate is fixed in the server — no team, no comparison operator. They
+     * pass false, and the two dead controls stay out of the window.
+     */
+    scoped?: boolean;
+}
+
+export const WiredConditionTeamHasScoreView: FC<WiredConditionTeamHasScoreViewProps> = ({ scoped = true }) => {
     const { trigger = null, setIntParams = null } = useWired();
+    const ceiling = scoped ? MAX_SCORE : MAX_AMOUNT;
     const [team, setTeam] = useState(1);
     const [comparison, setComparison] = useState(1);
     const [score, setScore] = useState(0);
@@ -32,7 +44,7 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
 
         const nextTeam = trigger.intData.length > 0 ? trigger.intData[0] : 1;
         const nextComparison = trigger.intData.length > 1 ? trigger.intData[1] : 1;
-        const nextScore = clampScore(trigger.intData.length > 2 ? trigger.intData[2] : 0);
+        const nextScore = clampScore(trigger.intData.length > 2 ? trigger.intData[2] : 0, ceiling);
         const nextUserSource = trigger.intData.length > 3 ? trigger.intData[3] : 0;
         const nextQuantifier = trigger.intData.length > 4 ? trigger.intData[4] : 0;
 
@@ -43,10 +55,10 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
         setUserSource(nextUserSource);
         setQuantifier(nextQuantifier === 1 ? 1 : 0);
         setShowAdvanced(nextUserSource !== 0 || nextQuantifier !== 0);
-    }, [trigger]);
+    }, [ceiling, trigger]);
 
     const updateScore = (value: number) => {
-        const nextValue = clampScore(value);
+        const nextValue = clampScore(value, ceiling);
 
         setScore(nextValue);
         setScoreInput(nextValue.toString());
@@ -66,7 +78,7 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
     };
 
     const save = () => {
-        setIntParams([team, comparison, clampScore(score), userSource, quantifier]);
+        setIntParams([team, comparison, clampScore(score, ceiling), userSource, quantifier]);
     };
 
     return (
@@ -106,57 +118,67 @@ export const WiredConditionTeamHasScoreView: FC<{}> = () => {
                 </div>
             }
         >
+            {scoped && (
+                <>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.team')}</Text>
+                    {TEAM_OPTIONS.map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={team === value}
+                                    className="form-check-input"
+                                    id={`teamHasScore${value}`}
+                                    name="teamHasScore"
+                                    type="radio"
+                                    onChange={() => setTeam(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.team.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+                <div className="flex flex-col gap-1">
+                    <Text bold>{LocalizeText('wiredfurni.params.comparison_selection')}</Text>
+                    {COMPARISON_OPTIONS.map((value) => {
+                        return (
+                            <div key={value} className="flex items-center gap-1">
+                                <input
+                                    checked={comparison === value}
+                                    className="form-check-input"
+                                    id={`teamScoreComparison${value}`}
+                                    name="teamScoreComparison"
+                                    type="radio"
+                                    onChange={() => setComparison(value)}
+                                />
+                                <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
+                            </div>
+                        );
+                    })}
+                </div>
+                </>
+            )}
             <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.team')}</Text>
-                {TEAM_OPTIONS.map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={team === value}
-                                className="form-check-input"
-                                id={`teamHasScore${value}`}
-                                name="teamHasScore"
-                                type="radio"
-                                onChange={() => setTeam(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.team.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.comparison_selection')}</Text>
-                {COMPARISON_OPTIONS.map((value) => {
-                    return (
-                        <div key={value} className="flex items-center gap-1">
-                            <input
-                                checked={comparison === value}
-                                className="form-check-input"
-                                id={`teamScoreComparison${value}`}
-                                name="teamScoreComparison"
-                                type="radio"
-                                onChange={() => setComparison(value)}
-                            />
-                            <Text>{LocalizeText(`wiredfurni.params.comparison.${value}`)}</Text>
-                        </div>
-                    );
-                })}
-            </div>
-            <div className="flex flex-col gap-1">
-                <Text bold>{LocalizeText('wiredfurni.params.setscore2')}</Text>
+                <Text bold>
+                    {scoped
+                        ? LocalizeText('wiredfurni.params.setscore2')
+                        : localizeWithFallback('wiredfurni.params.user_amount', 'Amount:')}
+                </Text>
                 <input
                     className="form-control form-control-sm"
                     inputMode="numeric"
                     type="text"
                     value={scoreInput}
-                    onBlur={() => setScoreInput(clampScore(score).toString())}
+                    onBlur={() => setScoreInput(clampScore(score, ceiling).toString())}
                     onChange={(event) => updateScoreInput(event.target.value)}
                 />
             </div>
-            <div className="flex flex-col gap-1">
-                <Slider max={MAX_SCORE} min={MIN_SCORE} step={1} value={score} onChange={(event) => updateScore(event as number)} />
-                <Text small>{score}</Text>
-            </div>
+            {scoped && (
+                <div className="flex flex-col gap-1">
+                    <Slider max={MAX_SCORE} min={MIN_SCORE} step={1} value={score} onChange={(event) => updateScore(event as number)} />
+                    <Text small>{score}</Text>
+                </div>
+            )}
         </WiredConditionBaseView>
     );
 };

--- a/src/components/wired/views/triggers/WiredTriggerLayoutView.tsx
+++ b/src/components/wired/views/triggers/WiredTriggerLayoutView.tsx
@@ -68,6 +68,7 @@ export const WiredTriggerLayoutView = (code: number) => {
             return <WiredTriggeExecutePeriodicallyLongView />;
         case WiredTriggerLayout.GAME_ENDS:
             return <WiredTriggerGameEndsView />;
+        case WiredTriggerLayout.TEAM_GAME_RESULT:
         case WiredTriggerLayout.GAME_STARTS:
             return <WiredTriggerGameStartsView />;
         case WiredTriggerLayout.SCORE_ACHIEVED:

--- a/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.test.ts
+++ b/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { formatScore, getClearType, getScoreType, isConfigured, isTimeScore, scoreToTime } from './useFurnitureHighScoreWidget';
+
+// The score type is an index into a list the client does not own: the server sends the number and
+// the official client reads ["perteam","mostwins","classic","fastesttime","longesttime"]. The board
+// knew only the first three, so both time types fell off the end.
+
+describe('score types', () => {
+    it('covers all five the official client knows', () => {
+        expect([0, 1, 2, 3, 4].map(getScoreType)).toEqual(['perteam', 'mostwins', 'classic', 'fastesttime', 'longesttime']);
+    });
+
+    it('reads the two time types as times and the other three as points', () => {
+        expect([0, 1, 2].map(isTimeScore)).toEqual([false, false, false]);
+        expect([3, 4].map(isTimeScore)).toEqual([true, true]);
+    });
+
+    it('keeps the four clear types', () => {
+        expect([0, 1, 2, 3].map(getClearType)).toEqual(['alltime', 'daily', 'weekly', 'monthly']);
+    });
+});
+
+describe('a board whose type never arrived', () => {
+    it('is not configured at -1, so nothing indexes the list with -1', () => {
+        expect(isConfigured(-1, -1)).toBe(false);
+        expect(isConfigured(-1, 0)).toBe(false);
+        expect(isConfigured(0, -1)).toBe(false);
+    });
+
+    it('is not configured past the end of either list', () => {
+        expect(isConfigured(5, 0)).toBe(false);
+        expect(isConfigured(0, 4)).toBe(false);
+    });
+
+    it('is configured for every real combination', () => {
+        for (let score = 0; score < 5; score++) {
+            for (let clear = 0; clear < 4; clear++) expect(isConfigured(score, clear)).toBe(true);
+        }
+    });
+
+    it('reports an unknown type as points rather than throwing', () => {
+        expect(isTimeScore(-1)).toBe(false);
+        expect(isTimeScore(99)).toBe(false);
+    });
+});
+
+describe('scoreToTime', () => {
+    it('writes minutes and seconds zero padded', () => {
+        expect(scoreToTime(125, 2)).toBe('02:05');
+        expect(scoreToTime(0, 2)).toBe('00:00');
+        expect(scoreToTime(59, 2)).toBe('00:59');
+        expect(scoreToTime(60, 2)).toBe('01:00');
+    });
+
+    it('writes hours without padding them', () => {
+        expect(scoreToTime(3661, 3)).toBe('1:01:01');
+        expect(scoreToTime(3600, 3)).toBe('1:00:00');
+        expect(scoreToTime(45296, 3)).toBe('12:34:56');
+    });
+
+    it('gives back a plain number when the part count is out of range', () => {
+        expect(scoreToTime(90, 0)).toBe('90');
+        expect(scoreToTime(90, 4)).toBe('90');
+    });
+});
+
+describe('formatScore', () => {
+    it('leaves a points board alone', () => {
+        expect(formatScore(125, 2)).toBe('125');
+        expect(formatScore(0, 0)).toBe('0');
+    });
+
+    it('writes a time board as a duration, and picks hours only past the hour', () => {
+        expect(formatScore(125, 4)).toBe('02:05');
+        expect(formatScore(3599, 3)).toBe('59:59');
+        expect(formatScore(3600, 3)).toBe('1:00:00');
+    });
+});

--- a/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.ts
+++ b/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.ts
@@ -10,7 +10,7 @@ const SCORE_TYPES = ['perteam', 'mostwins', 'classic', 'fastesttime', 'longestti
 const CLEAR_TYPES = ['alltime', 'daily', 'weekly', 'monthly'];
 
 // Seconds as H:MM:SS past the hour, MM:SS below it. Anything else stays a plain number.
-const scoreToTime = (score: number, parts: number) => {
+export const scoreToTime = (score: number, parts: number) => {
     const divisors = [60, 60, 24];
 
     if (parts < 1 || parts > divisors.length) return `${ score }`;
@@ -36,24 +36,25 @@ const scoreToTime = (score: number, parts: number) => {
     return out.slice(0, -1);
 };
 
+export const getScoreType = (type: number) => SCORE_TYPES[type];
+export const getClearType = (type: number) => CLEAR_TYPES[type];
+
+// A board whose type never arrived reads as -1, which would index the list with -1.
+export const isConfigured = (scoreType: number, clearType: number) =>
+    scoreType >= 0 && scoreType < SCORE_TYPES.length && clearType >= 0 && clearType < CLEAR_TYPES.length;
+
+// The official client decides this from the type's own name, not from a separate list.
+export const isTimeScore = (scoreType: number) => (SCORE_TYPES[scoreType] ?? '').includes('time');
+
+export const formatScore = (score: number, scoreType: number) => {
+    if (!isTimeScore(scoreType)) return `${ score }`;
+
+    return scoreToTime(score, score >= 3600 ? 3 : 2);
+};
+
 const useFurnitureHighScoreWidgetState = () => {
     const [stuffDatas, setStuffDatas] = useState<Map<number, HighScoreDataType>>(new Map());
     const { roomSession = null } = useRoom();
-
-    const getScoreType = (type: number) => SCORE_TYPES[type];
-    const getClearType = (type: number) => CLEAR_TYPES[type];
-
-    // A board whose type never arrived reads as -1, which would index the list with -1.
-    const isConfigured = (scoreType: number, clearType: number) =>
-        scoreType >= 0 && scoreType < SCORE_TYPES.length && clearType >= 0 && clearType < CLEAR_TYPES.length;
-
-    const isTimeScore = (scoreType: number) => (SCORE_TYPES[scoreType] ?? '').includes('time');
-
-    const formatScore = (score: number, scoreType: number) => {
-        if (!isTimeScore(scoreType)) return `${ score }`;
-
-        return scoreToTime(score, score >= 3600 ? 3 : 2);
-    };
 
     useNitroEvent<RoomEngineTriggerWidgetEvent>(RoomEngineTriggerWidgetEvent.REQUEST_HIGH_SCORE_DISPLAY, (event) => {
         const roomObject = GetRoomEngine().getRoomObject(event.roomId, event.objectId, event.category);

--- a/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.ts
+++ b/src/hooks/rooms/widgets/furniture/useFurnitureHighScoreWidget.ts
@@ -3,8 +3,38 @@ import { useState } from 'react';
 import { useNitroEvent } from '../../../events';
 import { useRoom } from '../../useRoom';
 
-const SCORE_TYPES = ['perteam', 'mostwins', 'classic'];
+// The order is the client contract, not ours: the server sends an index into this list.
+// Two of the five are times rather than points, which changes both the column header and
+// how the value is written.
+const SCORE_TYPES = ['perteam', 'mostwins', 'classic', 'fastesttime', 'longesttime'];
 const CLEAR_TYPES = ['alltime', 'daily', 'weekly', 'monthly'];
+
+// Seconds as H:MM:SS past the hour, MM:SS below it. Anything else stays a plain number.
+const scoreToTime = (score: number, parts: number) => {
+    const divisors = [60, 60, 24];
+
+    if (parts < 1 || parts > divisors.length) return `${ score }`;
+
+    let remaining = score;
+    let out = '';
+
+    for (let i = 0; i < parts; i++) {
+        let piece: string;
+
+        if (i === parts - 1) {
+            piece = `${ remaining }`;
+        } else {
+            piece = `${ remaining % divisors[i] }`;
+            remaining = Math.floor(remaining / divisors[i]);
+        }
+
+        if (piece.length < 2 && i < 2) piece = `0${ piece }`;
+
+        out = `${ piece }:${ out }`;
+    }
+
+    return out.slice(0, -1);
+};
 
 const useFurnitureHighScoreWidgetState = () => {
     const [stuffDatas, setStuffDatas] = useState<Map<number, HighScoreDataType>>(new Map());
@@ -12,6 +42,18 @@ const useFurnitureHighScoreWidgetState = () => {
 
     const getScoreType = (type: number) => SCORE_TYPES[type];
     const getClearType = (type: number) => CLEAR_TYPES[type];
+
+    // A board whose type never arrived reads as -1, which would index the list with -1.
+    const isConfigured = (scoreType: number, clearType: number) =>
+        scoreType >= 0 && scoreType < SCORE_TYPES.length && clearType >= 0 && clearType < CLEAR_TYPES.length;
+
+    const isTimeScore = (scoreType: number) => (SCORE_TYPES[scoreType] ?? '').includes('time');
+
+    const formatScore = (score: number, scoreType: number) => {
+        if (!isTimeScore(scoreType)) return `${ score }`;
+
+        return scoreToTime(score, score >= 3600 ? 3 : 2);
+    };
 
     useNitroEvent<RoomEngineTriggerWidgetEvent>(RoomEngineTriggerWidgetEvent.REQUEST_HIGH_SCORE_DISPLAY, (event) => {
         const roomObject = GetRoomEngine().getRoomObject(event.roomId, event.objectId, event.category);
@@ -44,7 +86,7 @@ const useFurnitureHighScoreWidgetState = () => {
         });
     });
 
-    return { stuffDatas, getScoreType, getClearType };
+    return { stuffDatas, getScoreType, getClearType, isConfigured, isTimeScore, formatScore };
 };
 
 export const useFurnitureHighScoreWidget = useFurnitureHighScoreWidgetState;


### PR DESCRIPTION
The client half of the wired pass. Server half: duckietm/Polaris-Emulator#646 — this needs it, and on its own it only changes which questions the windows ask.

## Windows that matched a different box

Twenty-six boxes drew another box's dialog, so the window asked for things the class never reads and hid the ones it does. Each one here gives a box a window that matches what its class actually stores.

- the team-result triggers get a window with nothing in it, instead of the bot dialog
- the chat window stops asking nineteen effects for a message they never read
- seven conditions are freed from the altitude dialog's counter gate
- four amount conditions stop offering a team and an operator
- four user conditions stop asking for a badge code
- the freeze conditions stop asking for an effect id
- the tag and motto conditions get fields labelled as what they are
- walk-to-furni stops offering an instant teleport it cannot do
- the source picker is hidden where everyone leaves the team
- the kick message goes, the tile count nobody could set arrives

## New windows

The **override-height** action, and the **chest threshold**, which can now be a room or user variable instead of a number typed once — the picker keeps a token whose variable has since gone, so reopening the box shows what it was set to rather than looking unconfigured.

## The highscore board

The board knew three score types out of five, so both time-based ones fell off the end of the list and the caption resolved to a key ending in `undefined` — even though both text keys have always been in the gamedata.

Two behaviours the official client has and this one did not: on a time-based board the second column is headed **Time** rather than Score, and the value is written as a duration — `H:MM:SS` past the hour, `MM:SS` below it — so a result of 125 reads `02:05` instead of `125`. Both follow the official rule of asking whether the type's own name contains "time". A board whose type never arrived reads as `-1`, which indexed the list with `-1`; it now falls back to a plain caption.

## The monitor

Two warnings the server can now raise. `NO_TARGETS` — a chain fired and an effect had nothing to act on, naming which source came back empty. `UNREACHABLE` — a furni is waiting on something its room has no way of producing, a highscore board with no game timer being the case that prompted it. Both are warnings with a plain-language explanation of what is missing rather than what failed.

## Verification

`yarn typecheck` clean, `yarn lint:hooks` clean, `yarn test --run` — 210 files, 1131 cases. Twelve new cases on the board's score types and duration format, verified red before green by removing the zero padding and watching three of them fail.

`NavigatorAirParity.test.ts` fails on this branch. **It fails on a plain `origin/Dev` checkout too** — it is a pre-existing upstream failure and nothing here touches the navigator.

**Not exercised in a running room.** The emulator does not start on the machine this was written on, so the two behaviour changes the server half lists are the ones worth a look in a real room before this merges.
